### PR TITLE
feat(ui): 为前端markdown渲染加入LaTeX支持

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "sonettohere-web",
-  "version": "2.1.0",
+  "version": "0.2.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonettohere-web",
-      "version": "2.1.0",
+      "version": "0.2.0-beta",
       "dependencies": {
+        "katex": "^0.16.47",
         "marked": "^12.0.0",
+        "marked-katex-extension": "^5.1.8",
         "vue": "^3.4.0",
         "vue-router": "^4.3.0"
       },
@@ -1028,6 +1030,15 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1123,6 +1134,22 @@
         "he": "bin/he"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1142,6 +1169,16 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/marked-katex-extension": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/marked-katex-extension/-/marked-katex-extension-5.1.8.tgz",
+      "integrity": "sha512-TsV9OCHHDjVBf4IH0RSjLs4Eqsjj8HGfmVCKlimrS391EtBBxzXj2gBYdF9tY7f7oXu9tb1kHV86ExJsG3iMhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "katex": ">=0.16 <0.17",
+        "marked": ">=4 <19"
       }
     },
     "node_modules/minimatch": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "katex": "^0.16.47",
     "marked": "^12.0.0",
+    "marked-katex-extension": "^5.1.8",
     "vue": "^3.4.0",
     "vue-router": "^4.3.0"
   },

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import 'katex/dist/katex.min.css'
 import '@/components/tools/_shared/shared.css'
 
 const app = createApp(App)

--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -1,9 +1,11 @@
 import { Marked } from 'marked'
+import markedKatex from 'marked-katex-extension'
 
 const marked = new Marked({
   breaks: true,
   gfm: true,
 })
+marked.use(markedKatex())
 
 export function renderMarkdown(content: string): string {
   if (!content) return ''


### PR DESCRIPTION
## Summary
- 安装 katex + marked-katex-extension
- markdown.ts 注册 markedKatex() 插件
- main.ts 引入 katex.min.css
- 支持 $E=mc^2$ 行内公式和 $$\int_a^b f(x)dx$$ 块级公式

## Test plan
- [ ] 在对话中输入含 LaTeX 公式的内容，确认渲染正常
- [ ] 确认普通 markdown 不受影响（标题、列表、代码块等）