### PR TITLE
fix(deps): 补全 filelock 依赖声明

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "langgraph>=0.2.0",
     "pydantic-settings>=2.0.0",
     "colorama>=0.4.0",
+    "filelock>=3.13.0",
     "todoist-api-python>=2.0.0",
     "uapi-sdk-python>=0.1.17",
     "python-dotenv>=1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ langchain-openai>=0.3.0
 langgraph>=0.2.0
 pydantic-settings>=2.0.0
 colorama>=0.4.0
+filelock>=3.13.0
 todoist-api-python>=2.0.0
 uapi-sdk-python>=0.1.17
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary
- `memory/narrative.py` 直接导入 `filelock`，但未在 `pyproject.toml` / `requirements.txt` 中声明
- 在新 venv 中 `filelock` 仅作为传递依赖存在，`pip install -e .` 后直接运行会报 `ModuleNotFoundError`

## Fix
- `pyproject.toml` 和 `requirements.txt` 中补全 `filelock>=3.13.0`

## Test plan
- [x] 67/67 tests pass