### PR TITLE
feat(clients): 添加私密模式与 /help 命令

### DIFF
--- a/clients/cli.py
+++ b/clients/cli.py
@@ -40,15 +40,17 @@ class SonettoCLI:
         )
         self.memory = ShortTermMemory()
         self._turn_messages: list[dict] = []
+        self._private_mode = False
 
     async def run(self) -> None:
         """启动 REPL 主循环：读取用户输入 → 注入长期记忆 → 流式输出 → 保存本轮对话。"""
         print("SonettoHere v2.0.0 — LangGraph ReAct Agent")
-        print("输入 /exit 退出，/clear 清空对话\n")
+        print("输入 /exit 退出，/clear 清空对话，/private 切换私密模式\n")
 
         while True:
             try:
-                user_input = input(">>> ").strip()
+                prompt = "[私密] >>> " if self._private_mode else ">>> "
+                user_input = input(prompt).strip()
             except (EOFError, KeyboardInterrupt):
                 print("\n再见！")
                 break
@@ -62,6 +64,11 @@ class SonettoCLI:
                 self.memory.clear()
                 self._turn_messages.clear()
                 print("对话已清空。")
+                continue
+            if user_input == "/private":
+                self._private_mode = not self._private_mode
+                status = "已开启" if self._private_mode else "已关闭"
+                print(f"私密模式{status}。")
                 continue
 
             # 注入长期记忆
@@ -141,6 +148,8 @@ class SonettoCLI:
 
     def _save_turn(self) -> None:
         """将本轮消息交给记忆提取器，持久化错误规则和偏好。"""
+        if self._private_mode:
+            return
         if not self._turn_messages:
             return
         try:

--- a/clients/cli.py
+++ b/clients/cli.py
@@ -45,7 +45,7 @@ class SonettoCLI:
     async def run(self) -> None:
         """启动 REPL 主循环：读取用户输入 → 注入长期记忆 → 流式输出 → 保存本轮对话。"""
         print("SonettoHere v2.0.0 — LangGraph ReAct Agent")
-        print("输入 /exit 退出，/clear 清空对话，/private 切换私密模式\n")
+        print("输入 /help 或 / 查看可用命令\n")
 
         while True:
             try:
@@ -69,6 +69,15 @@ class SonettoCLI:
                 self._private_mode = not self._private_mode
                 status = "已开启" if self._private_mode else "已关闭"
                 print(f"私密模式{status}。")
+                continue
+            if user_input in ("/", "/help"):
+                print("""
+可用命令:
+  /exit      退出程序
+  /clear     清空当前对话
+  /private   切换私密模式（开启后对话不被记录）
+  /help      显示此帮助信息
+""")
                 continue
 
             # 注入长期记忆


### PR DESCRIPTION
## Summary
- 新增 `/private` 命令，切换私密模式（开启后对话不被记录到长期记忆）
- 新增 `/help`（及 `/`）命令，列出所有可用命令
- 简化启动提示，仅指向 `/help` 命令

## Test plan
- [x] `/private` 切换提示符为 `[私密] >>>`，再次输入恢复
- [x] 私密模式下 `extracted/extracted_history.json` 不新增记录
- [x] `/help` 和 `/` 均显示命令列表
- [x] `/exit`、`/clear` 行为不变