### PR TITLE
feat(api): 添加上下文窗口用量 API 与 WebUI 指示器

### DIFF
--- a/api/context_usage.py
+++ b/api/context_usage.py
@@ -1,0 +1,48 @@
+"""上下文窗口用量估算 — 基于 tiktoken 的 token 计数工具。"""
+
+import tiktoken
+
+_ENCODING = None
+
+
+def _get_encoding():
+    global _ENCODING
+    if _ENCODING is None:
+        _ENCODING = tiktoken.get_encoding("cl100k_base")
+    return _ENCODING
+
+
+def count_tokens(text: str) -> int:
+    """返回文本的 token 数量估计值。"""
+    return len(_get_encoding().encode(text))
+
+
+def estimate_context_usage(
+    messages: list,
+    system_prompt: str,
+    max_tokens: int,
+    model_name: str = "",
+) -> dict:
+    """估算当前上下文占用的 token 数。
+
+    Args:
+        messages: LangChain 消息列表（含 role + content）
+        system_prompt: 系统提示词全文
+        max_tokens: 模型上下文窗口上限
+        model_name: 模型名称
+
+    Returns:
+        {"current_tokens": int, "max_tokens": int, "usage_percent": float, "model_name": str}
+    """
+    total = count_tokens(system_prompt)
+    for msg in messages:
+        content = msg.content if hasattr(msg, "content") else str(msg)
+        total += count_tokens(content) + 4  # ~4 tokens 消息格式化开销
+
+    usage_percent = round(total / max_tokens * 100, 1) if max_tokens else 0.0
+    return {
+        "current_tokens": total,
+        "max_tokens": max_tokens,
+        "usage_percent": usage_percent,
+        "model_name": model_name,
+    }

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -10,6 +10,8 @@ from langchain_core.messages import AIMessage, HumanMessage
 from agent.graph import build_agent
 from agent.prompts import build_enhanced_prompt
 from api.callbacks.websocket_callback import WebSocketCallback
+from api.context_usage import estimate_context_usage
+from config.settings import get_settings
 
 router = APIRouter()
 
@@ -22,6 +24,16 @@ async def websocket_chat(ws: WebSocket, session_id: str):
     sm = app_state.session_manager
     session = sm.get_or_create(session_id)
     ws_callback = WebSocketCallback(ws)
+
+    # 连接建立后立即推送初始上下文用量
+    settings = get_settings()
+    initial_usage = estimate_context_usage(
+        messages=[],
+        system_prompt=app_state.system_prompt,
+        max_tokens=settings.model_context_window,
+        model_name=settings.model_name,
+    )
+    await ws.send_json({"type": "context_usage", "payload": initial_usage})
 
     try:
         while True:
@@ -111,9 +123,19 @@ async def websocket_chat(ws: WebSocket, session_id: str):
                     })
                 finally:
                     session._active_task = None
+                    settings = get_settings()
+                    context_usage = estimate_context_usage(
+                        messages=session.short_term_memory.messages,
+                        system_prompt=enhanced_prompt,
+                        max_tokens=settings.model_context_window,
+                        model_name=settings.model_name,
+                    )
                     await ws.send_json({
                         "type": "done",
-                        "payload": {"turn_id": turn_id},
+                        "payload": {
+                            "turn_id": turn_id,
+                            "context_usage": context_usage,
+                        },
                     })
 
                 session.short_term_memory.add_message(

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -2,6 +2,9 @@
 
 from fastapi import APIRouter, HTTPException, Request
 
+from api.context_usage import estimate_context_usage
+from config.settings import get_settings
+
 router = APIRouter()
 
 
@@ -39,6 +42,24 @@ async def get_messages(session_id: str, request: Request):
         raise HTTPException(status_code=404, detail="Session not found")
     msgs = session.short_term_memory.messages
     return {"session_id": session_id, "messages": [{"role": m.type, "content": m.content} for m in msgs]}
+
+
+@router.get("/sessions/{session_id}/context-usage")
+async def get_context_usage(session_id: str, request: Request):
+    sm = request.app.state.session_manager
+    session = sm.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    settings = get_settings()
+    system_prompt = request.app.state.system_prompt
+    usage = estimate_context_usage(
+        messages=session.short_term_memory.messages,
+        system_prompt=system_prompt,
+        max_tokens=settings.model_context_window,
+        model_name=settings.model_name,
+    )
+    usage["session_id"] = session_id
+    return usage
 
 
 @router.delete("/sessions/{session_id}")

--- a/config/settings.py
+++ b/config/settings.py
@@ -23,6 +23,12 @@ class Settings(BaseSettings):
     qq_appid: str = ""
     qq_token: str = ""
 
+    # 模型上下文窗口大小（DeepSeek V4 Flash = 1M tokens）
+    model_context_window: int = 1000000
+
+    # 模型名称
+    model_name: str = "deepseek-v4-flash"
+
     model_config = {
         "env_file": ".env",
         "env_file_encoding": "utf-8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "qq-botpy>=1.0.0",
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.27.0",
+    "tiktoken>=0.7.0",
 ]
 
 [project.optional-dependencies]

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -3,6 +3,7 @@ import type {
   ListSessionsResponse,
   SessionInfo,
   NarrativeResponse,
+  ContextUsage,
 } from '@/types'
 
 const BASE = '/api'
@@ -33,4 +34,7 @@ export const api = {
 
   getNarrative: () =>
     request<NarrativeResponse>('/narrative'),
+
+  getContextUsage: (sessionId: string) =>
+    request<ContextUsage & { session_id: string }>(`/sessions/${sessionId}/context-usage`),
 }

--- a/web/src/components/ContextUsageBadge.vue
+++ b/web/src/components/ContextUsageBadge.vue
@@ -1,0 +1,90 @@
+<template>
+  <div v-if="usage" class="context-usage" :class="level">
+    <svg class="ring" viewBox="0 0 32 32">
+      <circle
+        class="ring-bg"
+        cx="16" cy="16" r="13"
+        fill="none"
+        stroke-width="3"
+      />
+      <circle
+        class="ring-fill"
+        cx="16" cy="16" r="13"
+        fill="none"
+        stroke-width="3"
+        stroke-linecap="round"
+        :stroke-dasharray="circumference"
+        :stroke-dashoffset="dashOffset"
+      />
+    </svg>
+    <span class="label">{{ Math.round(usage.usage_percent) }}%</span>
+    <span class="model-name">{{ usage.model_name }}</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ContextUsage } from '@/types'
+
+const props = defineProps<{ usage: ContextUsage | null }>()
+
+const circumference = 2 * Math.PI * 13
+
+const dashOffset = computed(() => {
+  if (!props.usage) return circumference
+  const pct = Math.min(props.usage.usage_percent, 100)
+  return circumference * (1 - pct / 100)
+})
+
+const level = computed(() => {
+  if (!props.usage) return ''
+  if (props.usage.usage_percent < 60) return 'safe'
+  if (props.usage.usage_percent < 85) return 'warn'
+  return 'danger'
+})
+</script>
+
+<style scoped>
+.context-usage {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.ring {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  transform: rotate(-90deg);
+}
+.ring-bg {
+  stroke: var(--border);
+}
+.ring-fill {
+  transition: stroke-dashoffset 0.5s ease, stroke 0.5s ease;
+}
+.safe .ring-fill {
+  stroke: #7ab87a;
+}
+.safe .label {
+  color: #7ab87a;
+}
+.warn .ring-fill {
+  stroke: #c9b44a;
+}
+.warn .label {
+  color: #c9b44a;
+}
+.danger .ring-fill {
+  stroke: #c97a7a;
+}
+.danger .label {
+  color: #c97a7a;
+}
+.model-name {
+  color: var(--text-secondary);
+  opacity: 1;
+}
+</style>

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -1,5 +1,5 @@
 import { ref, reactive, watch, onUnmounted, nextTick, type Ref } from 'vue'
-import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent } from '@/types'
+import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage } from '@/types'
 
 const TURNS_KEY_PREFIX = 'sonetto_turns_'
 
@@ -40,6 +40,7 @@ export function useChat(sessionId: Ref<string>) {
   const turns = reactive<ChatTurn[]>([])
   const currentTurn = ref<ChatTurn | null>(null)
   const error = ref<string | null>(null)
+  const contextUsage = ref<ContextUsage | null>(null)
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 
   function persistTurns() {
@@ -99,6 +100,12 @@ export function useChat(sessionId: Ref<string>) {
   }
 
   function handleEvent(event: ServerEvent) {
+    // context_usage 可以在无活跃轮次时接收（如连接初始化）
+    if (event.type === 'context_usage') {
+      contextUsage.value = event.payload
+      return
+    }
+
     const turn = currentTurn.value
     if (!turn) return
 
@@ -163,6 +170,9 @@ export function useChat(sessionId: Ref<string>) {
       }
 
       case 'done':
+        if (event.payload.context_usage) {
+          contextUsage.value = event.payload.context_usage
+        }
         if (currentTurn.value) {
           const lastThink = findLastThinking(currentTurn.value.events)
           if (lastThink?.becameAnswer) {
@@ -233,7 +243,7 @@ export function useChat(sessionId: Ref<string>) {
 
   onUnmounted(() => disconnect())
 
-  return { connected, isStreaming, turns, currentTurn, error, send, cancel, connect, disconnect }
+  return { connected, isStreaming, turns, currentTurn, error, contextUsage, send, cancel, connect, disconnect }
 }
 
 function findLastThinking(events: TurnEvent[]): ThinkingBlock | undefined {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -37,7 +37,7 @@ export interface AnswerEvent {
 
 export interface DoneEvent {
   type: 'done'
-  payload: { turn_id: string }
+  payload: { turn_id: string; context_usage?: ContextUsage }
 }
 
 export interface ErrorEvent {
@@ -48,6 +48,11 @@ export interface ErrorEvent {
 export interface PongEvent {
   type: 'pong'
   payload: Record<string, never>
+}
+
+export interface ContextUsageEvent {
+  type: 'context_usage'
+  payload: ContextUsage
 }
 
 export type ServerEvent =
@@ -61,6 +66,7 @@ export type ServerEvent =
   | DoneEvent
   | ErrorEvent
   | PongEvent
+  | ContextUsageEvent
 
 // === WebSocket 客户端 → 服务端消息 ===
 
@@ -128,4 +134,13 @@ export interface ListSessionsResponse {
 
 export interface NarrativeResponse {
   narrative: string
+}
+
+// === 上下文窗口用量 ===
+
+export interface ContextUsage {
+  current_tokens: number
+  max_tokens: number
+  usage_percent: number
+  model_name: string
 }

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -2,6 +2,7 @@
   <div class="chat-view">
     <header class="chat-header">
       <StatusBadge :connected="connected" />
+      <ContextUsageBadge :usage="contextUsage" />
     </header>
 
     <ChatWindow
@@ -23,11 +24,12 @@
 import { useSession } from '@/composables/useSession'
 import { useChat } from '@/composables/useChat'
 import StatusBadge from '@/components/StatusBadge.vue'
+import ContextUsageBadge from '@/components/ContextUsageBadge.vue'
 import ChatWindow from '@/components/ChatWindow.vue'
 import ChatInput from '@/components/ChatInput.vue'
 
 const { sessionId } = useSession()
-const { connected, isStreaming, turns, currentTurn, error, send, cancel } =
+const { connected, isStreaming, turns, currentTurn, error, contextUsage, send, cancel } =
   useChat(sessionId)
 </script>
 
@@ -41,6 +43,7 @@ const { connected, isStreaming, turns, currentTurn, error, send, cancel } =
 .chat-header {
   display: flex;
   align-items: center;
+  gap: 20px;
   padding: 12px 24px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-card);


### PR DESCRIPTION
## Summary
- 新增 `GET /api/sessions/{id}/context-usage` REST 端点，返回当前 token 用量、最大窗口、百分比和模型名
- WebSocket `done` 事件自动附带 `context_usage`，连接建立时立即推送初始 0% 状态
- 前端新增 `ContextUsageBadge` 组件：SVG 圆环进度指示器 + 百分比 + 模型名，绿/黄/红三色分级
- 配置新增 `model_context_window` 和 `model_name` 字段，可通过 `.env` 覆盖

## Test plan
- [x] 67 个后端测试全部通过
- [x] 前端 TypeScript 类型检查无错误
- [ ] 浏览器端：连接后立即显示 0% + 模型名，多轮对话后百分比上升