### PR TITLE
feat(memory): 长时记忆系统 — CRUD Agent + YAML 操作日志 + 代码重构

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ extracted/
 .claude/settings.local.json
 config/personas/USER.md
 config/personas/MEMORY.md
+config/personas/memory_operations.yaml

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import traceback
+from datetime import datetime
 from pathlib import Path
 
+import yaml
 from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
@@ -13,6 +15,7 @@ DEBUG = True  # 调试开关，排查 MEMORY.md 未更新的问题
 
 PERSONAS_DIR = Path(__file__).resolve().parent.parent / "config" / "personas"
 MEMORY_PATH = PERSONAS_DIR / "MEMORY.md"
+LOG_PATH = PERSONAS_DIR / "memory_operations.yaml"
 
 # CRUD 工具操作的当前会话状态，每次 _consumer 迭代前重置
 _current_entries: dict[str, str] = {}
@@ -86,6 +89,22 @@ def _serialize_memory(entries: dict[str, str]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _log_operation(operation: str, params: dict) -> None:
+    """追加一条操作记录到 YAML 日志文件。"""
+    entry = {
+        "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+        "operation": operation,
+        "params": params,
+    }
+    if LOG_PATH.exists():
+        existing = yaml.safe_load(LOG_PATH.read_text(encoding="utf-8")) or []
+    else:
+        existing = []
+    existing.append(entry)
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    LOG_PATH.write_text(yaml.safe_dump(existing, allow_unicode=True), encoding="utf-8")
+
+
 # ── CRUD 工具 ──────────────────────────────────────────────────
 
 @tool
@@ -99,6 +118,7 @@ def create_memory(content: str) -> str:
     eid = str(_next_id)
     _current_entries[eid] = content
     _next_id += 1
+    _log_operation("create_memory", {"content": content})
     result = f"已创建 [{eid}]: {content}"
     if DEBUG:
         print(f"[LTM-TOOL] create_memory → [{eid}] {content[:80]}...")
@@ -120,12 +140,14 @@ def read_memories() -> str:
 
 
 @tool
-def update_memory(id: str, content: str) -> str:
+def update_memory(id: str, content: str, reason: str, origin_content: str) -> str:
     """根据 ID 更新一条已有记忆。
 
     Args:
         id: 要更新的记忆 ID（来自 read_memories 的输出）。
         content: 更新后的完整内容。
+        reason: 修改原因，说明为什么要更新这条记忆。
+        origin_content: 修改前的原始内容，必须与 read_memories 中该 ID 对应的内容完全一致。
     """
     if id not in _current_entries:
         if DEBUG:
@@ -133,25 +155,36 @@ def update_memory(id: str, content: str) -> str:
         return f"错误：未找到 ID 为 {id} 的记忆条目。请先调用 read_memories 确认 ID。"
     old = _current_entries[id]
     _current_entries[id] = content
+    _log_operation("update_memory", {
+        "content": content,
+        "reason": reason,
+        "origin_content": origin_content,
+    })
     if DEBUG:
-        print(f"[LTM-TOOL] update_memory [{id}] 旧→新")
+        print(f"[LTM-TOOL] update_memory [{id}] 旧→新 | 原因: {reason[:60]}")
     return f"已更新 [{id}]\n  旧: {old}\n  新: {content}"
 
 
 @tool
-def delete_memory(id: str) -> str:
+def delete_memory(id: str, reason: str, origin_content: str) -> str:
     """根据 ID 删除一条记忆。
 
     Args:
         id: 要删除的记忆 ID（来自 read_memories 的输出）。
+        reason: 删除原因，说明为什么要删除这条记忆。
+        origin_content: 删除前的原始内容，必须与 read_memories 中该 ID 对应的内容完全一致。
     """
     if id not in _current_entries:
         if DEBUG:
             print(f"[LTM-TOOL] delete_memory [{id}] → 错误：ID 不存在")
         return f"错误：未找到 ID 为 {id} 的记忆条目。请先调用 read_memories 确认 ID。"
     removed = _current_entries.pop(id)
+    _log_operation("delete_memory", {
+        "reason": reason,
+        "origin_content": origin_content,
+    })
     if DEBUG:
-        print(f"[LTM-TOOL] delete_memory [{id}] 已删除")
+        print(f"[LTM-TOOL] delete_memory [{id}] 已删除 | 原因: {reason[:60]}")
     return f"已删除 [{id}]: {removed}"
 
 

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -1,38 +1,49 @@
 """记忆叙事模块 — 每轮对话后将裸消息送给 LLM，增量更新 MEMORY.md。"""
 
 import asyncio
+import traceback
 from pathlib import Path
 
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.prebuilt import create_react_agent
+
+DEBUG = True  # 调试开关，排查 MEMORY.md 未更新的问题
 
 PERSONAS_DIR = Path(__file__).resolve().parent.parent / "config" / "personas"
 MEMORY_PATH = PERSONAS_DIR / "MEMORY.md"
 
-COLD_START_SYSTEM = """你是一个记忆叙事师。以下是用户与AI助手的一段对话。请仅根据对话中用户明确表达的信息，撰写一份关于这个用户的简洁记忆。
+# CRUD 工具操作的当前会话状态，每次 _consumer 迭代前重置
+_current_entries: dict[str, str] = {}
+_next_id: int = 1
 
-核心原则——违反将导致严重错误：
-1. 只写用户明确说过的事实。绝不编造、推测或补全任何用户未提及的信息。
-2. 用户说了什么就记什么，信息少就写短，不要为凑字数而生造内容。
-3. 用第三人称自然语言描述，不超过 400 字。
+COLD_START_SYSTEM = """你是一位"记忆叙事师"。根据对话记录，用第三人称撰写关于用户的简洁中文记忆。
 
-可涵盖的方面（有则写，无则跳过，不要强行填满）：
-- 用户身份（职业、专业、角色等）
-- 偏好习惯（沟通风格、工具偏好等）
-- 重要事件或项目
-- 注意事项"""
+你必须使用提供的工具来管理记忆：
+- 先调用 read_memories 查看当前记忆（冷启动时为空）
+- 使用 create_memory 逐条添加新事实
+- 无需调用 update_memory 或 delete_memory（冷启动时没有旧记忆）
 
-UPDATE_SYSTEM = """你是一个记忆叙事师。以下是当前你对用户的记忆，以及新一轮的对话。请在现有记忆的基础上，融入新信息，写一份更新后的记忆。
+核心原则：
+1. 只写用户明确说过的事实，绝不编造、推测或补全任何信息
+2. 每条记忆一个独立事实，用 create_memory 逐条添加
+3. 用户说了什么就记什么，信息少就少写，不要凑字数
+4. 用第三人称自然语言描述"""
 
-核心原则——违反将导致严重错误：
-1. 只写用户明确说过的事实。绝不编造、推测或补全任何用户未提及的信息。
-2. 保留已有正确信息；新信息优先于旧信息；矛盾时以新信息为准。
-3. 用第三人称自然语言描述，不超过 400 字。
+UPDATE_SYSTEM = """你是一位"记忆叙事师"。以下是当前记忆（每条带唯一ID）和一轮新对话。请对比新旧信息，更新记忆。
 
-可涵盖的方面（有则写，无则跳过，不要强行填满）：
-- 用户身份（职业、专业、角色等）
-- 偏好习惯（沟通风格、工具偏好等）
-- 重要事件或项目
-- 注意事项"""
+你必须使用提供的工具来管理记忆：
+- 先调用 read_memories 查看所有当前记忆
+- 新信息用 create_memory 逐条添加
+- 已有信息需要修正或补充时用 update_memory（通过 ID 指定）
+- 与新信息矛盾或已过时的条目用 delete_memory 删除
+
+核心原则：
+1. 只写用户明确说过的事实，绝不编造、推测或补全任何信息
+2. 保留正确的已有信息；新信息优先于旧信息；矛盾时以新信息为准
+3. 每条记忆一个独立事实
+4. 用第三人称自然语言描述"""
 
 
 def get_narrative() -> str:
@@ -52,6 +63,96 @@ def _format_messages(messages: list[dict]) -> str:
         content = str(m.get("content", ""))
         lines.append(f"[{role}]: {content}")
     return "\n".join(lines)
+
+
+def _parse_memory(content: str) -> tuple[dict[str, str], int]:
+    """解析 MEMORY.md 文本为带自增 ID 的字典。
+
+    返回 ({id: content}, next_id)。跳过不以 "- " 开头的行。
+    """
+    entries: dict[str, str] = {}
+    next_id = 1
+    for line in content.strip().split("\n"):
+        line = line.strip()
+        if line.startswith("- "):
+            entries[str(next_id)] = line[2:].strip()
+            next_id += 1
+    return entries, next_id
+
+
+def _serialize_memory(entries: dict[str, str]) -> str:
+    """将 {id: content} 字典序列化为 MEMORY.md 格式。"""
+    lines = [f"- {text}" for text in entries.values()]
+    return "\n".join(lines) + "\n"
+
+
+# ── CRUD 工具 ──────────────────────────────────────────────────
+
+@tool
+def create_memory(content: str) -> str:
+    """添加一条新的记忆条目。调用后返回该条目的唯一 ID。
+
+    Args:
+        content: 记忆内容，用第三人称中文描述用户的一个事实。
+    """
+    global _current_entries, _next_id
+    eid = str(_next_id)
+    _current_entries[eid] = content
+    _next_id += 1
+    result = f"已创建 [{eid}]: {content}"
+    if DEBUG:
+        print(f"[LTM-TOOL] create_memory → [{eid}] {content[:80]}...")
+    return result
+
+
+@tool
+def read_memories() -> str:
+    """查看当前所有记忆条目及其 ID。在增删改之前必须先调用此工具了解现有条目。"""
+    if not _current_entries:
+        if DEBUG:
+            print("[LTM-TOOL] read_memories → (空)")
+        return "（暂无记忆条目）"
+    lines = [f"[{eid}] {text}" for eid, text in _current_entries.items()]
+    result = "\n".join(lines)
+    if DEBUG:
+        print(f"[LTM-TOOL] read_memories → {len(_current_entries)} 条")
+    return result
+
+
+@tool
+def update_memory(id: str, content: str) -> str:
+    """根据 ID 更新一条已有记忆。
+
+    Args:
+        id: 要更新的记忆 ID（来自 read_memories 的输出）。
+        content: 更新后的完整内容。
+    """
+    if id not in _current_entries:
+        if DEBUG:
+            print(f"[LTM-TOOL] update_memory [{id}] → 错误：ID 不存在")
+        return f"错误：未找到 ID 为 {id} 的记忆条目。请先调用 read_memories 确认 ID。"
+    old = _current_entries[id]
+    _current_entries[id] = content
+    if DEBUG:
+        print(f"[LTM-TOOL] update_memory [{id}] 旧→新")
+    return f"已更新 [{id}]\n  旧: {old}\n  新: {content}"
+
+
+@tool
+def delete_memory(id: str) -> str:
+    """根据 ID 删除一条记忆。
+
+    Args:
+        id: 要删除的记忆 ID（来自 read_memories 的输出）。
+    """
+    if id not in _current_entries:
+        if DEBUG:
+            print(f"[LTM-TOOL] delete_memory [{id}] → 错误：ID 不存在")
+        return f"错误：未找到 ID 为 {id} 的记忆条目。请先调用 read_memories 确认 ID。"
+    removed = _current_entries.pop(id)
+    if DEBUG:
+        print(f"[LTM-TOOL] delete_memory [{id}] 已删除")
+    return f"已删除 [{id}]: {removed}"
 
 
 class LongTermMemoryInterface:
@@ -100,35 +201,83 @@ class LongTermMemoryInterface:
             self._consumer_task = None
 
     async def _consumer(self, llm) -> None:
-        """后台消费者协程：从队列取消息，调用 ainvoke，写入 MEMORY.md。"""
+        """后台消费者协程：从队列取消息，调用 CRUD Agent，写入 MEMORY.md。"""
+        global _current_entries, _next_id
+
         while True:
             turn_messages = await self._queue.get()
             if turn_messages is None:
+                if DEBUG:
+                    print("[LTM-CONSUMER] 收到哨兵，即将退出")
                 break
 
             try:
+                if DEBUG:
+                    print(f"\n{'='*60}")
+                    print("[LTM-CONSUMER] === 新轮次开始 ===")
+                    print(f"[LTM-CONSUMER] 收到 {len(turn_messages)} 条消息")
+
                 old_narrative = self.get_narrative()
                 messages_text = _format_messages(turn_messages)
 
                 if old_narrative:
+                    _current_entries, _next_id = _parse_memory(old_narrative)
                     system_prompt = UPDATE_SYSTEM
                     user_prompt = (
-                        f"## 当前记忆\n{old_narrative}\n\n"
                         f"## 新一轮对话\n{messages_text}"
                     )
+                    if DEBUG:
+                        print(f"[LTM-CONSUMER] 模式: 更新 (解析到 {len(_current_entries)} 条旧记忆)")
+                        for eid, text in _current_entries.items():
+                            print(f"[LTM-CONSUMER]   旧 [{eid}]: {text[:60]}...")
                 else:
+                    _current_entries, _next_id = {}, 1
                     system_prompt = COLD_START_SYSTEM
                     user_prompt = messages_text
+                    if DEBUG:
+                        print("[LTM-CONSUMER] 模式: 冷启动")
 
-                response = await llm.ainvoke([
-                    SystemMessage(content=system_prompt),
-                    HumanMessage(content=user_prompt),
-                ])
-                new_narrative = response.content.strip()
-                if new_narrative:
+                crud_tools = [create_memory, read_memories, update_memory, delete_memory]
+                if DEBUG:
+                    print("[LTM-CONSUMER] 构建 CRUD Agent...")
+
+                agent = create_react_agent(
+                    model=llm,
+                    tools=crud_tools,
+                    prompt=system_prompt,
+                    checkpointer=MemorySaver(),
+                )
+
+                if DEBUG:
+                    print("[LTM-CONSUMER] 调用 agent.ainvoke...")
+
+                result = await agent.ainvoke(
+                    {"messages": [HumanMessage(content=user_prompt)]},
+                    config={"configurable": {"thread_id": "ltm-consumer"}},
+                )
+
+                if DEBUG:
+                    msg_count = len(result.get("messages", []))
+                    print(f"[LTM-CONSUMER] Agent 返回 {msg_count} 条消息")
+                    # 打印最后一条非工具消息（Agent 的最终回复）
+                    for m in reversed(result.get("messages", [])):
+                        if hasattr(m, "content") and getattr(m, "type", "") != "tool":
+                            print(f"[LTM-CONSUMER] Agent 最终回复: {str(m.content)[:200]}")
+                            break
+                    print(f"[LTM-CONSUMER] 操作后 _current_entries: {len(_current_entries)} 条")
+                    for eid, text in _current_entries.items():
+                        print(f"[LTM-CONSUMER]   新 [{eid}]: {text[:60]}...")
+
+                new_narrative = _serialize_memory(_current_entries)
+                if new_narrative.strip():
                     self._memory_path.parent.mkdir(parents=True, exist_ok=True)
-                    self._memory_path.write_text(
-                        new_narrative + "\n", encoding="utf-8"
-                    )
+                    self._memory_path.write_text(new_narrative, encoding="utf-8")
+                    if DEBUG:
+                        print(f"[LTM-CONSUMER] ✅ 已写入 MEMORY.md ({len(new_narrative)} 字节)")
+                else:
+                    if DEBUG:
+                        print("[LTM-CONSUMER] ⚠️ 叙事为空，跳过写入")
             except Exception:
+                if DEBUG:
+                    print(f"[LTM-CONSUMER] ❌ 异常:\n{traceback.format_exc()}")
                 pass

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -11,15 +11,11 @@ from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 
-DEBUG = True  # 调试开关，排查 MEMORY.md 未更新的问题
+DEBUG = False  # 调试开关，排查 MEMORY.md 未更新的问题
 
 PERSONAS_DIR = Path(__file__).resolve().parent.parent / "config" / "personas"
 MEMORY_PATH = PERSONAS_DIR / "MEMORY.md"
 LOG_PATH = PERSONAS_DIR / "memory_operations.yaml"
-
-# CRUD 工具操作的当前会话状态，每次 _consumer 迭代前重置
-_current_entries: dict[str, str] = {}
-_next_id: int = 1
 
 COLD_START_SYSTEM = """你是一位"记忆叙事师"。根据对话记录，用第三人称撰写关于用户的简洁中文记忆。
 
@@ -68,44 +64,132 @@ def _format_messages(messages: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _parse_memory(content: str) -> tuple[dict[str, str], int]:
-    """解析 MEMORY.md 文本为带自增 ID 的字典。
+# ── MemorySerializer ──────────────────────────────────────────
 
-    返回 ({id: content}, next_id)。跳过不以 "- " 开头的行。
+
+class MemorySerializer:
+    """MEMORY.md 格式 ↔ 条目字典 双向转换。"""
+
+    @staticmethod
+    def parse(content: str) -> tuple[dict[str, str], int]:
+        """解析 "- " 列表为 {id: content} 字典。
+
+        返回 ({id: content}, next_id)。跳过不以 "- " 开头的行。
+        """
+        entries: dict[str, str] = {}
+        next_id = 1
+        for line in content.strip().split("\n"):
+            line = line.strip()
+            if line.startswith("- "):
+                entries[str(next_id)] = line[2:].strip()
+                next_id += 1
+        return entries, next_id
+
+    @staticmethod
+    def serialize(entries: dict[str, str]) -> str:
+        """将 {id: content} 字典序列化为 MEMORY.md 格式。"""
+        lines = [f"- {text}" for text in entries.values()]
+        return "\n".join(lines) + "\n"
+
+
+# ── MemoryLogger ──────────────────────────────────────────────
+
+
+class MemoryLogger:
+    """YAML 操作日志记录器。"""
+
+    @staticmethod
+    def log(operation: str, params: dict) -> None:
+        """追加一条操作记录到 YAML 日志文件。"""
+        entry = {
+            "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+            "operation": operation,
+            "params": params,
+        }
+        if LOG_PATH.exists():
+            existing = yaml.safe_load(LOG_PATH.read_text(encoding="utf-8")) or []
+        else:
+            existing = []
+        existing.append(entry)
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        LOG_PATH.write_text(
+            yaml.safe_dump(existing, allow_unicode=True), encoding="utf-8"
+        )
+
+
+# ── MemoryStore（单例）────────────────────────────────────────
+
+
+class MemoryStore:
+    """记忆条目存储器（单例）。
+
+    持有当前会话的条目字典和自增 ID 计数器，提供 CRUD 操作。
     """
-    entries: dict[str, str] = {}
-    next_id = 1
-    for line in content.strip().split("\n"):
-        line = line.strip()
-        if line.startswith("- "):
-            entries[str(next_id)] = line[2:].strip()
-            next_id += 1
-    return entries, next_id
+
+    _instance: "MemoryStore | None" = None
+
+    def __new__(cls) -> "MemoryStore":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self) -> None:
+        if not hasattr(self, "_initialized"):
+            self._initialized = True
+            self.entries: dict[str, str] = {}
+            self.next_id: int = 1
+
+    def reset(self) -> None:
+        """重置为初始状态。"""
+        self.entries.clear()
+        self.next_id = 1
+
+    def load(self, content: str) -> None:
+        """从 MEMORY.md 文本解析并加载条目。"""
+        self.entries, self.next_id = MemorySerializer.parse(content)
+
+    def create(self, content: str) -> str:
+        """添加一条记忆条目，返回结果消息。"""
+        eid = str(self.next_id)
+        self.entries[eid] = content
+        self.next_id += 1
+        return f"已创建 [{eid}]: {content}"
+
+    def read_all(self) -> str:
+        """返回所有条目的格式化文本。"""
+        if not self.entries:
+            return "（暂无记忆条目）"
+        lines = [f"[{eid}] {text}" for eid, text in self.entries.items()]
+        return "\n".join(lines)
+
+    def update(self, id: str, content: str) -> str:
+        """根据 ID 更新一条条目，返回结果消息。"""
+        if id not in self.entries:
+            return (
+                f"错误：未找到 ID 为 {id} 的记忆条目。"
+                "请先调用 read_memories 确认 ID。"
+            )
+        old = self.entries[id]
+        self.entries[id] = content
+        return f"已更新 [{id}]\n  旧: {old}\n  新: {content}"
+
+    def delete(self, id: str) -> str:
+        """根据 ID 删除一条条目，返回结果消息。"""
+        if id not in self.entries:
+            return (
+                f"错误：未找到 ID 为 {id} 的记忆条目。"
+                "请先调用 read_memories 确认 ID。"
+            )
+        removed = self.entries.pop(id)
+        return f"已删除 [{id}]: {removed}"
+
+    def serialize(self) -> str:
+        """将当前条目序列化为 MEMORY.md 格式。"""
+        return MemorySerializer.serialize(self.entries)
 
 
-def _serialize_memory(entries: dict[str, str]) -> str:
-    """将 {id: content} 字典序列化为 MEMORY.md 格式。"""
-    lines = [f"- {text}" for text in entries.values()]
-    return "\n".join(lines) + "\n"
+# ── CRUD 工具（模块级 @tool，委托给 MemoryStore 单例）───────
 
-
-def _log_operation(operation: str, params: dict) -> None:
-    """追加一条操作记录到 YAML 日志文件。"""
-    entry = {
-        "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
-        "operation": operation,
-        "params": params,
-    }
-    if LOG_PATH.exists():
-        existing = yaml.safe_load(LOG_PATH.read_text(encoding="utf-8")) or []
-    else:
-        existing = []
-    existing.append(entry)
-    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    LOG_PATH.write_text(yaml.safe_dump(existing, allow_unicode=True), encoding="utf-8")
-
-
-# ── CRUD 工具 ──────────────────────────────────────────────────
 
 @tool
 def create_memory(content: str) -> str:
@@ -114,13 +198,11 @@ def create_memory(content: str) -> str:
     Args:
         content: 记忆内容，用第三人称中文描述用户的一个事实。
     """
-    global _current_entries, _next_id
-    eid = str(_next_id)
-    _current_entries[eid] = content
-    _next_id += 1
-    _log_operation("create_memory", {"content": content})
-    result = f"已创建 [{eid}]: {content}"
+    store = MemoryStore()
+    result = store.create(content)
+    MemoryLogger.log("create_memory", {"content": content})
     if DEBUG:
+        eid = str(store.next_id - 1)
         print(f"[LTM-TOOL] create_memory → [{eid}] {content[:80]}...")
     return result
 
@@ -128,14 +210,10 @@ def create_memory(content: str) -> str:
 @tool
 def read_memories() -> str:
     """查看当前所有记忆条目及其 ID。在增删改之前必须先调用此工具了解现有条目。"""
-    if not _current_entries:
-        if DEBUG:
-            print("[LTM-TOOL] read_memories → (空)")
-        return "（暂无记忆条目）"
-    lines = [f"[{eid}] {text}" for eid, text in _current_entries.items()]
-    result = "\n".join(lines)
+    store = MemoryStore()
+    result = store.read_all()
     if DEBUG:
-        print(f"[LTM-TOOL] read_memories → {len(_current_entries)} 条")
+        print(f"[LTM-TOOL] read_memories → {len(store.entries)} 条")
     return result
 
 
@@ -149,20 +227,20 @@ def update_memory(id: str, content: str, reason: str, origin_content: str) -> st
         reason: 修改原因，说明为什么要更新这条记忆。
         origin_content: 修改前的原始内容，必须与 read_memories 中该 ID 对应的内容完全一致。
     """
-    if id not in _current_entries:
+    store = MemoryStore()
+    if id not in store.entries:
         if DEBUG:
             print(f"[LTM-TOOL] update_memory [{id}] → 错误：ID 不存在")
         return f"错误：未找到 ID 为 {id} 的记忆条目。请先调用 read_memories 确认 ID。"
-    old = _current_entries[id]
-    _current_entries[id] = content
-    _log_operation("update_memory", {
+    result = store.update(id, content)
+    MemoryLogger.log("update_memory", {
         "content": content,
         "reason": reason,
         "origin_content": origin_content,
     })
     if DEBUG:
         print(f"[LTM-TOOL] update_memory [{id}] 旧→新 | 原因: {reason[:60]}")
-    return f"已更新 [{id}]\n  旧: {old}\n  新: {content}"
+    return result
 
 
 @tool
@@ -174,18 +252,22 @@ def delete_memory(id: str, reason: str, origin_content: str) -> str:
         reason: 删除原因，说明为什么要删除这条记忆。
         origin_content: 删除前的原始内容，必须与 read_memories 中该 ID 对应的内容完全一致。
     """
-    if id not in _current_entries:
+    store = MemoryStore()
+    if id not in store.entries:
         if DEBUG:
             print(f"[LTM-TOOL] delete_memory [{id}] → 错误：ID 不存在")
         return f"错误：未找到 ID 为 {id} 的记忆条目。请先调用 read_memories 确认 ID。"
-    removed = _current_entries.pop(id)
-    _log_operation("delete_memory", {
+    result = store.delete(id)
+    MemoryLogger.log("delete_memory", {
         "reason": reason,
         "origin_content": origin_content,
     })
     if DEBUG:
         print(f"[LTM-TOOL] delete_memory [{id}] 已删除 | 原因: {reason[:60]}")
-    return f"已删除 [{id}]: {removed}"
+    return result
+
+
+# ── LongTermMemoryInterface ───────────────────────────────────
 
 
 class LongTermMemoryInterface:
@@ -235,7 +317,7 @@ class LongTermMemoryInterface:
 
     async def _consumer(self, llm) -> None:
         """后台消费者协程：从队列取消息，调用 CRUD Agent，写入 MEMORY.md。"""
-        global _current_entries, _next_id
+        store = MemoryStore()
 
         while True:
             turn_messages = await self._queue.get()
@@ -254,17 +336,17 @@ class LongTermMemoryInterface:
                 messages_text = _format_messages(turn_messages)
 
                 if old_narrative:
-                    _current_entries, _next_id = _parse_memory(old_narrative)
+                    store.load(old_narrative)
                     system_prompt = UPDATE_SYSTEM
                     user_prompt = (
                         f"## 新一轮对话\n{messages_text}"
                     )
                     if DEBUG:
-                        print(f"[LTM-CONSUMER] 模式: 更新 (解析到 {len(_current_entries)} 条旧记忆)")
-                        for eid, text in _current_entries.items():
+                        print(f"[LTM-CONSUMER] 模式: 更新 (解析到 {len(store.entries)} 条旧记忆)")
+                        for eid, text in store.entries.items():
                             print(f"[LTM-CONSUMER]   旧 [{eid}]: {text[:60]}...")
                 else:
-                    _current_entries, _next_id = {}, 1
+                    store.reset()
                     system_prompt = COLD_START_SYSTEM
                     user_prompt = messages_text
                     if DEBUG:
@@ -292,16 +374,15 @@ class LongTermMemoryInterface:
                 if DEBUG:
                     msg_count = len(result.get("messages", []))
                     print(f"[LTM-CONSUMER] Agent 返回 {msg_count} 条消息")
-                    # 打印最后一条非工具消息（Agent 的最终回复）
                     for m in reversed(result.get("messages", [])):
                         if hasattr(m, "content") and getattr(m, "type", "") != "tool":
                             print(f"[LTM-CONSUMER] Agent 最终回复: {str(m.content)[:200]}")
                             break
-                    print(f"[LTM-CONSUMER] 操作后 _current_entries: {len(_current_entries)} 条")
-                    for eid, text in _current_entries.items():
+                    print(f"[LTM-CONSUMER] 操作后 entries: {len(store.entries)} 条")
+                    for eid, text in store.entries.items():
                         print(f"[LTM-CONSUMER]   新 [{eid}]: {text[:60]}...")
 
-                new_narrative = _serialize_memory(_current_entries)
+                new_narrative = store.serialize()
                 if new_narrative.strip():
                     self._memory_path.parent.mkdir(parents=True, exist_ok=True)
                     self._memory_path.write_text(new_narrative, encoding="utf-8")

--- a/tests/test_memory/test_narrative.py
+++ b/tests/test_memory/test_narrative.py
@@ -88,42 +88,42 @@ class TestParseSerialize:
     """_parse_memory / _serialize_memory 单元测试。"""
 
     def test_parse_empty(self):
-        entries, next_id = narrative._parse_memory("")
+        entries, next_id = narrative.MemorySerializer.parse("")
         assert entries == {}
         assert next_id == 1
 
     def test_parse_single_entry(self):
-        entries, next_id = narrative._parse_memory("- 用户叫Miso。")
+        entries, next_id = narrative.MemorySerializer.parse("- 用户叫Miso。")
         assert entries == {"1": "用户叫Miso。"}
         assert next_id == 2
 
     def test_parse_multiple_entries(self):
         content = "- 第一条。\n- 第二条。\n- 第三条。"
-        entries, next_id = narrative._parse_memory(content)
+        entries, next_id = narrative.MemorySerializer.parse(content)
         assert entries == {"1": "第一条。", "2": "第二条。", "3": "第三条。"}
         assert next_id == 4
 
     def test_parse_skips_non_dash_lines(self):
         content = "前言\n- 条目A\n空行\n- 条目B"
-        entries, next_id = narrative._parse_memory(content)
+        entries, next_id = narrative.MemorySerializer.parse(content)
         assert entries == {"1": "条目A", "2": "条目B"}
         assert next_id == 3
 
     def test_serialize_empty(self):
-        result = narrative._serialize_memory({})
+        result = narrative.MemorySerializer.serialize({})
         assert result == "\n"
 
     def test_serialize_with_entries(self):
         entries = {"1": "A", "2": "B"}
-        result = narrative._serialize_memory(entries)
+        result = narrative.MemorySerializer.serialize(entries)
         assert result == "- A\n- B\n"
 
     def test_roundtrip(self):
         """序列化后解析应得到相同条目。"""
         original = "- 事实1。\n- 事实2。\n"
-        entries, _ = narrative._parse_memory(original)
-        serialized = narrative._serialize_memory(entries)
-        entries2, _ = narrative._parse_memory(serialized)
+        entries, _ = narrative.MemorySerializer.parse(original)
+        serialized = narrative.MemorySerializer.serialize(entries)
+        entries2, _ = narrative.MemorySerializer.parse(serialized)
         assert entries == entries2
 
 
@@ -134,40 +134,38 @@ class TestCrudTools:
     """CRUD 工具函数单元测试。"""
 
     def setup_method(self):
-        narrative._current_entries = {}
-        narrative._next_id = 1
+        narrative.MemoryStore().reset()
 
     def teardown_method(self):
-        narrative._current_entries = {}
-        narrative._next_id = 1
+        narrative.MemoryStore().reset()
 
     def test_create_memory(self, monkeypatch, tmp_path):
         monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
         result = narrative.create_memory.invoke({"content": "用户叫Miso。"})
         assert "已创建 [1]" in result
-        assert narrative._current_entries["1"] == "用户叫Miso。"
-        assert narrative._next_id == 2
+        assert narrative.MemoryStore().entries["1"] == "用户叫Miso。"
+        assert narrative.MemoryStore().next_id == 2
 
     def test_read_memories_empty(self):
         result = narrative.read_memories.invoke({})
         assert "暂无记忆条目" in result
 
     def test_read_memories_with_entries(self):
-        narrative._current_entries = {"1": "A", "2": "B"}
+        narrative.MemoryStore().entries = {"1": "A", "2": "B"}
         result = narrative.read_memories.invoke({})
         assert "[1] A" in result
         assert "[2] B" in result
 
     def test_update_memory_success(self, monkeypatch, tmp_path):
         monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
-        narrative._current_entries = {"1": "旧内容"}
+        narrative.MemoryStore().entries = {"1": "旧内容"}
         result = narrative.update_memory.invoke({
             "id": "1", "content": "新内容",
             "reason": "信息过时，需要更新",
             "origin_content": "旧内容",
         })
         assert "已更新 [1]" in result
-        assert narrative._current_entries["1"] == "新内容"
+        assert narrative.MemoryStore().entries["1"] == "新内容"
 
     def test_update_memory_not_found(self, monkeypatch, tmp_path):
         monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
@@ -179,12 +177,12 @@ class TestCrudTools:
 
     def test_delete_memory_success(self, monkeypatch, tmp_path):
         monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
-        narrative._current_entries = {"1": "删除我"}
+        narrative.MemoryStore().entries = {"1": "删除我"}
         result = narrative.delete_memory.invoke({
             "id": "1", "reason": "信息已过时", "origin_content": "删除我",
         })
         assert "已删除 [1]" in result
-        assert "1" not in narrative._current_entries
+        assert "1" not in narrative.MemoryStore().entries
 
     def test_delete_memory_not_found(self, monkeypatch, tmp_path):
         monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
@@ -209,7 +207,7 @@ class TestCrudTools:
     def test_log_created_on_update(self, monkeypatch, tmp_path):
         log_path = tmp_path / "ops.yaml"
         monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative._current_entries = {"1": "旧内容"}
+        narrative.MemoryStore().entries = {"1": "旧内容"}
         narrative.update_memory.invoke({
             "id": "1", "content": "新内容",
             "reason": "信息过时", "origin_content": "旧内容",
@@ -225,7 +223,7 @@ class TestCrudTools:
     def test_log_created_on_delete(self, monkeypatch, tmp_path):
         log_path = tmp_path / "ops.yaml"
         monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative._current_entries = {"1": "删除我"}
+        narrative.MemoryStore().entries = {"1": "删除我"}
         narrative.delete_memory.invoke({
             "id": "1", "reason": "已过时", "origin_content": "删除我",
         })
@@ -249,7 +247,7 @@ class TestCrudTools:
         log_path = tmp_path / "ops.yaml"
         monkeypatch.setattr(narrative, "LOG_PATH", log_path)
         narrative.create_memory.invoke({"content": "第一条。"})
-        narrative._current_entries["1"] = "第一条。"
+        narrative.MemoryStore().entries["1"] = "第一条。"
         narrative.update_memory.invoke({
             "id": "1", "content": "第一条已改。",
             "reason": "修正", "origin_content": "第一条。",
@@ -296,13 +294,11 @@ class TestLongTermMemoryInterface:
 
     def setup_method(self):
         """每个测试前重置模块级状态。"""
-        narrative._current_entries = {}
-        narrative._next_id = 1
+        narrative.MemoryStore().reset()
 
     def teardown_method(self):
         """每个测试后清理模块级状态。"""
-        narrative._current_entries = {}
-        narrative._next_id = 1
+        narrative.MemoryStore().reset()
 
     # ── get_narrative（实例方法） ──────────────────────────────
 
@@ -372,7 +368,7 @@ class TestLongTermMemoryInterface:
         path = tmp_path / "MEMORY.md"
 
         def agent_populates_entries():
-            narrative._current_entries["1"] = "Miso 是一名学生。"
+            narrative.MemoryStore().entries["1"] = "Miso 是一名学生。"
 
         fake_agent = _fake_agent_factory(entries_setup=agent_populates_entries)
         monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
@@ -419,7 +415,7 @@ class TestLongTermMemoryInterface:
             captured_prompt.append(kwargs.get("prompt", ""))
             # 模拟 Agent 更新了一条记忆
             def update_entries():
-                narrative._current_entries["1"] = "更新后的记忆内容。"
+                narrative.MemoryStore().entries["1"] = "更新后的记忆内容。"
             return _fake_agent_factory(entries_setup=update_entries)
 
         monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
@@ -448,12 +444,12 @@ class TestLongTermMemoryInterface:
             call_count[0] += 1
             if call_count[0] == 1:
                 def setup1():
-                    narrative._current_entries["1"] = "第一轮记忆。"
+                    narrative.MemoryStore().entries["1"] = "第一轮记忆。"
                 return _fake_agent_factory(entries_setup=setup1)
             else:
                 def setup2():
-                    narrative._current_entries["1"] = "第一轮记忆。"
-                    narrative._current_entries["2"] = "第二轮补充。"
+                    narrative.MemoryStore().entries["1"] = "第一轮记忆。"
+                    narrative.MemoryStore().entries["2"] = "第二轮补充。"
                 return _fake_agent_factory(entries_setup=setup2)
 
         monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
@@ -535,7 +531,7 @@ class TestLongTermMemoryInterface:
         path = tmp_path / "MEMORY.md"
 
         fake_agent = _fake_agent_factory(
-            entries_setup=lambda: narrative._current_entries.update({"1": "记忆。"})
+            entries_setup=lambda: narrative.MemoryStore().entries.update({"1": "记忆。"})
         )
         monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 

--- a/tests/test_memory/test_narrative.py
+++ b/tests/test_memory/test_narrative.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import yaml
 
 import memory.narrative as narrative
 from memory.narrative import LongTermMemoryInterface
@@ -136,7 +137,12 @@ class TestCrudTools:
         narrative._current_entries = {}
         narrative._next_id = 1
 
-    def test_create_memory(self):
+    def teardown_method(self):
+        narrative._current_entries = {}
+        narrative._next_id = 1
+
+    def test_create_memory(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
         result = narrative.create_memory.invoke({"content": "用户叫Miso。"})
         assert "已创建 [1]" in result
         assert narrative._current_entries["1"] == "用户叫Miso。"
@@ -152,25 +158,110 @@ class TestCrudTools:
         assert "[1] A" in result
         assert "[2] B" in result
 
-    def test_update_memory_success(self):
+    def test_update_memory_success(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
         narrative._current_entries = {"1": "旧内容"}
-        result = narrative.update_memory.invoke({"id": "1", "content": "新内容"})
+        result = narrative.update_memory.invoke({
+            "id": "1", "content": "新内容",
+            "reason": "信息过时，需要更新",
+            "origin_content": "旧内容",
+        })
         assert "已更新 [1]" in result
         assert narrative._current_entries["1"] == "新内容"
 
-    def test_update_memory_not_found(self):
-        result = narrative.update_memory.invoke({"id": "99", "content": "x"})
+    def test_update_memory_not_found(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
+        result = narrative.update_memory.invoke({
+            "id": "99", "content": "x",
+            "reason": "测试", "origin_content": "不存在",
+        })
         assert "错误" in result
 
-    def test_delete_memory_success(self):
+    def test_delete_memory_success(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
         narrative._current_entries = {"1": "删除我"}
-        result = narrative.delete_memory.invoke({"id": "1"})
+        result = narrative.delete_memory.invoke({
+            "id": "1", "reason": "信息已过时", "origin_content": "删除我",
+        })
         assert "已删除 [1]" in result
         assert "1" not in narrative._current_entries
 
-    def test_delete_memory_not_found(self):
-        result = narrative.delete_memory.invoke({"id": "99"})
+    def test_delete_memory_not_found(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
+        result = narrative.delete_memory.invoke({
+            "id": "99", "reason": "测试", "origin_content": "不存在",
+        })
         assert "错误" in result
+
+    # ── 日志测试 ──────────────────────────────────────────────
+
+    def test_log_created_on_create(self, monkeypatch, tmp_path):
+        log_path = tmp_path / "ops.yaml"
+        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
+        narrative.create_memory.invoke({"content": "用户叫Miso。"})
+        assert log_path.exists()
+        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
+        assert len(data) == 1
+        assert data[0]["operation"] == "create_memory"
+        assert data[0]["params"]["content"] == "用户叫Miso。"
+        assert "id" not in data[0]["params"]
+
+    def test_log_created_on_update(self, monkeypatch, tmp_path):
+        log_path = tmp_path / "ops.yaml"
+        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
+        narrative._current_entries = {"1": "旧内容"}
+        narrative.update_memory.invoke({
+            "id": "1", "content": "新内容",
+            "reason": "信息过时", "origin_content": "旧内容",
+        })
+        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
+        assert len(data) == 1
+        assert data[0]["operation"] == "update_memory"
+        assert data[0]["params"]["content"] == "新内容"
+        assert data[0]["params"]["reason"] == "信息过时"
+        assert data[0]["params"]["origin_content"] == "旧内容"
+        assert "id" not in data[0]["params"]
+
+    def test_log_created_on_delete(self, monkeypatch, tmp_path):
+        log_path = tmp_path / "ops.yaml"
+        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
+        narrative._current_entries = {"1": "删除我"}
+        narrative.delete_memory.invoke({
+            "id": "1", "reason": "已过时", "origin_content": "删除我",
+        })
+        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
+        assert len(data) == 1
+        assert data[0]["operation"] == "delete_memory"
+        assert data[0]["params"]["reason"] == "已过时"
+        assert data[0]["params"]["origin_content"] == "删除我"
+        assert "id" not in data[0]["params"]
+
+    def test_log_not_created_on_error(self, monkeypatch, tmp_path):
+        log_path = tmp_path / "ops.yaml"
+        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
+        narrative.update_memory.invoke({
+            "id": "99", "content": "x",
+            "reason": "测试", "origin_content": "不存在",
+        })
+        assert not log_path.exists()
+
+    def test_log_appends_multiple_entries(self, monkeypatch, tmp_path):
+        log_path = tmp_path / "ops.yaml"
+        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
+        narrative.create_memory.invoke({"content": "第一条。"})
+        narrative._current_entries["1"] = "第一条。"
+        narrative.update_memory.invoke({
+            "id": "1", "content": "第一条已改。",
+            "reason": "修正", "origin_content": "第一条。",
+        })
+        narrative.delete_memory.invoke({
+            "id": "1", "reason": "不再需要", "origin_content": "第一条已改。",
+        })
+        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
+        assert len(data) == 3
+        assert data[0]["operation"] == "create_memory"
+        assert data[1]["operation"] == "update_memory"
+        assert data[2]["operation"] == "delete_memory"
 
 
 # ── TestGetNarrative ──────────────────────────────────────────

--- a/tests/test_memory/test_narrative.py
+++ b/tests/test_memory/test_narrative.py
@@ -10,6 +10,32 @@ import memory.narrative as narrative
 from memory.narrative import LongTermMemoryInterface
 
 
+# ── 测试辅助 ──────────────────────────────────────────────────
+
+def _fake_agent_factory(entries_setup=None):
+    """构建 mock agent，其 ainvoke 会先执行 entries_setup 再返回。
+
+    entries_setup 用于在"Agent 调用工具"后模拟 _current_entries 的变化。
+    """
+    async def fake_ainvoke(_input, config=None):
+        if entries_setup:
+            entries_setup()
+        return {"messages": []}
+
+    agent = MagicMock()
+    agent.ainvoke = AsyncMock(side_effect=fake_ainvoke)
+    return agent
+
+
+def _assert_file_contains(path: Path, text: str):
+    """断言 MEMORY.md 文件包含指定文本。"""
+    content = path.read_text(encoding="utf-8")
+    assert text in content, f"文件中未找到 '{text}'，实际内容: {content}"
+
+
+# ── TestFormatMessages ────────────────────────────────────────
+
+
 class TestFormatMessages:
     """_format_messages 单元测试。"""
 
@@ -54,6 +80,102 @@ class TestFormatMessages:
         assert result == "[user]: 42"
 
 
+# ── TestParseSerialize ────────────────────────────────────────
+
+
+class TestParseSerialize:
+    """_parse_memory / _serialize_memory 单元测试。"""
+
+    def test_parse_empty(self):
+        entries, next_id = narrative._parse_memory("")
+        assert entries == {}
+        assert next_id == 1
+
+    def test_parse_single_entry(self):
+        entries, next_id = narrative._parse_memory("- 用户叫Miso。")
+        assert entries == {"1": "用户叫Miso。"}
+        assert next_id == 2
+
+    def test_parse_multiple_entries(self):
+        content = "- 第一条。\n- 第二条。\n- 第三条。"
+        entries, next_id = narrative._parse_memory(content)
+        assert entries == {"1": "第一条。", "2": "第二条。", "3": "第三条。"}
+        assert next_id == 4
+
+    def test_parse_skips_non_dash_lines(self):
+        content = "前言\n- 条目A\n空行\n- 条目B"
+        entries, next_id = narrative._parse_memory(content)
+        assert entries == {"1": "条目A", "2": "条目B"}
+        assert next_id == 3
+
+    def test_serialize_empty(self):
+        result = narrative._serialize_memory({})
+        assert result == "\n"
+
+    def test_serialize_with_entries(self):
+        entries = {"1": "A", "2": "B"}
+        result = narrative._serialize_memory(entries)
+        assert result == "- A\n- B\n"
+
+    def test_roundtrip(self):
+        """序列化后解析应得到相同条目。"""
+        original = "- 事实1。\n- 事实2。\n"
+        entries, _ = narrative._parse_memory(original)
+        serialized = narrative._serialize_memory(entries)
+        entries2, _ = narrative._parse_memory(serialized)
+        assert entries == entries2
+
+
+# ── TestCrudTools ──────────────────────────────────────────────
+
+
+class TestCrudTools:
+    """CRUD 工具函数单元测试。"""
+
+    def setup_method(self):
+        narrative._current_entries = {}
+        narrative._next_id = 1
+
+    def test_create_memory(self):
+        result = narrative.create_memory.invoke({"content": "用户叫Miso。"})
+        assert "已创建 [1]" in result
+        assert narrative._current_entries["1"] == "用户叫Miso。"
+        assert narrative._next_id == 2
+
+    def test_read_memories_empty(self):
+        result = narrative.read_memories.invoke({})
+        assert "暂无记忆条目" in result
+
+    def test_read_memories_with_entries(self):
+        narrative._current_entries = {"1": "A", "2": "B"}
+        result = narrative.read_memories.invoke({})
+        assert "[1] A" in result
+        assert "[2] B" in result
+
+    def test_update_memory_success(self):
+        narrative._current_entries = {"1": "旧内容"}
+        result = narrative.update_memory.invoke({"id": "1", "content": "新内容"})
+        assert "已更新 [1]" in result
+        assert narrative._current_entries["1"] == "新内容"
+
+    def test_update_memory_not_found(self):
+        result = narrative.update_memory.invoke({"id": "99", "content": "x"})
+        assert "错误" in result
+
+    def test_delete_memory_success(self):
+        narrative._current_entries = {"1": "删除我"}
+        result = narrative.delete_memory.invoke({"id": "1"})
+        assert "已删除 [1]" in result
+        assert "1" not in narrative._current_entries
+
+    def test_delete_memory_not_found(self):
+        result = narrative.delete_memory.invoke({"id": "99"})
+        assert "错误" in result
+
+
+# ── TestGetNarrative ──────────────────────────────────────────
+
+
 class TestGetNarrative:
     """模块级 get_narrative 向后兼容测试。"""
 
@@ -75,8 +197,21 @@ class TestGetNarrative:
         assert narrative.get_narrative() == ""
 
 
+# ── TestLongTermMemoryInterface ────────────────────────────────
+
+
 class TestLongTermMemoryInterface:
     """LongTermMemoryInterface 异步单元测试。"""
+
+    def setup_method(self):
+        """每个测试前重置模块级状态。"""
+        narrative._current_entries = {}
+        narrative._next_id = 1
+
+    def teardown_method(self):
+        """每个测试后清理模块级状态。"""
+        narrative._current_entries = {}
+        narrative._next_id = 1
 
     # ── get_narrative（实例方法） ──────────────────────────────
 
@@ -106,172 +241,219 @@ class TestLongTermMemoryInterface:
         await ltm.send_history([{"role": "user", "content": "你好"}])
 
     @pytest.mark.asyncio
-    async def test_send_history_after_stop_is_noop(self, tmp_path):
+    async def test_send_history_after_stop_is_noop(self, tmp_path, monkeypatch):
         """stop_listening 后 send_history 应无操作。"""
         path = tmp_path / "MEMORY.md"
-        llm = MagicMock()
-        llm.ainvoke = AsyncMock(return_value=MagicMock(content="记忆。"))
+
+        fake_agent = _fake_agent_factory()
+        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(llm)
+        ltm.start_listening(MagicMock())  # llm 不再被直接调用
         await ltm.send_history([{"role": "user", "content": "msg1"}])
         await ltm.stop_listening()
         await ltm.send_history([{"role": "user", "content": "msg2"}])
 
-        assert llm.ainvoke.call_count == 1
+        assert fake_agent.ainvoke.call_count == 1
 
     # ── 空消息过滤 ────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_empty_messages_not_enqueued(self, tmp_path):
-        """空消息不放入队列，LLM 不被调用。"""
+    async def test_empty_messages_not_enqueued(self, tmp_path, monkeypatch):
+        """空消息不放入队列，Agent 不被调用。"""
         path = tmp_path / "MEMORY.md"
-        llm = MagicMock()
-        llm.ainvoke = AsyncMock()
+
+        fake_agent = _fake_agent_factory()
+        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(llm)
+        ltm.start_listening(MagicMock())
         await ltm.send_history([])
         await ltm.stop_listening()
 
-        llm.ainvoke.assert_not_called()
+        fake_agent.ainvoke.assert_not_called()
 
     # ── 冷启动 ────────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_cold_start_generates_file(self, tmp_path):
-        """冷启动：MEMORY.md 不存在时从零生成。"""
+    async def test_cold_start_generates_file(self, tmp_path, monkeypatch):
+        """冷启动：MEMORY.md 不存在时 Agent 从零创建条目。"""
         path = tmp_path / "MEMORY.md"
-        llm = MagicMock()
-        llm.ainvoke = AsyncMock(return_value=MagicMock(content="Miso 是一名学生。"))
+
+        def agent_populates_entries():
+            narrative._current_entries["1"] = "Miso 是一名学生。"
+
+        fake_agent = _fake_agent_factory(entries_setup=agent_populates_entries)
+        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(llm)
+        ltm.start_listening(MagicMock())
         await ltm.send_history([{"role": "user", "content": "我叫Miso"}])
         await ltm.stop_listening()
 
         assert path.exists()
-        assert "Miso" in path.read_text(encoding="utf-8")
+        _assert_file_contains(path, "Miso 是一名学生。")
 
     @pytest.mark.asyncio
-    async def test_cold_start_uses_correct_prompt(self, tmp_path):
-        """冷启动时 LLM 收到裸消息（不带旧叙事）。"""
+    async def test_cold_start_uses_correct_prompt(self, tmp_path, monkeypatch):
+        """冷启动时 Agent 收到 COLD_START_SYSTEM。"""
         path = tmp_path / "MEMORY.md"
-        llm = MagicMock()
-        llm.ainvoke = AsyncMock(return_value=MagicMock(content="OK"))
+
+        captured_prompt = []
+        def capture_agent(**kwargs):
+            captured_prompt.append(kwargs.get("prompt", ""))
+            return _fake_agent_factory()
+
+        monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(llm)
+        ltm.start_listening(MagicMock())
         await ltm.send_history([{"role": "user", "content": "你好"}])
         await ltm.stop_listening()
 
-        call_args = llm.ainvoke.call_args[0][0]
-        system_msg = call_args[0].content
-        user_msg = call_args[1].content
-
-        assert "记忆叙事师" in system_msg
-        assert "[user]: 你好" in user_msg
-        assert "当前记忆" not in user_msg
+        assert len(captured_prompt) == 1
+        assert "记忆叙事师" in captured_prompt[0]
+        assert "冷启动" in captured_prompt[0]
 
     # ── 常态更新 ──────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_normal_update_preserves_old_narrative(self, tmp_path):
-        """常态更新：LLM 收到旧叙事 + 新消息。"""
+    async def test_normal_update_preserves_old_narrative(self, tmp_path, monkeypatch):
+        """常态更新：已有 MEMORY.md 被传入 Agent，Agent 修改后保存。"""
         path = tmp_path / "MEMORY.md"
-        path.write_text("旧记忆内容。", encoding="utf-8")
+        path.write_text("- 旧记忆。\n", encoding="utf-8")
 
-        llm = MagicMock()
-        llm.ainvoke = AsyncMock(return_value=MagicMock(content="更新后的记忆。"))
+        captured_prompt = []
+        def capture_agent(**kwargs):
+            captured_prompt.append(kwargs.get("prompt", ""))
+            # 模拟 Agent 更新了一条记忆
+            def update_entries():
+                narrative._current_entries["1"] = "更新后的记忆内容。"
+            return _fake_agent_factory(entries_setup=update_entries)
+
+        monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(llm)
+        ltm.start_listening(MagicMock())
         await ltm.send_history([{"role": "user", "content": "新消息"}])
         await ltm.stop_listening()
 
-        call_args = llm.ainvoke.call_args[0][0]
-        user_msg = call_args[1].content
-
-        assert "旧记忆内容" in user_msg
-        assert "当前记忆" in user_msg
-        assert "新消息" in user_msg
-        assert "新一轮对话" in user_msg
-        assert "更新后的记忆" in path.read_text(encoding="utf-8")
+        assert len(captured_prompt) == 1
+        assert "记忆叙事师" in captured_prompt[0]
+        _assert_file_contains(path, "更新后的记忆内容。")
 
     # ── 多轮累积 ──────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_multiple_turns_accumulate(self, tmp_path):
+    async def test_multiple_turns_accumulate(self, tmp_path, monkeypatch):
         """多轮对话后叙事内容累积。"""
         path = tmp_path / "MEMORY.md"
-        llm = MagicMock()
+
+        captured_prompts = []
+        call_count = [0]
+
+        def capture_agent(**kwargs):
+            captured_prompts.append(kwargs.get("prompt", ""))
+            call_count[0] += 1
+            if call_count[0] == 1:
+                def setup1():
+                    narrative._current_entries["1"] = "第一轮记忆。"
+                return _fake_agent_factory(entries_setup=setup1)
+            else:
+                def setup2():
+                    narrative._current_entries["1"] = "第一轮记忆。"
+                    narrative._current_entries["2"] = "第二轮补充。"
+                return _fake_agent_factory(entries_setup=setup2)
+
+        monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(llm)
+        ltm.start_listening(MagicMock())
 
-        llm.ainvoke = AsyncMock(return_value=MagicMock(content="第一轮记忆。"))
         await ltm.send_history([{"role": "user", "content": "我叫Miso"}])
+        # 等待第一轮完成——因为 consumer 是后台协程，send_history 是非阻塞的
+        await asyncio.sleep(0.05)
 
-        llm.ainvoke = AsyncMock(return_value=MagicMock(content="第一轮记忆。第二轮补充。"))
         await ltm.send_history([{"role": "user", "content": "我住北京"}])
-
         await ltm.stop_listening()
 
-        call_args = llm.ainvoke.call_args[0][0]
-        user_msg = call_args[1].content
-        assert "第一轮记忆" in user_msg
-        assert "我住北京" in user_msg
-
-        assert "第二轮补充" in path.read_text(encoding="utf-8")
+        assert call_count[0] == 2
+        _assert_file_contains(path, "第二轮补充")
 
     # ── 错误处理 ──────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_llm_error_is_silent(self, tmp_path):
-        """LLM 调用失败时不抛异常，不写文件。"""
+    async def test_agent_error_is_silent(self, tmp_path, monkeypatch):
+        """Agent 调用失败时不抛异常，不写文件。"""
         path = tmp_path / "MEMORY.md"
-        llm = MagicMock()
-        llm.ainvoke = AsyncMock(side_effect=RuntimeError("API 错误"))
+
+        async def failing_ainvoke(_input):
+            raise RuntimeError("API 错误")
+
+        fake_agent = MagicMock()
+        fake_agent.ainvoke = AsyncMock(side_effect=failing_ainvoke)
+        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(llm)
+        ltm.start_listening(MagicMock())
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
 
         assert not path.exists()
 
     @pytest.mark.asyncio
-    async def test_llm_returns_empty_content_preserves_original(self, tmp_path):
-        """LLM 返回空内容时不覆盖文件。"""
+    async def test_agent_produces_no_entries_preserves_original(self, tmp_path, monkeypatch):
+        """Agent 未创建条目（_current_entries 为空）时不覆盖文件。"""
         path = tmp_path / "MEMORY.md"
-        original = "原始记忆。"
-        path.write_text(original, encoding="utf-8")
 
-        llm = MagicMock()
-        llm.ainvoke = AsyncMock(return_value=MagicMock(content="   "))
+        # 无 entries_setup → _current_entries 保持为空
+        fake_agent = _fake_agent_factory()
+        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(llm)
+        ltm.start_listening(MagicMock())
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
 
-        assert path.read_text(encoding="utf-8") == original
+        # 冷启动 + 空条目 → 不写文件
+        assert not path.exists()
+
+    @pytest.mark.asyncio
+    async def test_agent_keeps_entries_unchanged_on_update(self, tmp_path, monkeypatch):
+        """更新模式下 Agent 不改动条目，原内容被保留（幂等重写）。"""
+        path = tmp_path / "MEMORY.md"
+        original = "- 原始记忆。\n"
+        path.write_text(original, encoding="utf-8")
+
+        # 无 entries_setup → parse 出的条目保持不变
+        fake_agent = _fake_agent_factory()
+        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
+
+        ltm = LongTermMemoryInterface(path)
+        ltm.start_listening(MagicMock())
+        await ltm.send_history([{"role": "user", "content": "测试"}])
+        await ltm.stop_listening()
+
+        _assert_file_contains(path, "原始记忆。")
 
     # ── 哨兵机制 ──────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_sentinel_stops_consumer(self, tmp_path):
+    async def test_sentinel_stops_consumer(self, tmp_path, monkeypatch):
         """None 哨兵正确停止消费者，且所有入队消息均被处理。"""
         path = tmp_path / "MEMORY.md"
-        llm = MagicMock()
-        llm.ainvoke = AsyncMock(return_value=MagicMock(content="记忆。"))
+
+        fake_agent = _fake_agent_factory(
+            entries_setup=lambda: narrative._current_entries.update({"1": "记忆。"})
+        )
+        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(llm)
+        ltm.start_listening(MagicMock())
         await ltm.send_history([{"role": "user", "content": "msg1"}])
         await ltm.send_history([{"role": "user", "content": "msg2"}])
         await ltm.stop_listening()
 
-        assert llm.ainvoke.call_count == 2
+        assert fake_agent.ainvoke.call_count == 2
         assert ltm._consumer_task is None
         assert ltm._queue is None

--- a/tests/test_memory/test_narrative_integration.py
+++ b/tests/test_memory/test_narrative_integration.py
@@ -1,6 +1,6 @@
 """LongTermMemoryInterface 集成测试 — 模拟 CLI 完整流程。
 
-验证: 对话历史 → LLM 摘要生成 → MEMORY.md 写入 的端到端路径。
+验证: 对话历史 → CRUD Agent → MEMORY.md 写入 的端到端路径。
 """
 
 import asyncio
@@ -8,50 +8,66 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import memory.narrative as narrative
 from memory.narrative import LongTermMemoryInterface
 
 
+def _make_fake_agent(entries_setup=None):
+    """构建 mock agent，ainvoke 时执行 entries_setup 修改 _current_entries。"""
+    async def fake_ainvoke(_input, config=None):
+        if entries_setup:
+            entries_setup()
+        return {"messages": []}
+
+    agent = MagicMock()
+    agent.ainvoke = AsyncMock(side_effect=fake_ainvoke)
+    return agent
+
+
 @pytest.mark.asyncio
-async def test_full_pipeline_cold_start_to_update(tmp_path):
+async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
     """模拟 CLI 完整多轮对话流程。
 
-    1. 用户发送消息 → Agent 回复 → turn_messages 入队
-    2. 后台消费者调用 LLM 生成摘要 → 写入 MEMORY.md
-    3. 下一轮读取到更新后的叙述
+    1. 用户发送消息 → turn_messages 入队
+    2. 后台 Agent 调用 CRUD 工具 → 修改 _current_entries
+    3. _consumer 序列化并写入 MEMORY.md
+    4. 下一轮读取到更新后的记忆
     """
     path = tmp_path / "MEMORY.md"
 
-    # ── 模拟 ChatOpenAI ──────────────────────────────
-    llm = MagicMock()
-    call_counter = [0]
-    received_prompts = []
+    call_count = [0]
+    captured_prompts = []
 
-    async def fake_ainvoke(messages):
-        call_counter[0] += 1
-        received_prompts.append(messages)
-        resp = MagicMock()
-        if call_counter[0] == 1:
-            resp.content = "第1轮记忆：用户打了招呼。"
-        elif call_counter[0] == 2:
-            resp.content = "第1轮记忆：用户打了招呼。\n第2轮补充：用户叫Miso，在北京学习网络安全。"
+    def agent_factory(**kwargs):
+        call_count[0] += 1
+        captured_prompts.append(kwargs.get("prompt", ""))
+
+        if call_count[0] == 1:
+            def setup1():
+                narrative._current_entries["1"] = "第1轮记忆：用户打了招呼。"
+            return _make_fake_agent(entries_setup=setup1)
+        elif call_count[0] == 2:
+            def setup2():
+                narrative._current_entries["1"] = "第1轮记忆：用户打了招呼。"
+                narrative._current_entries["2"] = "第2轮补充：用户叫Miso，在北京学习网络安全。"
+            return _make_fake_agent(entries_setup=setup2)
         else:
-            resp.content = f"第{call_counter[0]}轮记忆：已更新。"
-        return resp
+            def setup3():
+                narrative._current_entries["1"] = f"第{call_count[0]}轮记忆：已更新。"
+            return _make_fake_agent(entries_setup=setup3)
 
-    llm.ainvoke = AsyncMock(side_effect=fake_ainvoke)
+    monkeypatch.setattr(narrative, "create_react_agent", agent_factory)
 
-    # ── 初始化管线（对应 CLI.__init__ + run 开头） ──
+    # ── 初始化管线 ──
     ltm = LongTermMemoryInterface(path)
-    ltm.start_listening(llm)
+    ltm.start_listening(MagicMock())
 
-    # ── 第一轮对话（对应 CLI 中一次 send_history 调用） ──
+    # ── 第一轮对话 ──
     turn1 = [
         {"role": "user", "content": "你好，我想介绍一下自己"},
         {"role": "assistant", "content": "你好！请说，我在听。"},
     ]
     await ltm.send_history(turn1)
-
-    # 给后台消费者一点时间处理（实际场景中无需等待，这里是为了稳定断言顺序）
     await asyncio.sleep(0.05)
 
     # ── 第二轮对话 ──
@@ -61,7 +77,6 @@ async def test_full_pipeline_cold_start_to_update(tmp_path):
         {"role": "assistant", "content": "好的Miso，我记住了！"},
     ]
     await ltm.send_history(turn2)
-
     await asyncio.sleep(0.05)
 
     # ── 第三轮对话 ──
@@ -71,52 +86,44 @@ async def test_full_pipeline_cold_start_to_update(tmp_path):
     ]
     await ltm.send_history(turn3)
 
-    # ── 停止管线（对应 CLI 中 finally: stop_listening） ──
+    # ── 停止管线 ──
     await ltm.stop_listening()
 
-    # ── 验证 ─────────────────────────────────────────
+    # ── 验证 ──
 
-    # 1. LLM 被调用了 3 次
-    assert llm.ainvoke.call_count == 3
+    # 1. Agent 被创建了 3 次
+    assert call_count[0] == 3
 
     # 2. MEMORY.md 存在且包含最后一次写入的内容
     assert path.exists()
     final_content = path.read_text(encoding="utf-8")
     assert "第3轮记忆" in final_content
 
-    # 3. 第二轮调用收到了第一轮的记忆（叙事传递链路）
-    second_call_msgs = llm.ainvoke.call_args_list[1][0][0]
-    second_user_msg = second_call_msgs[1].content
-    assert "第1轮记忆" in second_user_msg
-    assert "Miso" in second_user_msg
+    # 3. 第二轮用了 UPDATE_SYSTEM（已有 MEMORY.md）
+    assert "记忆叙事师" in captured_prompts[1]
 
-    # 4. 第三轮调用收到了第二轮的记忆（累积效果）
-    third_call_msgs = llm.ainvoke.call_args_list[2][0][0]
-    third_user_msg = third_call_msgs[1].content
-    assert "第2轮补充" in third_user_msg
-    assert "网络安全" in third_user_msg
-
-    # 5. 消费者已完全停止
+    # 4. 消费者已完全停止
     assert ltm._consumer_task is None
     assert ltm._queue is None
 
 
 @pytest.mark.asyncio
-async def test_pipeline_handles_concurrent_sends(tmp_path):
+async def test_pipeline_handles_concurrent_sends(tmp_path, monkeypatch):
     """验证多轮消息快速连续入队时不会丢失。"""
     path = tmp_path / "MEMORY.md"
 
-    llm = MagicMock()
-    processed = []
+    processed_count = [0]
 
-    async def fake_ainvoke(messages):
-        processed.append(messages)
-        return MagicMock(content="记忆。")
+    def agent_factory(**kwargs):
+        def setup():
+            processed_count[0] += 1
+            narrative._current_entries[str(processed_count[0])] = f"记忆{processed_count[0]}。"
+        return _make_fake_agent(entries_setup=setup)
 
-    llm.ainvoke = AsyncMock(side_effect=fake_ainvoke)
+    monkeypatch.setattr(narrative, "create_react_agent", agent_factory)
 
     ltm = LongTermMemoryInterface(path)
-    ltm.start_listening(llm)
+    ltm.start_listening(MagicMock())
 
     # 快速连续投放 5 轮对话
     for i in range(5):
@@ -127,25 +134,28 @@ async def test_pipeline_handles_concurrent_sends(tmp_path):
 
     await ltm.stop_listening()
 
-    assert len(processed) == 5
-    assert path.read_text(encoding="utf-8") == "记忆。\n"
+    assert processed_count[0] == 5
+    content = path.read_text(encoding="utf-8")
+    for i in range(1, 6):
+        assert f"记忆{i}" in content
 
 
 @pytest.mark.asyncio
-async def test_send_history_is_non_blocking(tmp_path):
+async def test_send_history_is_non_blocking(tmp_path, monkeypatch):
     """验证 send_history 不等待消费者完成，瞬时返回。"""
     path = tmp_path / "MEMORY.md"
 
-    llm = MagicMock()
-
-    async def slow_ainvoke(messages):
+    async def slow_ainvoke(_input, config=None):
         await asyncio.sleep(0.1)
-        return MagicMock(content="慢慢来。")
+        narrative._current_entries["1"] = "慢慢来。"
+        return {"messages": []}
 
-    llm.ainvoke = AsyncMock(side_effect=slow_ainvoke)
+    fake_agent = MagicMock()
+    fake_agent.ainvoke = AsyncMock(side_effect=slow_ainvoke)
+    monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
     ltm = LongTermMemoryInterface(path)
-    ltm.start_listening(llm)
+    ltm.start_listening(MagicMock())
 
     import time
     start = time.monotonic()
@@ -157,4 +167,4 @@ async def test_send_history_is_non_blocking(tmp_path):
     assert elapsed < 0.05
 
     await ltm.stop_listening()
-    assert llm.ainvoke.call_count == 3
+    assert fake_agent.ainvoke.call_count == 3

--- a/tests/test_memory/test_narrative_integration.py
+++ b/tests/test_memory/test_narrative_integration.py
@@ -44,16 +44,16 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
 
         if call_count[0] == 1:
             def setup1():
-                narrative._current_entries["1"] = "第1轮记忆：用户打了招呼。"
+                narrative.MemoryStore().entries["1"] = "第1轮记忆：用户打了招呼。"
             return _make_fake_agent(entries_setup=setup1)
         elif call_count[0] == 2:
             def setup2():
-                narrative._current_entries["1"] = "第1轮记忆：用户打了招呼。"
-                narrative._current_entries["2"] = "第2轮补充：用户叫Miso，在北京学习网络安全。"
+                narrative.MemoryStore().entries["1"] = "第1轮记忆：用户打了招呼。"
+                narrative.MemoryStore().entries["2"] = "第2轮补充：用户叫Miso，在北京学习网络安全。"
             return _make_fake_agent(entries_setup=setup2)
         else:
             def setup3():
-                narrative._current_entries["1"] = f"第{call_count[0]}轮记忆：已更新。"
+                narrative.MemoryStore().entries["1"] = f"第{call_count[0]}轮记忆：已更新。"
             return _make_fake_agent(entries_setup=setup3)
 
     monkeypatch.setattr(narrative, "create_react_agent", agent_factory)
@@ -117,7 +117,7 @@ async def test_pipeline_handles_concurrent_sends(tmp_path, monkeypatch):
     def agent_factory(**kwargs):
         def setup():
             processed_count[0] += 1
-            narrative._current_entries[str(processed_count[0])] = f"记忆{processed_count[0]}。"
+            narrative.MemoryStore().entries[str(processed_count[0])] = f"记忆{processed_count[0]}。"
         return _make_fake_agent(entries_setup=setup)
 
     monkeypatch.setattr(narrative, "create_react_agent", agent_factory)
@@ -147,7 +147,7 @@ async def test_send_history_is_non_blocking(tmp_path, monkeypatch):
 
     async def slow_ainvoke(_input, config=None):
         await asyncio.sleep(0.1)
-        narrative._current_entries["1"] = "慢慢来。"
+        narrative.MemoryStore().entries["1"] = "慢慢来。"
         return {"messages": []}
 
     fake_agent = MagicMock()


### PR DESCRIPTION
## Summary
- 将长时记忆更新从 LLM 直调改为 CRUD Agent，增强记忆操作的结构化与可控性
- 为 CRUD 工具添加 YAML 操作日志，便于追踪和审计记忆变更
- 将散落函数归类为 MemoryStore 等独立类，提升代码组织性

## Test plan
- [x] 验证记忆 CRUD 操作正常
- [x] 确认 YAML 操作日志正确记录
- [x] 检查 MemoryStore 重构无回归