### PR TITLE
feat(webui): 添加引用本地文件功能

### DIFF
--- a/api/routes/files.py
+++ b/api/routes/files.py
@@ -1,5 +1,6 @@
 """REST API — 本地文件服务（封面图等）。"""
 
+import asyncio
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -8,6 +9,70 @@ from fastapi.responses import FileResponse
 router = APIRouter()
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@router.get("/select-file")
+async def select_file(type: str = "file"):
+    """打开系统原生文件选择对话框，返回所选文件或文件夹的绝对路径。
+
+    仅在本地开发环境可用（对话框在服务器端弹出）。
+    type: "file" 选择文件, "folder" 选择文件夹
+    """
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+
+        import sys
+
+        def _set_dpi_awareness() -> None:
+            """启用 Windows DPI 感知，避免对话框在高 DPI 下模糊。"""
+            if sys.platform == "win32":
+                import ctypes
+
+                try:
+                    # PROCESS_PER_MONITOR_DPI_AWARE = 1
+                    ctypes.windll.shcore.SetProcessDpiAwareness(1)
+                except (AttributeError, OSError):
+                    try:
+                        ctypes.windll.user.SetProcessDPIAware()
+                    except (AttributeError, OSError):
+                        pass
+
+        def _open_dialog() -> str | None:
+            _set_dpi_awareness()
+            root = tk.Tk()
+            root.withdraw()
+            try:
+                dpi = root.winfo_fpixels("1i")
+                root.tk.call("tk", "scaling", dpi / 72.0)
+            except Exception:
+                pass
+            root.attributes("-topmost", True)
+
+            if type == "folder":
+                path = filedialog.askdirectory(title="选择要引用的文件夹")
+            else:
+                path = filedialog.askopenfilename(
+                    title="选择要引用的文件",
+                    filetypes=[
+                        ("所有文件", "*.*"),
+                        ("文本文件", "*.txt"),
+                        ("图片", "*.png;*.jpg;*.jpeg;*.gif;*.bmp"),
+                        ("PDF", "*.pdf"),
+                        ("文档", "*.doc;*.docx"),
+                        ("代码", "*.py;*.js;*.ts;*.vue;*.html;*.css"),
+                    ],
+                )
+            root.destroy()
+            return path if path else None
+
+        loop = asyncio.get_event_loop()
+        path = await loop.run_in_executor(None, _open_dialog)
+        return {"path": path}
+    except ImportError:
+        raise HTTPException(status_code=500, detail="tkinter 不可用，无法打开文件对话框")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"打开文件对话框失败: {str(e)}")
 
 
 @router.get("/file")

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -1,6 +1,33 @@
 <template>
   <div class="chat-input-wrapper">
+    <div v-if="filePaths.length" class="file-refs-bar">
+      <span
+        v-for="(fp, idx) in filePaths"
+        :key="idx"
+        class="file-tag"
+        :title="fp"
+      >
+        <span class="file-tag-icon">📎</span>
+        <span class="file-tag-name">{{ getFileName(fp) }}</span>
+        <button class="file-tag-remove" @click="removeFile(idx)">✕</button>
+      </span>
+    </div>
     <div class="chat-input">
+      <div class="btn-add-file-wrapper">
+        <button class="btn-add-file" :disabled="disabled" @click="toggleMenu">
+          <span v-if="loading" class="btn-add-file-spin">⟳</span>
+          <span v-else>＋</span>
+        </button>
+        <div v-if="showMenu" class="add-file-menu" @click.stop>
+          <button class="add-file-menu-item" @click="pickFile">
+            <span class="menu-item-icon">📄</span> 选择文件
+          </button>
+          <button class="add-file-menu-item" @click="pickFolder">
+            <span class="menu-item-icon">📁</span> 选择文件夹
+          </button>
+        </div>
+        <div v-if="showMenu" class="menu-backdrop" @click="showMenu = false"></div>
+      </div>
       <textarea
         ref="textareaRef"
         v-model="text"
@@ -43,12 +70,63 @@ const emit = defineEmits<{
 
 const text = ref('')
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
+const filePaths = ref<string[]>([])
+const loading = ref(false)
+const showMenu = ref(false)
+
+function getFileName(fp: string): string {
+  const parts = fp.replace(/\\/g, '/').split('/')
+  return parts[parts.length - 1] || fp
+}
+
+function toggleMenu() {
+  if (props.disabled) return
+  showMenu.value = !showMenu.value
+}
+
+async function pickFile() {
+  showMenu.value = false
+  await _pick('file')
+}
+
+async function pickFolder() {
+  showMenu.value = false
+  await _pick('folder')
+}
+
+async function _pick(type: string) {
+  if (loading.value) return
+  loading.value = true
+  try {
+    const res = await fetch(`/api/select-file?type=${type}`)
+    const data = await res.json()
+    if (data.path) {
+      filePaths.value.push(data.path)
+    }
+  } catch {
+    // 静默失败
+  } finally {
+    loading.value = false
+  }
+}
+
+function removeFile(index: number) {
+  filePaths.value.splice(index, 1)
+}
 
 function handleSend() {
   const msg = text.value.trim()
   if (!msg || props.disabled) return
-  emit('send', msg)
+
+  let finalMsg = msg
+  if (filePaths.value.length > 0) {
+    const refs = filePaths.value.map((p) => `[引用文件: ${p}]`).join('\n')
+    finalMsg = `${msg}\n\n${refs}`
+  }
+
+  emit('send', finalMsg)
   text.value = ''
+  filePaths.value = []
   nextTick(() => autoResize())
 }
 
@@ -66,6 +144,51 @@ function autoResize() {
   padding: 16px 24px;
   background: var(--bg-card);
 }
+
+/* 文件引用标签条 */
+.file-refs-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 0 8px 0;
+}
+.file-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--text-primary);
+  max-width: 100%;
+  overflow: hidden;
+}
+.file-tag-icon {
+  flex-shrink: 0;
+  font-size: 12px;
+}
+.file-tag-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.file-tag-remove {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+.file-tag-remove:hover {
+  color: #c97a7a;
+}
+
 .chat-input {
   display: flex;
   align-items: flex-end;
@@ -79,6 +202,88 @@ function autoResize() {
 .chat-input:focus-within {
   border-color: var(--accent);
 }
+
+/* 添加文件按钮 */
+.btn-add-file-wrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+.btn-add-file {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  padding: 0;
+  font-family: inherit;
+}
+.btn-add-file:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+.btn-add-file:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.btn-add-file-spin {
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+/* 添加文件菜单 */
+.menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+}
+.add-file-menu {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  min-width: 140px;
+}
+.add-file-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 14px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  white-space: nowrap;
+  transition: background 0.12s;
+}
+.add-file-menu-item:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.menu-item-icon {
+  font-size: 14px;
+}
+
 .input-area {
   flex: 1;
   border: none;


### PR DESCRIPTION
## Summary

- 输入框左侧添加「＋」按钮，点击弹出菜单选择「选择文件」或「选择文件夹」
- 选中后路径以标签形式悬浮显示在输入框正上方，每个标签带「✕」删除按钮
- 发送时自动将引用路径以 `[引用文件: 路径]` 格式拼接到消息末尾传给后端
- 后端新增 `GET /api/select-file` 端点，通过 tkinter 弹出系统原生文件/文件夹选择对话框
- 修复 tkinter 对话框在高 DPI 屏幕下的模糊问题（启用 Windows DPI 感知 + 动态缩放）

## Test plan

- [x] 点击「＋」弹出菜单，两个选项均正常显示
- [x] 选择文件后路径标签出现在输入框上方
- [x] 选择文件夹后路径标签正常显示
- [x] 点击「✕」可删除引用
- [x] 发送时 WebSocket 消息末尾包含 `[引用文件: 路径]`
- [x] 多次选择可累积多个引用标签
