### PR TITLE
feat(ui): 改进token用量统计与悬浮详情卡片

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -102,8 +102,18 @@ async def _run_agent_turn(
     finally:
         session._active_task = None
         settings = get_settings()
+
+        # 从 graph 的最终 state 取回完整消息列表（含工具调用/结果）
+        try:
+            state = await graph.aget_state(
+                {"configurable": {"thread_id": session.session_id}}
+            )
+            counting_messages = state.values.get("messages", [])
+        except Exception:
+            counting_messages = session.short_term_memory.messages
+
         context_usage = estimate_context_usage(
-            messages=session.short_term_memory.messages,
+            messages=counting_messages,
             system_prompt=enhanced_prompt,
             max_tokens=settings.model_context_window,
             model_name=settings.model_name,

--- a/config/settings.py
+++ b/config/settings.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     qq_token: str = ""
 
     # 模型上下文窗口大小（DeepSeek V4 Flash = 1M tokens）
-    model_context_window: int = 1000000
+    model_context_window: int = 256_000 # 避免上下文丢失现象
 
     # 模型名称
     model_name: str = "deepseek-v4-flash"

--- a/web/src/components/ContextUsageBadge.vue
+++ b/web/src/components/ContextUsageBadge.vue
@@ -19,6 +19,22 @@
     </svg>
     <span class="label">{{ Math.round(usage.usage_percent) }}%</span>
     <span class="model-name">{{ usage.model_name }}</span>
+
+    <div class="hover-card">
+      <div class="card-row">
+        <span class="card-label">Current</span>
+        <span class="card-value">{{ formatTokens(usage.current_tokens) }}</span>
+      </div>
+      <div class="card-row">
+        <span class="card-label">Max</span>
+        <span class="card-value">{{ formatTokens(usage.max_tokens) }}</span>
+      </div>
+      <div class="card-divider"></div>
+      <div class="card-row">
+        <span class="card-label">Used</span>
+        <span class="card-value">{{ Math.round(usage.usage_percent) }}%</span>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -29,6 +45,12 @@ import type { ContextUsage } from '@/types'
 const props = defineProps<{ usage: ContextUsage | null }>()
 
 const circumference = 2 * Math.PI * 13
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K'
+  return n.toLocaleString()
+}
 
 const dashOffset = computed(() => {
   if (!props.usage) return circumference
@@ -83,8 +105,53 @@ const level = computed(() => {
 .danger .label {
   color: #c97a7a;
 }
+.context-usage {
+  position: relative;
+}
+.context-usage:hover .hover-card {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+}
 .model-name {
   color: var(--text-secondary);
   opacity: 1;
+}
+.hover-card {
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: visibility 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 100;
+  min-width: 160px;
+  padding: 8px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+.card-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+.card-label {
+  color: var(--text-secondary);
+}
+.card-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+.card-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
 }
 </style>


### PR DESCRIPTION
## Summary
- 修复 token 统计：从 graph 最终 state 取完整消息列表（含本轮输入和工具调用），不再滞后
- 新增 ContextUsageBadge 悬浮卡片，hover 时展示 Current / Max / Used tokens
- 卡片加入淡入+上滑动画，数字字体统一为 tabular-nums
- 调整上下文窗口为 256K 以避免丢失现象

## Test plan
- [ ] 启动前后端，发起含工具调用的对话，确认 ContextUsageBadge 百分比正确
- [ ] Hover badge 查看详情卡片是否正常弹出
- [ ] 确认 token 数稳定 ≥ 旧方式（不再漏算）