### PR TITLE
feat(ui): Python 代码渲染使用 Maple Mono 斜体字体集

### DIFF
--- a/web/src/components/tools/PythonBubble.vue
+++ b/web/src/components/tools/PythonBubble.vue
@@ -104,6 +104,14 @@ function copyCode() {
   font-display: swap;
 }
 
+@font-face {
+  font-family: 'MapleMono';
+  src: url('/fonts/MapleMono-NF-CN-Italic.ttf') format('truetype');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
 .py-section {
   margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary

- 添加 MapleMono-NF-CN-Italic.ttf 字体文件
- 新增 `@font-face` `font-style: italic` 声明，关联斜体字体文件
- Python 代码中的关键字（`.py-kw`）和注释（`.py-comment`）现使用 Maple Mono 原生斜体字形，而非浏览器假斜体

## Test plan

- [ ] 打开任意 Python 工具调用渲染页
- [ ] 确认关键字（如 `def`、`if`、`class`）和注释斜体显示正常
- [ ] 确认斜体字形为 Maple Mono 原生设计（字母 `f`、`i`、`k` 等有手写变体），而非机械倾斜