### PR TITLE
fix(skills): 修复网页抓取 greenlet 线程切换冲突

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "tiktoken>=0.7.0",
     "httpx>=0.23.0",
     "moviepy>=1.0.3",
+    "playwright>=1.40.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ beautifulsoup4>=4.12.0
 PyPDF2>=3.0.0
 python-docx>=1.1.0
 requests>=2.31.0
+playwright>=1.40.0
 qq-botpy>=1.0.0
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0

--- a/skills/network/SKILL.md
+++ b/skills/network/SKILL.md
@@ -5,7 +5,7 @@
 |-------|------|---------|
 | `get_current_weather` | 实时天气/预报/生活指数 | UAPI misc.get_misc_weather |
 | `smart_search` | 网络搜索 | UAPI zhi_neng_sou_suo.post_search_aggregate |
-| `scrape_webpage` | 网页内容抓取 | 直接 HTTP + BeautifulSoup |
+| `scrape_webpage` | 网页内容抓取 | Playwright 真实 Chromium 浏览器（有头模式） |
 | `holiday_calendar` | 节假日/万年历查询 | UAPI misc.get_misc_holiday_calendar |
 
 ## 技能协作流程
@@ -16,6 +16,6 @@
 ## 常见陷阱
 - **天气 city vs adcode**：传城市名时不要同时传 adcode，避免API混淆
 - **smart_search 的 fetch_full**：本 Skill 不支持 fetch_full 参数。如需全文，先用 smart_search 获取 URL 列表，再逐条调用 scrape_webpage
-- **scrape_webpage 超时**：部分网站反爬或加载慢，默认 10 秒超时
+- **scrape_webpage 人机验证**：使用有头 Chromium 浏览器，用户可在浏览器窗口中手动完成 CAPTCHA/Turnstile/登录等验证。默认有 5 秒额外等待时间，可通过 `wait_ms` 参数调整。导航超时 60 秒。
 - **holiday_calendar 参数互斥**：date / month / year 三选一，不要同时传多个
 - **天气 minutely 仅国内**：分钟级降水预报仅支持中国大陆城市

--- a/skills/network/browser_manager.py
+++ b/skills/network/browser_manager.py
@@ -1,0 +1,82 @@
+"""Shared Playwright browser manager — singleton, lazy-init, headed mode."""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserManager:
+    """模块级单例，管理 Playwright + Microsoft Edge 浏览器实例。
+
+    使用有头模式（headless=False），浏览器窗口对用户可见，
+    便于手动解决人机验证（CAPTCHA / Turnstile / 登录等）。
+
+    使用 async_api 避免与 uvicorn asyncio 事件循环的 greenlet 冲突。
+    """
+
+    _instance: "BrowserManager | None" = None
+    _playwright = None
+    _browser = None
+    _loop_id: int | None = None
+    _lock = asyncio.Lock()
+
+    def __new__(cls) -> "BrowserManager":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    async def _ensure_browser(self):
+        loop_id = id(asyncio.get_running_loop())
+        if self._browser is not None and self._loop_id != loop_id:
+            logger.info("事件循环已变更，重新创建浏览器实例")
+            await self._close_locked()
+        if self._browser is None:
+            from playwright.async_api import async_playwright
+
+            self._playwright = await async_playwright().start()
+            self._browser = await self._playwright.chromium.launch(
+                headless=False,
+                channel="msedge",
+            )
+            self._loop_id = loop_id
+            logger.info("Microsoft Edge 浏览器已启动（有头模式）")
+
+    async def get_browser(self):
+        async with self._lock:
+            await self._ensure_browser()
+            return self._browser
+
+    async def new_page(self):
+        """创建新页面，默认 1920x1080 视口。"""
+        browser = await self.get_browser()
+        context = await browser.new_context(
+            viewport={"width": 1920, "height": 1080},
+            user_agent=(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            ),
+        )
+        return await context.new_page()
+
+    async def _close_locked(self):
+        """关闭资源（需在持有 _lock 时调用）。"""
+        if self._browser:
+            await self._browser.close()
+            self._browser = None
+        if self._playwright:
+            await self._playwright.stop()
+            self._playwright = None
+        self._loop_id = None
+
+    async def close(self):
+        async with self._lock:
+            await self._close_locked()
+            BrowserManager._instance = None
+            logger.info("浏览器已关闭")
+
+
+def get_browser_manager() -> BrowserManager:
+    """获取全局 BrowserManager 单例。"""
+    return BrowserManager()

--- a/skills/network/skill_scraper.py
+++ b/skills/network/skill_scraper.py
@@ -1,76 +1,257 @@
-"""Skill: scrape_webpage — 网页内容抓取。"""
+"""Skill: scrape_webpage — 基于 Playwright 的网页内容抓取。
+
+使用真实 Chromium 浏览器（有头模式）抓取网页，用户可手动解决人机验证。
+提取内容远超标题+正文：元数据、Open Graph、JSON-LD、标题层级、链接、图片等。
+"""
+
+import asyncio
+import base64
+import json
+import logging
 
 from pydantic import BaseModel, Field
 
 from skills.base import SkillBase, format_error, format_success
+from skills.network.browser_manager import get_browser_manager
+
+logger = logging.getLogger(__name__)
 
 
 class ScraperInput(BaseModel):
     get_doc: bool = Field(default=False, description="设为 true 以获取使用说明和领域知识")
     url: str = Field(default="", description="目标网页 URL，须以 http:// 或 https:// 开头")
+    wait_ms: int = Field(
+        default=5000,
+        description="页面加载后额外等待毫秒数，给用户时间解决人机验证（默认 5000）",
+    )
+    screenshot: bool = Field(default=False, description="是否同时截取页面首屏截图（base64）")
+
+
+CONTENT_SELECTORS = [
+    "article",
+    "main",
+    '[role="main"]',
+    ".content",
+    "#content",
+    ".post",
+    ".article",
+    ".post-content",
+    ".article-content",
+]
+
+MAX_CONTENT_LENGTH = 50000
+MAX_LINKS = 200
+MAX_IMAGES = 100
+
+
+async def _extract_meta(page) -> dict:
+    """提取 <meta name/property> 标签。"""
+    meta = {}
+    for tag in await page.query_selector_all('meta[name], meta[property]'):
+        key = await tag.get_attribute("name") or await tag.get_attribute("property") or ""
+        content = await tag.get_attribute("content")
+        if key and content:
+            meta[key] = content
+    return meta
+
+
+async def _extract_open_graph(page) -> dict:
+    """提取 Open Graph 标签。"""
+    og = {}
+    for tag in await page.query_selector_all('meta[property^="og:"]'):
+        prop = await tag.get_attribute("property") or ""
+        content = await tag.get_attribute("content") or ""
+        if prop and content:
+            og[prop.replace("og:", "")] = content
+    return og
+
+
+async def _extract_twitter_card(page) -> dict:
+    """提取 Twitter Card 标签。"""
+    tc = {}
+    for tag in await page.query_selector_all('meta[name^="twitter:"]'):
+        name = await tag.get_attribute("name") or ""
+        content = await tag.get_attribute("content") or ""
+        if name and content:
+            tc[name.replace("twitter:", "")] = content
+    return tc
+
+
+async def _extract_jsonld(page) -> list[dict]:
+    """提取 JSON-LD 结构化数据。"""
+    items = []
+    for el in await page.query_selector_all('script[type="application/ld+json"]'):
+        try:
+            text = await el.inner_text()
+            if text.strip():
+                items.append(json.loads(text))
+        except (json.JSONDecodeError, Exception):
+            pass
+    return items
+
+
+async def _extract_headings(page) -> list[dict]:
+    """提取页面标题层级 (h1-h6)。"""
+    headings = []
+    for level in range(1, 7):
+        for el in await page.query_selector_all(f"h{level}"):
+            text = (await el.inner_text()).strip()
+            if text:
+                headings.append({"level": level, "text": text})
+    return headings
+
+
+async def _extract_links(page) -> list[dict]:
+    """提取页面链接，去重并过滤 javascript: 等。"""
+    links = []
+    seen: set[str] = set()
+    for el in await page.query_selector_all("a[href]"):
+        href = ((await el.get_attribute("href")) or "").strip()
+        if not href or href.startswith("javascript:") or href.startswith("#"):
+            continue
+        if href in seen:
+            continue
+        seen.add(href)
+        text = (await el.inner_text()).strip() or ""
+        links.append({"text": text, "href": href})
+        if len(links) >= MAX_LINKS:
+            break
+    return links
+
+
+async def _extract_images(page) -> list[dict]:
+    """提取页面图片。"""
+    images = []
+    for el in await page.query_selector_all("img[src]"):
+        src = (await el.get_attribute("src")) or ""
+        alt = (await el.get_attribute("alt")) or ""
+        if src and not src.startswith("data:"):
+            images.append({"src": src, "alt": alt})
+            if len(images) >= MAX_IMAGES:
+                break
+    return images
+
+
+async def _extract_content(page) -> str:
+    """提取正文 HTML，优先语义标签，保留链接等丰富结构。"""
+    for selector in CONTENT_SELECTORS:
+        el = await page.query_selector(selector)
+        if el:
+            html = await el.inner_html()
+            if len(html.strip()) > 100:
+                return html
+
+    html = await page.evaluate("""() => {
+        const body = document.body;
+        if (!body) return '';
+        const clone = body.cloneNode(true);
+        for (const sel of ['script', 'style']) {
+            for (const el of clone.querySelectorAll(sel)) {
+                el.remove();
+            }
+        }
+        return clone.innerHTML;
+    }""")
+    return html or ""
 
 
 class WebScraperSkill(SkillBase):
     name: str = "scrape_webpage"
     description: str = (
-        "抓取指定网页的标题和正文内容。适合全文阅读搜索结果中的页面。"
+        "使用真实 Microsoft Edge 浏览器抓取网页内容。"
+        "提取：标题、元数据、Open Graph、JSON-LD 结构化数据、标题层级、链接、图片、正文 HTML（保留链接等丰富结构）。"
+        "支持 JavaScript 渲染页面。有头模式，用户可手动解决人机验证。"
         "★ 首次使用先 get_doc=true。"
     )
     args_schema: type[BaseModel] = ScraperInput
 
-    def _run(self, get_doc: bool = False, url: str = "") -> str:
+    async def _arun(
+        self,
+        get_doc: bool = False,
+        url: str = "",
+        wait_ms: int = 5000,
+        screenshot: bool = False,
+    ) -> str:
         if get_doc:
             return self._load_doc()
         if not url:
             return format_error("url 不能为空")
 
         try:
-            from bs4 import BeautifulSoup
+            manager = get_browser_manager()
+            page = await manager.new_page()
 
-            headers = {
-                "User-Agent": (
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) "
-                    "Chrome/120.0.0.0 Safari/537.36"
-                )
+            await page.goto(url, wait_until="domcontentloaded", timeout=60000)
+            await page.wait_for_timeout(wait_ms)
+
+            result: dict = {
+                "url": page.url,
+                "title": await page.title(),
             }
-            resp = self.client._session.get(url, headers=headers, timeout=10)
-            resp.raise_for_status()
-            resp.encoding = resp.apparent_encoding
 
-            soup = BeautifulSoup(resp.text, "html.parser")
+            meta = await _extract_meta(page)
+            if meta:
+                result["meta"] = meta
 
-            title = soup.title.get_text(strip=True) if soup.title else ""
+            og = await _extract_open_graph(page)
+            if og:
+                result["open_graph"] = og
 
-            for element in soup(["script", "style", "nav", "header", "footer", "aside"]):
-                element.decompose()
+            tc = await _extract_twitter_card(page)
+            if tc:
+                result["twitter_card"] = tc
 
-            content = ""
-            for selector in [
-                "article", "main", ".content", "#content",
-                ".post-content", ".article-content",
-                'div[class*="content"]', 'div[id*="content"]',
-            ]:
-                el = soup.select_one(selector)
-                if el:
-                    content = el.get_text(separator="\n", strip=True)
-                    break
+            jsonld = await _extract_jsonld(page)
+            if jsonld:
+                result["structured_data"] = jsonld
 
-            if not content:
-                paragraphs = soup.find_all("p")
-                content = "\n".join(
-                    p.get_text(strip=True) for p in paragraphs if p.get_text(strip=True)
-                )
+            headings = await _extract_headings(page)
+            if headings:
+                result["headings"] = headings
 
-            if not content and soup.body:
-                content = soup.body.get_text(separator="\n", strip=True)
+            links = await _extract_links(page)
+            if links:
+                result["links"] = links
 
-            lines = [line.strip() for line in content.split("\n") if line.strip()]
-            content = "\n".join(lines)
+            images = await _extract_images(page)
+            if images:
+                result["images"] = images
 
-            if len(content) > 5000:
-                content = content[:5000] + "\n\n[内容已截断]"
+            content = await _extract_content(page)
+            if len(content) > MAX_CONTENT_LENGTH:
+                content = content[:MAX_CONTENT_LENGTH] + "\n\n<!-- 内容已截断 -->"
+            result["content"] = content
 
-            return format_success({"title": title, "content": content, "url": url})
+            if screenshot:
+                screenshot_bytes = await page.screenshot(full_page=False)
+                result["screenshot_base64"] = base64.b64encode(screenshot_bytes).decode()
+
+            return format_success(result)
+
         except Exception as e:
+            logger.exception("网页抓取失败: %s", url)
             return format_error(f"网页抓取失败: {e}")
+
+    def _run(
+        self,
+        get_doc: bool = False,
+        url: str = "",
+        wait_ms: int = 5000,
+        screenshot: bool = False,
+    ) -> str:
+        """同步包装，供 CLI 等同步调用方使用。"""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._arun(
+                get_doc=get_doc, url=url, wait_ms=wait_ms, screenshot=screenshot
+            ))
+
+        # 运行中的事件循环不可嵌套 — 用独立线程执行
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(
+                asyncio.run,
+                self._arun(get_doc=get_doc, url=url, wait_ms=wait_ms, screenshot=screenshot),
+            )
+            return future.result()


### PR DESCRIPTION
## Summary
- 将 Playwright 从 `sync_api` 迁移到 `async_api`，解决与 uvicorn asyncio 事件循环的 greenlet 线程切换冲突
- BrowserManager 增加事件循环 ID 检测，跨循环时自动重建浏览器实例，避免 Playwright 对象绑定到过期事件循环
- WebScraperSkill 核心逻辑移至 `_arun()`，`_run()` 仅作为 CLI 模式的同步回退

## Test plan
- [ ] WebSocket 模式下调用 `scrape_webpage` 不再报 greenlet 线程切换冲突
- [ ] CLI 模式 (`python main.py cli`) 下 `scrape_webpage` 正常工作
- [ ] 多次调用不复用过期的事件循环资源