### PR TITLE
feat(agent): 网页抓取工具暴露 headless 参数供 Agent 决策

### DIFF
--- a/skills/network/SKILL.md
+++ b/skills/network/SKILL.md
@@ -17,7 +17,7 @@
 ## 常见陷阱
 - **天气 city vs adcode**：传城市名时不要同时传 adcode，避免API混淆
 - **smart_search 的 fetch_full**：本 Skill 不支持 fetch_full 参数。如需全文，先用 smart_search 获取 URL 列表，再逐条调用 scrape_webpage
-- **scrape_webpage 人机验证**：使用有头 Chromium 浏览器，用户可在浏览器窗口中手动完成 CAPTCHA/Turnstile/登录等验证。默认有 5 秒额外等待时间，可通过 `wait_ms` 参数调整。导航超时 60 秒。
+- **scrape_webpage 人机验证**：默认无头模式（静默抓取）。如遇到 CAPTCHA/Turnstile/登录等需要手动交互的页面，可设置 `headless=false` 切换为有头模式，用户可在浏览器窗口中手动完成验证。此时可通过 `wait_ms` 调整等待时间（默认 5000ms）。导航超时 60 秒。
 - **holiday_calendar 参数互斥**：date / month / year 三选一，不要同时传多个
 - **analyze_image 图片来源**：本地用 `local:绝对路径`，网络用 `url:https://...`。prompt 默认"请描述这张图片"，可自定义提问如"文字是啥？""这是什么物体？"
 - **天气 minutely 仅国内**：分钟级降水预报仅支持中国大陆城市

--- a/skills/network/browser_manager.py
+++ b/skills/network/browser_manager.py
@@ -9,8 +9,8 @@ logger = logging.getLogger(__name__)
 class BrowserManager:
     """模块级单例，管理 Playwright + Microsoft Edge 浏览器实例。
 
-    使用有头模式（headless=False），浏览器窗口对用户可见，
-    便于手动解决人机验证（CAPTCHA / Turnstile / 登录等）。
+    支持无头/有头模式切换。默认无头模式（headless=True），
+    有头模式时浏览器窗口对用户可见，便于手动解决人机验证。
 
     使用 async_api 避免与 uvicorn asyncio 事件循环的 greenlet 冲突。
     """
@@ -19,6 +19,7 @@ class BrowserManager:
     _playwright = None
     _browser = None
     _loop_id: int | None = None
+    _headless: bool = True
     _lock = asyncio.Lock()
 
     def __new__(cls) -> "BrowserManager":
@@ -26,30 +27,34 @@ class BrowserManager:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    async def _ensure_browser(self):
+    async def _ensure_browser(self, headless: bool = True):
         loop_id = id(asyncio.get_running_loop())
         if self._browser is not None and self._loop_id != loop_id:
             logger.info("事件循环已变更，重新创建浏览器实例")
+            await self._close_locked()
+        if self._browser is not None and self._headless != headless:
+            logger.info("无头模式切换（%s→%s），重新创建浏览器", self._headless, headless)
             await self._close_locked()
         if self._browser is None:
             from playwright.async_api import async_playwright
 
             self._playwright = await async_playwright().start()
             self._browser = await self._playwright.chromium.launch(
-                headless=False,
+                headless=headless,
                 channel="msedge",
             )
             self._loop_id = loop_id
-            logger.info("Microsoft Edge 浏览器已启动（有头模式）")
+            self._headless = headless
+            logger.info("Microsoft Edge 浏览器已启动（%s）", "无头模式" if headless else "有头模式")
 
-    async def get_browser(self):
+    async def get_browser(self, headless: bool = True):
         async with self._lock:
-            await self._ensure_browser()
+            await self._ensure_browser(headless=headless)
             return self._browser
 
-    async def new_page(self):
+    async def new_page(self, headless: bool = True):
         """创建新页面，默认 1920x1080 视口。"""
-        browser = await self.get_browser()
+        browser = await self.get_browser(headless=headless)
         context = await browser.new_context(
             viewport={"width": 1920, "height": 1080},
             user_agent=(

--- a/skills/network/skill_scraper.py
+++ b/skills/network/skill_scraper.py
@@ -25,6 +25,10 @@ class ScraperInput(BaseModel):
         description="页面加载后额外等待毫秒数，给用户时间解决人机验证（默认 5000）",
     )
     screenshot: bool = Field(default=False, description="是否同时截取页面首屏截图（base64）")
+    headless: bool = Field(
+        default=True,
+        description="是否使用无头模式（默认 true：不显示浏览器窗口，后台静默抓取；设为 false 则弹出浏览器窗口，适用于需要手动解决人机验证的场景）",
+    )
 
 
 CONTENT_SELECTORS = [
@@ -160,7 +164,8 @@ class WebScraperSkill(SkillBase):
     description: str = (
         "使用真实 Microsoft Edge 浏览器抓取网页内容。"
         "提取：标题、元数据、Open Graph、JSON-LD 结构化数据、标题层级、链接、图片、正文 HTML（保留链接等丰富结构）。"
-        "支持 JavaScript 渲染页面。有头模式，用户可手动解决人机验证。"
+        "支持 JavaScript 渲染页面。默认无头模式后台静默抓取，"
+        "可设置 headless=false 切换为有头模式以手动解决人机验证。"
         "★ 首次使用先 get_doc=true。"
     )
     args_schema: type[BaseModel] = ScraperInput
@@ -171,6 +176,7 @@ class WebScraperSkill(SkillBase):
         url: str = "",
         wait_ms: int = 5000,
         screenshot: bool = False,
+        headless: bool = True,
     ) -> str:
         if get_doc:
             return self._load_doc()
@@ -179,7 +185,7 @@ class WebScraperSkill(SkillBase):
 
         try:
             manager = get_browser_manager()
-            page = await manager.new_page()
+            page = await manager.new_page(headless=headless)
 
             await page.goto(url, wait_until="domcontentloaded", timeout=60000)
             await page.wait_for_timeout(wait_ms)
@@ -238,13 +244,15 @@ class WebScraperSkill(SkillBase):
         url: str = "",
         wait_ms: int = 5000,
         screenshot: bool = False,
+        headless: bool = True,
     ) -> str:
         """同步包装，供 CLI 等同步调用方使用。"""
         try:
             asyncio.get_running_loop()
         except RuntimeError:
             return asyncio.run(self._arun(
-                get_doc=get_doc, url=url, wait_ms=wait_ms, screenshot=screenshot
+                get_doc=get_doc, url=url, wait_ms=wait_ms, screenshot=screenshot,
+                headless=headless,
             ))
 
         # 运行中的事件循环不可嵌套 — 用独立线程执行
@@ -252,6 +260,7 @@ class WebScraperSkill(SkillBase):
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(
                 asyncio.run,
-                self._arun(get_doc=get_doc, url=url, wait_ms=wait_ms, screenshot=screenshot),
+                self._arun(get_doc=get_doc, url=url, wait_ms=wait_ms, screenshot=screenshot,
+                           headless=headless),
             )
             return future.result()


### PR DESCRIPTION
## Summary

- `ScraperInput` 新增 `headless` 参数，默认 `true`（无头模式）
- `BrowserManager` 支持运行时动态切换无头/有头模式，切换时自动重启浏览器
- `description` 和 `SKILL.md` 同步更新，告知 Agent 可在需要人机验证时设置 `headless=false`
- 前端无影响，参数仅在 Agent 决策层可见

## Test plan

- [ ] Agent 默认无头调用抓取，浏览器窗口不弹出
- [ ] Agent 设置 `headless=false`，弹出 Edge 浏览器窗口
- [ ] 连续调用中切换 headless 模式，浏览器正确重启