### PR TITLE
fix(clients): 修复 _stream_events 中 final_output 未初始化导致的 UnboundLocalError

### DIFF
--- a/clients/cli.py
+++ b/clients/cli.py
@@ -134,6 +134,8 @@ class SonettoCLI:
     async def _stream_events(self, inputs: dict, config: dict) -> None:
         """流式消费 Agent 图事件，收集工具输出和最终回复到 _turn_messages。"""
 
+        final_output = None
+
         async for event in self.graph.astream_events(inputs, config=config, version="v2"):
             kind = event["event"]
             name = event.get("name", "")


### PR DESCRIPTION
## Summary
- 修复 `_stream_events` 方法中 `final_output` 变量可能未初始化导致 `UnboundLocalError` 的 bug
- 在 `async for` 遍历前将 `final_output` 初始化为 `None`

## Test plan
- [ ] CI 通过