### PR TITLE
fix: 切换会话时 ContextUsage 及时更新

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -148,10 +148,10 @@ async def websocket_chat(ws: WebSocket, session_id: str):
     sm = app_state.session_manager
     session = sm.get_or_create(session_id)
 
-    # 连接建立后立即推送初始上下文用量
+    # 连接建立后立即推送初始上下文用量（含已有历史）
     settings = get_settings()
     initial_usage = estimate_context_usage(
-        messages=[],
+        messages=session.short_term_memory.messages,
         system_prompt=app_state.system_prompt,
         max_tokens=settings.model_context_window,
         model_name=settings.model_name,

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -292,6 +292,7 @@ export function useChat(sessionId: Ref<string>) {
       }
       currentTurn.value = null
       error.value = null
+      contextUsage.value = null
       if (newId) {
         connect()
       }


### PR DESCRIPTION
## Summary\n- 前端：切换会话时清空 contextUsage，避免闪现旧数据\n- 后端：初始 context_usage 使用会话已有历史，而非空列表