### PR TITLE
refactor(agent): 将 build_enhanced_prompt 提取到 prompts.py 并移除 prompt.py

### DIFF
--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -1,8 +1,11 @@
-"""系统提示词组装（启动时读盘一次，缓存）。"""
+"""系统提示词组装。"""
 
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
+
+from memory.long_term import retrieve_long_term_context
+from memory.preference import get_stable_preferences
 
 PERSONAS_DIR = Path(__file__).resolve().parent.parent / "config" / "personas"
 
@@ -31,3 +34,30 @@ def build_system_prompt() -> str:
         _read_persona("MEMORY.md"),
     ]
     return "\n".join(parts)
+
+
+def build_enhanced_prompt(system_prompt: str, user_input: str) -> str:
+    """检索长期记忆和用户偏好，拼接增强后的系统提示词。"""
+    prompt = system_prompt
+    try:
+        retrieved = retrieve_long_term_context(user_input, top_k=10)
+        stable = get_stable_preferences()
+
+        if retrieved.get("error_rules"):
+            rules = "\n".join(
+                f"- {r.get('correction', r.get('mistake', str(r)))}"
+                for r in retrieved["error_rules"][:5]
+            )
+            prompt += f"\n\n## 错误规避规则\n{rules}"
+        if retrieved.get("preference_rules"):
+            prefs = "\n".join(
+                f"- {p.get('habit', str(p))}"
+                for p in retrieved["preference_rules"][:5]
+            )
+            prompt += f"\n\n## 用户偏好\n{prefs}"
+        if stable:
+            lines = [f"- {k} = {v.get('value', '')}" for k, v in stable.items()]
+            prompt += f"\n\n## 稳定偏好\n" + "\n".join(lines[:5])
+    except Exception:
+        pass
+    return prompt

--- a/clients/cli.py
+++ b/clients/cli.py
@@ -7,12 +7,10 @@ from datetime import datetime
 from langchain_openai import ChatOpenAI
 
 from agent.graph import build_agent
-from agent.prompts import build_system_prompt
+from agent.prompts import build_enhanced_prompt, build_system_prompt
 from callbacks.printer import PrinterCallback
 from config.settings import get_settings
 from memory.extractor import extract_from_messages, save_extracted
-from memory.long_term import retrieve_long_term_context
-from memory.preference import get_stable_preferences
 from memory.short_term import ShortTermMemory
 from skills import get_all_skills
 
@@ -82,7 +80,7 @@ class SonettoCLI:
                 continue
 
             # 注入长期记忆
-            enhanced_prompt = self._build_enhanced_prompt(user_input)
+            enhanced_prompt = build_enhanced_prompt(self.system_prompt, user_input)
 
             self.graph = build_agent(
                 model=self.llm,
@@ -97,7 +95,7 @@ class SonettoCLI:
             self._turn_messages = [{"role": "user", "content": user_input}]
 
             print()
-            await self._stream_events(
+            await self._run_stream_events(
                 {"messages": [{"role": "user", "content": user_input}]},
                 config,
             )
@@ -105,33 +103,7 @@ class SonettoCLI:
 
             self._save_turn()
 
-    def _build_enhanced_prompt(self, user_input: str) -> str:
-        """检索长期记忆和用户偏好，拼接增强后的系统提示词。"""
-        prompt = self.system_prompt
-        try:
-            retrieved = retrieve_long_term_context(user_input, top_k=10)
-            stable = get_stable_preferences()
-
-            if retrieved.get("error_rules"):
-                rules = "\n".join(
-                    f"- {r.get('correction', r.get('mistake', str(r)))}"
-                    for r in retrieved["error_rules"][:5]
-                )
-                prompt += f"\n\n## 错误规避规则\n{rules}"
-            if retrieved.get("preference_rules"):
-                prefs = "\n".join(
-                    f"- {p.get('habit', str(p))}"
-                    for p in retrieved["preference_rules"][:5]
-                )
-                prompt += f"\n\n## 用户偏好\n{prefs}"
-            if stable:
-                lines = [f"- {k} = {v.get('value', '')}" for k, v in stable.items()]
-                prompt += f"\n\n## 稳定偏好\n" + "\n".join(lines[:5])
-        except Exception:
-            pass
-        return prompt
-
-    async def _stream_events(self, inputs: dict, config: dict) -> None:
+    async def _run_stream_events(self, inputs: dict, config: dict) -> None:
         """流式消费 Agent 图事件，收集工具输出和最终回复到 _turn_messages。"""
 
         final_output = None

--- a/clients/qqbot.py
+++ b/clients/qqbot.py
@@ -9,11 +9,9 @@ from botpy.types.message import Message
 from langchain_openai import ChatOpenAI
 
 from agent.graph import build_agent
-from agent.prompts import build_system_prompt
+from agent.prompts import build_enhanced_prompt, build_system_prompt
 from config.settings import get_settings
 from memory.extractor import extract_from_messages, save_extracted
-from memory.long_term import retrieve_long_term_context
-from memory.preference import get_stable_preferences
 from memory.short_term import ShortTermMemory
 from skills import get_all_skills
 
@@ -55,7 +53,7 @@ class SonettoQQBot(botpy.Client):
         session = self._get_session(user_id)
 
         # 注入长期记忆构建增强提示词
-        enhanced_prompt = self._build_enhanced_prompt(user_input)
+        enhanced_prompt = build_enhanced_prompt(self.system_prompt, user_input)
 
         # 每条消息使用独立的 graph，共享 thread_id 以维持对话上下文
         graph = build_agent(
@@ -95,33 +93,6 @@ class SonettoQQBot(botpy.Client):
             save_extracted(extracted, source="qqbot", session_id=session["thread_id"])
         except Exception:
             pass
-
-    def _build_enhanced_prompt(self, user_input: str) -> str:
-        """检索长期记忆和用户偏好，拼接增强后的系统提示词。"""
-        prompt = self.system_prompt
-        try:
-            retrieved = retrieve_long_term_context(user_input, top_k=10)
-            stable = get_stable_preferences()
-
-            if retrieved.get("error_rules"):
-                rules = "\n".join(
-                    f"- {r.get('correction', r.get('mistake', str(r)))}"
-                    for r in retrieved["error_rules"][:5]
-                )
-                prompt += f"\n\n## 错误规避规则\n{rules}"
-            if retrieved.get("preference_rules"):
-                prefs = "\n".join(
-                    f"- {p.get('habit', str(p))}"
-                    for p in retrieved["preference_rules"][:5]
-                )
-                prompt += f"\n\n## 用户偏好\n{prefs}"
-            if stable:
-                lines = [f"- {k} = {v.get('value', '')}" for k, v in stable.items()]
-                prompt += f"\n\n## 稳定偏好\n" + "\n".join(lines[:5])
-        except Exception:
-            pass
-        return prompt
-
 
 def create_client_from_config() -> SonettoQQBot:
     """从 Settings 读取 QQ Bot 配置并创建客户端实例。"""

--- a/docs/06-客户端与回调系统.md
+++ b/docs/06-客户端与回调系统.md
@@ -67,7 +67,7 @@ async def run(self) -> None:
         user_input = input(">>> ").strip()
 
         if user_input == "/exit":    break
-        if user_input == "/clear":   # 重置记忆和回合消息
+        if user_input == "/clear":  # 重置记忆和回合消息
             self.memory.clear()
             self._turn_messages.clear()
             continue
@@ -78,7 +78,7 @@ async def run(self) -> None:
 
         # 流式执行
         config = {"configurable": {"thread_id": self.session_id}}
-        await self._stream_events(
+        await self._run_stream_events(
             {"messages": [{"role": "user", "content": user_input}]},
             config,
         )


### PR DESCRIPTION
## Summary
- 将 `_build_enhanced_prompt` 方法从 `cli.py` 和 `qqbot.py` 提取为 `agent/prompts.py` 中的共享函数 `build_enhanced_prompt`
- 删除冗余的 `agent/prompt.py`
- 统一从 `agent/prompts` 导入两个函数
- 更新文档中对 `_stream_events` → `_run_stream_events` 的引用

## Test plan
- [ ] CLI 端启动正常，多轮对话无报错
- [ ] QQ Bot 端消息处理正常