### PR TITLE
chore(clients,docs): 将 deepseek-chat 模型名更新为 deepseek-v4-flash

### DIFF
--- a/clients/cli.py
+++ b/clients/cli.py
@@ -22,7 +22,7 @@ class SonettoCLI:
         settings = get_settings()
         self.session_id = datetime.now().strftime("%Y%m%d_%H%M%S") + "_" + uuid.uuid4().hex[:8]
         self.llm = ChatOpenAI(
-            model="deepseek-chat",
+            model="deepseek-v4-flash",
             api_key=settings.deepseek_api_key,
             base_url=settings.deepseek_base_url,
             temperature=0.7,

--- a/docs/02-LangGraph状态图与状态管理.md
+++ b/docs/02-LangGraph状态图与状态管理.md
@@ -114,7 +114,7 @@ def build_agent(
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
-| `model` | `BaseChatModel` | 绑定了 tools 的 LLM 实例。本项目使用 `ChatOpenAI(model="deepseek-chat")` |
+| `model` | `BaseChatModel` | 绑定了 tools 的 LLM 实例。本项目使用 `ChatOpenAI(model="deepseek-v4-flash")` |
 | `tools` | `list[BaseTool]` | 工具列表。本项目为 `get_all_skills()` 返回的 30 个 Skill |
 | `state_schema` | `AgentState` | 自定义状态类型（含 `messages` + `remaining_steps`） |
 | `prompt` | `str` | 系统提示词字符串，被包装为 `SystemMessage` 追加到消息列表头部 |

--- a/docs/06-客户端与回调系统.md
+++ b/docs/06-客户端与回调系统.md
@@ -34,7 +34,7 @@ class SonettoCLI:
         settings = get_settings()
         self.session_id = datetime.now().strftime("%Y%m%d_%H%M%S") + "_" + uuid.uuid4().hex[:8]
         self.llm = ChatOpenAI(
-            model="deepseek-chat",
+            model="deepseek-v4-flash",
             api_key=settings.deepseek_api_key,
             base_url=settings.deepseek_base_url,
             temperature=0.7,
@@ -209,7 +209,7 @@ from callbacks.printer import PrinterCallback
 
 # 在 ChatOpenAI 初始化时传入
 llm = ChatOpenAI(
-    model="deepseek-chat",
+    model="deepseek-v4-flash",
     ...,
     callbacks=[PrinterCallback()],
 )


### PR DESCRIPTION
## Summary

- 将所有 `deepseek-chat` 模型名称替换为 `deepseek-v4-flash`
- 涉及 3 个文件，共 4 处

## Test plan
- [x] CLI 启动后 LLM 正常调用