### PR TITLE
fix(kaleidoscope): KEP—搜索结果展示优化

### DIFF
--- a/web/src/components/tools/SearchBubble.vue
+++ b/web/src/components/tools/SearchBubble.vue
@@ -1,8 +1,7 @@
 <template>
   <BubbleChrome :tool-call="toolCall">
-    <!-- 运行中 -->
+    <!-- 运行中（spinner 在 BubbleChrome header 中，此处仅文字） -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>正在搜索...</span>
     </div>
 
@@ -120,7 +119,8 @@ const processTime = computed(() => td.value.process_time_ms ?? td.value.process_
 // ── 结果列表 ──
 const resultList = computed<Array<Record<string, any>>>(() => {
   const results = td.value.results
-  return Array.isArray(results) ? results : []
+  if (!Array.isArray(results)) return []
+  return [...results].sort((a, b) => (a.position ?? 99) - (b.position ?? 99))
 })
 
 // ── 搜索源 ──


### PR DESCRIPTION
## Summary
- 移除搜索运行状态下 body 中的冗余 spinner（BubbleChrome header 已有一个）
- 搜索结果按 position 字段升序排列

## Test plan
- [ ] 启动前后端，触发搜索工具，确认只有 header 有一个 spinner，body 不再有
- [ ] 确认搜索结果按 position 从小到大的顺序展示