### PR TITLE
feat(skills): 添加图片理解工具，集成 GLM-5V-Turbo

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -6,6 +6,9 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """全局配置，所有 API Key 从环境变量/.env 加载。"""
 
+    # ZhiPu AI (GLM-5V-Turbo 图片理解)
+    zhipuai_api_key: str = ""
+
     # DeepSeek
     deepseek_api_key: str = ""
     deepseek_base_url: str = "https://api.deepseek.com/v1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ PyPDF2>=3.0.0
 python-docx>=1.1.0
 requests>=2.31.0
 playwright>=1.40.0
+zai-sdk
 qq-botpy>=1.0.0
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0

--- a/skills/__init__.py
+++ b/skills/__init__.py
@@ -45,6 +45,7 @@ def get_all_skills() -> list[BaseTool]:
     from skills.network.skill_search import SmartSearchSkill
     from skills.network.skill_scraper import WebScraperSkill
     from skills.network.skill_holiday import HolidayCalendarSkill
+    from skills.network.skill_image_understand import ImageUnderstandSkill
 
     # Files
     from skills.files.skill_file_ops import FileOperationsSkill
@@ -95,6 +96,7 @@ def get_all_skills() -> list[BaseTool]:
         SmartSearchSkill(client=client),
         WebScraperSkill(client=client),
         HolidayCalendarSkill(client=client),
+        ImageUnderstandSkill(client=client),
         # Files
         FileOperationsSkill(client=client),
         PDFReaderSkill(client=client),

--- a/skills/network/SKILL.md
+++ b/skills/network/SKILL.md
@@ -7,6 +7,7 @@
 | `smart_search` | 网络搜索 | UAPI zhi_neng_sou_suo.post_search_aggregate |
 | `scrape_webpage` | 网页内容抓取 | Playwright 真实 Chromium 浏览器（有头模式） |
 | `holiday_calendar` | 节假日/万年历查询 | UAPI misc.get_misc_holiday_calendar |
+| `analyze_image` | 图片理解/OCR/描述 | GLM-5V-Turbo 多模态模型 |
 
 ## 技能协作流程
 - **天气 + 节假日**：用户问"国庆节北京天气如何"时，先调 `holiday_calendar` 确认日期，再调 `get_current_weather`
@@ -18,4 +19,5 @@
 - **smart_search 的 fetch_full**：本 Skill 不支持 fetch_full 参数。如需全文，先用 smart_search 获取 URL 列表，再逐条调用 scrape_webpage
 - **scrape_webpage 人机验证**：使用有头 Chromium 浏览器，用户可在浏览器窗口中手动完成 CAPTCHA/Turnstile/登录等验证。默认有 5 秒额外等待时间，可通过 `wait_ms` 参数调整。导航超时 60 秒。
 - **holiday_calendar 参数互斥**：date / month / year 三选一，不要同时传多个
+- **analyze_image 图片来源**：本地用 `local:绝对路径`，网络用 `url:https://...`。prompt 默认"请描述这张图片"，可自定义提问如"文字是啥？""这是什么物体？"
 - **天气 minutely 仅国内**：分钟级降水预报仅支持中国大陆城市

--- a/skills/network/skill_image_understand.py
+++ b/skills/network/skill_image_understand.py
@@ -1,0 +1,105 @@
+"""Skill: analyze_image — 图片理解（GLM-5V-Turbo）。"""
+
+import base64
+import mimetypes
+import re
+import urllib.parse
+from pathlib import Path
+
+import requests
+from pydantic import BaseModel, Field
+from zai import ZhipuAiClient
+
+from config.settings import get_settings
+from skills.base import SkillBase, format_error, format_success
+
+MODEL = "glm-5v-turbo"
+
+
+def _get_mime_type(source: str, content_type: str | None = None) -> str:
+    """从 Content-Type 或文件扩展名推断 MIME 类型。"""
+    if content_type and "/" in content_type:
+        return content_type.split(";")[0].strip()
+    ext = Path(urllib.parse.urlparse(source).path).suffix.lower()
+    mime, _ = mimetypes.guess_type(f"file{ext}")
+    return mime or "image/png"
+
+
+def _load_image_bytes(image_source: str) -> tuple[bytes, str]:
+    """解析 image_source 前缀，返回 (bytes, mime_type)。"""
+    if image_source.startswith("local:"):
+        path = image_source[6:]
+        file_path = Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"文件不存在: {path}")
+        if not file_path.is_file():
+            raise IsADirectoryError(f"路径不是文件: {path}")
+        image_bytes = file_path.read_bytes()
+        mime = _get_mime_type(path)
+        return image_bytes, mime
+
+    if image_source.startswith("url:"):
+        url = image_source[4:]
+        resp = requests.get(url, timeout=30, headers={"User-Agent": "SonettoHere/1.0"})
+        resp.raise_for_status()
+        content_type = resp.headers.get("Content-Type")
+        mime = _get_mime_type(url, content_type)
+        return resp.content, mime
+
+    raise ValueError(f"image_source 必须以 'local:' 或 'url:' 开头: {image_source}")
+
+
+class ImageUnderstandInput(BaseModel):
+    get_doc: bool = Field(default=False, description="设为 true 以获取使用说明")
+    image_source: str = Field(
+        default="",
+        description="图片来源: 'local:C:\\path\\to\\image.jpg' 或 'url:https://example.com/photo.png'",
+    )
+    prompt: str = Field(default="请描述这张图片", description="向模型提问的指令")
+
+
+class ImageUnderstandSkill(SkillBase):
+    name: str = "analyze_image"
+    description: str = (
+        "使用智谱 GLM-5V-Turbo 多模态模型理解图片内容。"
+        "支持本地文件（local:path）和网络图片（url:https://...）。"
+        "可指定 prompt 提问，如 '这张图里有什么文字？'。★ 首次使用先 get_doc=true。"
+    )
+    args_schema: type[BaseModel] = ImageUnderstandInput
+
+    def _run(
+        self,
+        get_doc: bool = False,
+        image_source: str = "",
+        prompt: str = "请描述这张图片",
+    ) -> str:
+        if get_doc:
+            return self._load_doc()
+        if not image_source.strip():
+            return format_error("image_source 不能为空")
+
+        settings = get_settings()
+        client = ZhipuAiClient(api_key=settings.zhipuai_api_key)
+
+        try:
+            image_bytes, mime = _load_image_bytes(image_source)
+            image_b64 = base64.b64encode(image_bytes).decode("utf-8")
+            data_url = f"data:{mime};base64,{image_b64}"
+
+            response = client.chat.completions.create(
+                model=MODEL,
+                messages=[{
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": data_url}},
+                        {"type": "text", "text": prompt},
+                    ],
+                }],
+                thinking={"type": "enabled"},
+            )
+
+            return format_success({
+                "response": response.choices[0].message.content,
+            })
+        except Exception as e:
+            return format_error(f"图片理解失败: {e}")


### PR DESCRIPTION
## Summary
- 新增 `analyze_image` skill，基于智谱 GLM-5V-Turbo 多模态模型实现图片理解/OCR/描述
- 支持本地图片（`local:路径`）和网络图片（`url:https://...`）
- 添加 `zai-sdk` 依赖和 `zhipuai_api_key` 配置项

## Test plan
- [ ] 本地图片分析：`analyze_image image_source="local:/path/to/image.jpg" prompt="描述这张图"`
- [ ] 网络图片分析：`analyze_image image_source="url:https://example.com/photo.png"`
- [ ] 自定义 prompt：`prompt="图片里有什么文字？"`
- [ ] get_doc 返回使用说明