### PR TITLE
feat(ui): 添加气泡右键上下文菜单与引用功能

### DIFF
--- a/dev_docs/context-menu.md
+++ b/dev_docs/context-menu.md
@@ -1,0 +1,199 @@
+# 气泡右键上下文菜单设计文档
+
+## 概述
+
+为 Web UI 中所有聊天气泡（用户消息、AI 回复、思考过程、工具输出）添加了统一的右键上下文菜单。当前仅实现「引用」功能，但架构支持低成本扩展。
+
+---
+
+## 架构
+
+### 组件层次
+
+```
+ChatView
+ └── ChatWindow
+      ├── .cite-source (wrapper)  ← @contextmenu.prevent
+      │    └── MessageBubble / ThinkingBlock / ToolBubbleRouter
+      ├── .cite-source (wrapper)
+      │    └── ...
+      └── ContextMenu  ← 全局唯一实例
+```
+
+- 每个气泡外层包裹 `div.cite-source`（`display: contents`，不影响布局），绑定 `@contextmenu.prevent`
+- `ChatWindow` 持有唯一 `ContextMenu` 实例，通过状态控制显示/隐藏
+- `ContextMenu` 使用 `<Teleport to="body">` 避免溢出裁剪
+
+### 数据流
+
+```
+用户右键气泡
+  → onBubbleContextMenu(event, sourceType, fullText, sourceLabel)
+  → 检测 window.getSelection() 判断是否框选文字
+  → 设置 pendingCitation + 菜单位置
+  → 显示 ContextMenu
+  → 用户点击菜单项
+  → handleContextMenuSelect(action)
+  → emit('cite', Citation) → ChatView → ChatInput
+```
+
+### Citation 类型
+
+```typescript
+interface Citation {
+  id: string
+  text: string
+  sourceLabel: string        // 显示标签："用户"、"AI"、"思考过程"、工具名称
+  sourceType: 'user_message' | 'assistant_message' | 'tool_result' | 'thinking'
+}
+```
+
+---
+
+## 核心机制
+
+### 框选文字检测
+
+```typescript
+const selection = window.getSelection()
+const selectedText = selection?.toString().trim()
+if (selectedText && selection!.rangeCount > 0) {
+  const range = selection!.getRangeAt(0)
+  const target = event.currentTarget as HTMLElement | null
+  if (target && target.contains(range.commonAncestorContainer)) {
+    citeText = selectedText  // 仅引用选中部分
+  }
+  selection!.removeAllRanges()
+}
+```
+
+- 使用 `event.currentTarget.contains()` 校验选中范围是否在当前气泡内
+- 跨气泡选中自动回退到引用全文
+- 选中后清除选区（`removeAllRanges`），避免干扰后续操作
+
+### 引用文本截断
+
+- 引用文本上限 1000 字符（`MAX_CITE_LENGTH`），超出尾部替换为 `…`
+- 标签预览截断为 40 字符，完整文本通过 `title` 属性在 hover 时查看
+
+---
+
+## ContextMenu 组件
+
+```vue
+<ContextMenu
+  :position="{ x, y }"
+  :items="[{ label, action, icon? }]"
+  :visible="boolean"
+  @select="onSelect"
+  @close="onClose"
+/>
+```
+
+- 使用 `<Teleport to="body">` 渲染，避免父级 `overflow: hidden` 裁剪
+- 半透明 backdrop 层拦截点击关闭 + 阻止原生右键菜单
+- `document.addEventListener('keydown')` 监听 Escape 键关闭
+- 菜单项通过 `items` prop 传入，组件本身不硬编码菜单内容
+
+---
+
+## 扩展指南
+
+### 添加新菜单项
+
+在 `ChatWindow.vue` 的 `ctxMenuItems` 数组中新增项即可：
+
+```typescript
+const ctxMenuItems: ContextMenuItem[] = [
+  { label: '引用', action: 'cite', icon: '💬' },
+  { label: '复制', action: 'copy', icon: '📋' },     // 新增
+  { label: '分享', action: 'share', icon: '🔗' },    // 新增
+]
+```
+
+在 `handleContextMenuSelect` 中添加对应分支：
+
+```typescript
+function handleContextMenuSelect(action: string) {
+  switch (action) {
+    case 'cite':
+      // 现有逻辑
+      break
+    case 'copy':
+      // await navigator.clipboard.writeText(pendingCitation.value.text)
+      break
+    case 'share':
+      // 分享逻辑
+      break
+  }
+  closeContextMenu()
+}
+```
+
+### 添加自定义菜单项属性
+
+扩展 `ContextMenuItem` 接口（在 `ContextMenu.vue` 中）：
+
+```typescript
+export interface ContextMenuItem {
+  label: string
+  action: string
+  icon?: string
+  disabled?: boolean       // 新增
+  divider?: boolean        // 新增：上方显示分割线
+  shortcut?: string        // 新增：快捷键提示，如 "Ctrl+C"
+}
+```
+
+`ContextMenu.vue` 模板对应扩展：
+
+```html
+<template v-for="item in items" :key="item.action">
+  <div v-if="item.divider" class="context-menu-divider"></div>
+  <button
+    v-else
+    class="context-menu-item"
+    :disabled="item.disabled"
+    @click="select(item.action)"
+  >
+    <span v-if="item.icon" class="context-menu-icon">{{ item.icon }}</span>
+    <span>{{ item.label }}</span>
+    <span v-if="item.shortcut" class="context-menu-shortcut">{{ item.shortcut }}</span>
+  </button>
+</template>
+```
+
+### 按气泡类型显示不同菜单
+
+在 `onBubbleContextMenu` 中根据 `sourceType` 动态构造菜单项：
+
+```typescript
+function onBubbleContextMenu(event, sourceType, fullText, sourceLabel) {
+  // ... 现有文本检测逻辑 ...
+
+  // 动态构建菜单
+  const items: ContextMenuItem[] = [{ label: '引用', action: 'cite' }]
+
+  if (sourceType === 'tool_result') {
+    items.push({ label: '查看原始输出', action: 'view_raw' })
+  }
+  if (sourceType === 'assistant_message') {
+    items.push({ label: '复制回复', action: 'copy' })
+  }
+
+  ctxMenuItems.value = items
+  // ... 显示菜单 ...
+}
+```
+
+注意：`ctxMenuItems` 需要从 `const` 改为 `ref`：
+
+```typescript
+const ctxMenuItems = ref<ContextMenuItem[]>([{ label: '引用', action: 'cite', icon: '💬' }])
+```
+
+### 引用功能自身可扩展
+
+- **引用多条合并**：当前多条引用分别以 `[引用: text]` 发送，可改为更结构化的格式（如 JSON block）
+- **引用位置锚点**：记录引用的 turnId + eventIndex，允许 AI 回复时回溯到原文
+- **跨会话引用**：持久化引用数据，允许在新会话中引用历史消息

--- a/dev_docs/context-menu.md
+++ b/dev_docs/context-menu.md
@@ -91,9 +91,106 @@ if (selectedText && selection!.rangeCount > 0) {
 ```
 
 - 使用 `<Teleport to="body">` 渲染，避免父级 `overflow: hidden` 裁剪
-- 半透明 backdrop 层拦截点击关闭 + 阻止原生右键菜单
+- 半透明 backdrop 层拦截点击关闭 + 阻止原生右键菜单（使用 `v-show` 而非 `v-if`，确保动画正常工作）
 - `document.addEventListener('keydown')` 监听 Escape 键关闭
 - 菜单项通过 `items` prop 传入，组件本身不硬编码菜单内容
+
+---
+
+## 样式与动画参数
+
+样式定义在 `web/src/components/ContextMenu.vue` 的 `<style scoped>` 中。
+
+### 磨砂玻璃背景（`.context-menu`）
+
+```css
+.context-menu {
+  background: color-mix(in srgb, var(--bg-card) 75%, transparent);
+  backdrop-filter: blur(16px) saturate(1.2);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  border-radius: 8px;
+  padding: 4px 0;
+}
+```
+
+| 属性 | 含义 | 修改指导 |
+|------|------|----------|
+| `background: color-mix(… 75%, transparent)` | 背景色取自 `--bg-card`，75% 不透明度实现半透明 | 增大百分比（如 90%）→ 更不透明，磨砂感减弱；减小 → 更透明 |
+| `backdrop-filter: blur(16px)` | 后方内容高斯模糊半径 | 增大（如 24px）→ 模糊更强，隐私性更好但可能晕眩；减小（如 8px）→ 更清晰 |
+| `backdrop-filter: saturate(1.2)` | 色彩饱和度增强，补偿模糊导致的褪色 | 设为 1.0 可取消；增大 → 色彩更鲜艳 |
+| `border: … 60%, transparent` | 边框颜色取自 `--border`，60% 不透明度 | 增大 → 边框更实；减小 → 边框更淡甚至消失 |
+| `box-shadow: 0 4px 24px rgba(0,0,0,0.15)` | 阴影偏移 4px、虚化 24px、透明度 15% | 调大虚化或透明度 → 阴影更柔和；调小 → 阴影更锐利 |
+| `border-radius: 8px` | 菜单圆角 | 增大（如 12px）→ 更圆润；减小（如 4px）→ 更方正 |
+| `padding: 4px 0` | 菜单项与容器边界的上下间距 | 增大 → 菜单项上下留白更多 |
+
+### 菜单项（`.context-menu-item`）
+
+```css
+.context-menu-item {
+  padding: 8px 16px;
+  font-size: 13px;
+  gap: 6px;           /* 图标与文字间距 */
+  transition: background 0.12s;
+}
+.context-menu-item:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+```
+
+| 属性 | 含义 | 修改指导 |
+|------|------|----------|
+| `padding: 8px 16px` | 菜单项内边距 | 增大 → 菜单项更高更宽；减小 → 更紧凑 |
+| `font-size: 13px` | 菜单文字大小 | 与全局 UI 字号保持一致 |
+| `gap: 6px` | 图标与文字间距 | 增大 → 图标与文字间隔更宽 |
+| `transition: background 0.12s` | hover 背景色的过渡时长 | 增大（如 0.2s）→ 过渡更平滑但略显拖沓；减小 → 更干脆 |
+| `hover background: … 12%` | hover 时 accent 颜色的混合比例 | 增大 → hover 背景色更明显 |
+
+### 弹出动画（Transition）
+
+使用 Vue 内置 `<Transition name="menu-pop">`，定义四个 CSS 类：
+
+```css
+/* 进入动画：120ms 缓出 */
+.menu-pop-enter-active {
+  transition: opacity 0.12s ease-out, transform 0.12s ease-out;
+}
+
+/* 离开动画：80ms 缓入（比进入快，符合直觉） */
+.menu-pop-leave-active {
+  transition: opacity 0.08s ease-in, transform 0.08s ease-in;
+}
+
+/* 进入起始状态：透明 + 缩小到 92% */
+.menu-pop-enter-from {
+  opacity: 0;
+  transform: scale(0.92);
+}
+
+/* 离开结束状态：透明 + 缩小到 92% */
+.menu-pop-leave-to {
+  opacity: 0;
+  transform: scale(0.92);
+}
+```
+
+#### 动画参数总表
+
+| 类名 | 触发时机 | 默认值 | 修改指导 |
+|------|----------|--------|----------|
+| `.menu-pop-enter-active` | 元素插入 DOM 时 | 120ms ease-out | 增大（如 200ms）→ 进入更优雅但稍慢；减小（如 60ms）→ 更干脆 |
+| `.menu-pop-leave-active` | 元素移除 DOM 时 | 80ms ease-in | 离开应快于进入，符合 UI 直觉；建议保持 ≤ enter 时长 |
+| `.menu-pop-enter-from` | 进入动画第一帧 | `scale(0.92)` + `opacity: 0` | 调大 scale（如 0.96）→ 弹入幅度更小；调小 → 弹出感更强 |
+| `.menu-pop-leave-to` | 离开动画最后一帧 | `scale(0.92)` + `opacity: 0` | 建议与 enter-from 一致，避免视觉跳跃 |
+
+#### 动画设计原则
+
+1. **方向一致性**：进入和离开使用相同的 `scale` 和 `opacity` 终始值，避免闪烁
+2. **时长不对称**：进入（120ms）> 离开（80ms），用户感知更自然
+3. **轴心**：`transform-origin: top left` 使缩放以菜单左上角为锚点，对齐光标位置
+4. **缓动函数**：进入用 `ease-out`（先快后慢），离开用 `ease-in`（先慢后快），符合物理运动直觉
+
+若需完全禁用动画，将上述四个类的 `transition` 和 `transform` 移除或设置为 `none`。也可仅保留 `opacity` 过渡实现纯淡入淡出效果。
 
 ---
 

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -12,6 +12,19 @@
         <button class="file-tag-remove" @click="removeFile(idx)">✕</button>
       </span>
     </div>
+    <div v-if="citations?.length" class="file-refs-bar">
+      <span
+        v-for="cit in citations"
+        :key="cit.id"
+        class="file-tag"
+        :title="cit.text"
+      >
+        <span class="file-tag-icon">💬</span>
+        <span class="file-tag-name">{{ truncateText(cit.text, 40) }}</span>
+        <span class="file-tag-source">{{ cit.sourceLabel }}</span>
+        <button class="file-tag-remove" @click="$emit('removeCitation', cit.id)">✕</button>
+      </span>
+    </div>
     <div class="chat-input">
       <div class="btn-add-file-wrapper">
         <button class="btn-add-file" :disabled="disabled" @click="toggleMenu">
@@ -57,15 +70,18 @@
 
 <script setup lang="ts">
 import { ref, nextTick } from 'vue'
+import type { Citation } from '@/types'
 
 const props = defineProps<{
   isStreaming: boolean
   disabled: boolean
+  citations?: Citation[]
 }>()
 
 const emit = defineEmits<{
   send: [message: string]
   stop: []
+  removeCitation: [id: string]
 }>()
 
 const text = ref('')
@@ -119,15 +135,29 @@ function handleSend() {
   if (!msg || props.disabled) return
 
   let finalMsg = msg
+  const parts: string[] = []
+
   if (filePaths.value.length > 0) {
-    const refs = filePaths.value.map((p) => `[引用文件: ${p}]`).join('\n')
-    finalMsg = `${msg}\n\n${refs}`
+    parts.push(filePaths.value.map((p) => `[引用文件: ${p}]`).join('\n'))
+  }
+
+  if (props.citations?.length) {
+    parts.push(props.citations.map((c) => `[引用: ${c.text}]`).join('\n'))
+  }
+
+  if (parts.length > 0) {
+    finalMsg = `${msg}\n\n${parts.join('\n\n')}`
   }
 
   emit('send', finalMsg)
   text.value = ''
   filePaths.value = []
   nextTick(() => autoResize())
+}
+
+function truncateText(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text
+  return text.slice(0, maxLen) + '…'
 }
 
 function autoResize() {
@@ -187,6 +217,14 @@ function autoResize() {
 }
 .file-tag-remove:hover {
   color: #c97a7a;
+}
+.file-tag-source {
+  font-size: 10px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  padding: 0 5px;
+  border-radius: 3px;
+  flex-shrink: 0;
 }
 
 .chat-input {

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -3,24 +3,74 @@
     <div class="messages-list">
       <!-- 已完成的消息轮次 -->
       <template v-for="turn in turns" :key="turn.id">
-        <MessageBubble role="user" :content="turn.userMessage" />
+        <div
+          class="cite-source"
+          @contextmenu.prevent="onBubbleContextMenu($event, 'user_message', turn.userMessage, '用户')"
+        >
+          <MessageBubble role="user" :content="turn.userMessage" />
+        </div>
         <template v-for="(ev, i) in turn.events" :key="i">
-          <ThinkingBlock v-if="ev.kind === 'thinking'" :block="ev" />
-          <ToolBubbleRouter v-else :tool-call="ev" @action="forwardAction" />
+          <div
+            v-if="ev.kind === 'thinking'"
+            class="cite-source"
+            @contextmenu.prevent="onBubbleContextMenu($event, 'thinking', ev.tokens, '思考过程')"
+          >
+            <ThinkingBlock :block="ev" />
+          </div>
+          <div
+            v-else
+            class="cite-source"
+            @contextmenu.prevent="
+              onBubbleContextMenu(
+                $event,
+                'tool_result',
+                ev.output || ev.input || '',
+                ev.name,
+              )
+            "
+          >
+            <ToolBubbleRouter :tool-call="ev" @action="forwardAction" />
+          </div>
         </template>
-        <MessageBubble
+        <div
           v-if="turn.finalAnswer && !hasAnswerBlock(turn)"
-          role="assistant"
-          :content="turn.finalAnswer"
-        />
+          class="cite-source"
+          @contextmenu.prevent="onBubbleContextMenu($event, 'assistant_message', turn.finalAnswer, 'AI')"
+        >
+          <MessageBubble role="assistant" :content="turn.finalAnswer" />
+        </div>
       </template>
 
       <!-- 当前正在流式生成的消息 -->
       <template v-if="currentTurn">
-        <MessageBubble role="user" :content="currentTurn.userMessage" />
+        <div
+          class="cite-source"
+          @contextmenu.prevent="onBubbleContextMenu($event, 'user_message', currentTurn.userMessage, '用户')"
+        >
+          <MessageBubble role="user" :content="currentTurn.userMessage" />
+        </div>
         <template v-for="(ev, i) in currentTurn.events" :key="i">
-          <ThinkingBlock v-if="ev.kind === 'thinking'" :block="ev" />
-          <ToolBubbleRouter v-else :tool-call="ev" @action="forwardAction" />
+          <div
+            v-if="ev.kind === 'thinking'"
+            class="cite-source"
+            @contextmenu.prevent="onBubbleContextMenu($event, 'thinking', ev.tokens, '思考过程')"
+          >
+            <ThinkingBlock :block="ev" />
+          </div>
+          <div
+            v-else
+            class="cite-source"
+            @contextmenu.prevent="
+              onBubbleContextMenu(
+                $event,
+                'tool_result',
+                ev.output || ev.input || '',
+                ev.name,
+              )
+            "
+          >
+            <ToolBubbleRouter :tool-call="ev" @action="forwardAction" />
+          </div>
         </template>
       </template>
 
@@ -33,15 +83,25 @@
         <p class="empty-desc">发送一条消息开始对话</p>
       </div>
     </div>
+
+    <ContextMenu
+      :position="ctxMenuPos"
+      :items="ctxMenuItems"
+      :visible="ctxMenuVisible"
+      @select="handleContextMenuSelect"
+      @close="closeContextMenu"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { watch, ref, nextTick } from 'vue'
-import type { ChatTurn } from '@/types'
+import type { ChatTurn, Citation } from '@/types'
 import MessageBubble from './MessageBubble.vue'
 import ThinkingBlock from './ThinkingBlock.vue'
 import ToolBubbleRouter from './ToolBubbleRouter.vue'
+import ContextMenu from './ContextMenu.vue'
+import type { ContextMenuItem } from './ContextMenu.vue'
 
 const props = defineProps<{
   turns: ChatTurn[]
@@ -51,6 +111,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'action', p: { action: string; data?: unknown }): void
+  (e: 'cite', citation: Citation): void
 }>()
 
 function forwardAction(payload: { action: string; data?: unknown }) {
@@ -81,6 +142,71 @@ watch(
   () => props.currentTurn?.finalAnswer,
   () => scrollToBottom()
 )
+
+// === 引用功能 ===
+
+const MAX_CITE_LENGTH = 1000
+
+const ctxMenuVisible = ref(false)
+const ctxMenuPos = ref({ x: 0, y: 0 })
+const pendingCitation = ref<{
+  text: string
+  sourceLabel: string
+  sourceType: Citation['sourceType']
+} | null>(null)
+
+const ctxMenuItems: ContextMenuItem[] = [
+  { label: '引用', action: 'cite', icon: '💬' },
+]
+
+function onBubbleContextMenu(
+  event: MouseEvent,
+  sourceType: Citation['sourceType'],
+  fullText: string,
+  sourceLabel: string,
+) {
+  let citeText = fullText
+
+  // 检查是否有文本选中
+  const selection = window.getSelection()
+  const selectedText = selection?.toString().trim()
+  if (selectedText && selection!.rangeCount > 0) {
+    const range = selection!.getRangeAt(0)
+    const target = event.currentTarget as HTMLElement | null
+    if (target && target.contains(range.commonAncestorContainer)) {
+      citeText = selectedText
+    }
+    selection!.removeAllRanges()
+  }
+
+  if (!citeText) return
+
+  if (citeText.length > MAX_CITE_LENGTH) {
+    citeText = citeText.slice(0, MAX_CITE_LENGTH) + '…'
+  }
+
+  pendingCitation.value = { text: citeText, sourceLabel, sourceType }
+  ctxMenuPos.value = { x: event.clientX, y: event.clientY }
+  ctxMenuVisible.value = true
+}
+
+function handleContextMenuSelect(action: string) {
+  if (action === 'cite' && pendingCitation.value) {
+    const citation: Citation = {
+      id: crypto.randomUUID(),
+      text: pendingCitation.value.text,
+      sourceLabel: pendingCitation.value.sourceLabel,
+      sourceType: pendingCitation.value.sourceType,
+    }
+    emit('cite', citation)
+  }
+  closeContextMenu()
+}
+
+function closeContextMenu() {
+  ctxMenuVisible.value = false
+  pendingCitation.value = null
+}
 </script>
 
 <style scoped>
@@ -95,6 +221,10 @@ watch(
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+.cite-source {
+  /* 包装层，不引入额外布局影响 */
+  display: contents;
 }
 .empty-state {
   display: flex;

--- a/web/src/components/ContextMenu.vue
+++ b/web/src/components/ContextMenu.vue
@@ -1,0 +1,121 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="visible"
+      class="context-backdrop"
+      @click="close"
+      @contextmenu.prevent="close"
+      @keydown.escape="close"
+    >
+      <div
+        class="context-menu"
+        :style="{ left: position.x + 'px', top: position.y + 'px' }"
+        @click.stop
+        @contextmenu.stop
+      >
+        <button
+          v-for="item in items"
+          :key="item.action"
+          class="context-menu-item"
+          @click="select(item.action)"
+        >
+          <span v-if="item.icon" class="context-menu-icon">{{ item.icon }}</span>
+          <span>{{ item.label }}</span>
+        </button>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+
+export interface ContextMenuItem {
+  label: string
+  action: string
+  icon?: string
+}
+
+export interface ContextMenuPosition {
+  x: number
+  y: number
+}
+
+const props = defineProps<{
+  position: ContextMenuPosition
+  items: ContextMenuItem[]
+  visible: boolean
+}>()
+
+const emit = defineEmits<{
+  select: [action: string]
+  close: []
+}>()
+
+function select(action: string) {
+  emit('select', action)
+}
+
+function close() {
+  emit('close')
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && props.visible) {
+    close()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', onKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', onKeydown)
+})
+</script>
+
+<style scoped>
+.context-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+}
+
+.context-menu {
+  position: fixed;
+  z-index: 1001;
+  min-width: 120px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  padding: 4px 0;
+}
+
+.context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 16px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  white-space: nowrap;
+  transition: background 0.12s;
+}
+
+.context-menu-item:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.context-menu-icon {
+  font-size: 14px;
+}
+</style>

--- a/web/src/components/ContextMenu.vue
+++ b/web/src/components/ContextMenu.vue
@@ -1,28 +1,30 @@
 <template>
   <Teleport to="body">
     <div
-      v-if="visible"
+      v-show="visible"
       class="context-backdrop"
       @click="close"
       @contextmenu.prevent="close"
-      @keydown.escape="close"
     >
-      <div
-        class="context-menu"
-        :style="{ left: position.x + 'px', top: position.y + 'px' }"
-        @click.stop
-        @contextmenu.stop
-      >
-        <button
-          v-for="item in items"
-          :key="item.action"
-          class="context-menu-item"
-          @click="select(item.action)"
+      <Transition name="menu-pop">
+        <div
+          v-if="visible"
+          class="context-menu"
+          :style="{ left: position.x + 'px', top: position.y + 'px' }"
+          @click.stop
+          @contextmenu.stop
         >
-          <span v-if="item.icon" class="context-menu-icon">{{ item.icon }}</span>
-          <span>{{ item.label }}</span>
-        </button>
-      </div>
+          <button
+            v-for="item in items"
+            :key="item.action"
+            class="context-menu-item"
+            @click="select(item.action)"
+          >
+            <span v-if="item.icon" class="context-menu-icon">{{ item.icon }}</span>
+            <span>{{ item.label }}</span>
+          </button>
+        </div>
+      </Transition>
     </div>
   </Teleport>
 </template>
@@ -86,12 +88,15 @@ onUnmounted(() => {
   position: fixed;
   z-index: 1001;
   min-width: 120px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-card) 0%, transparent);
+  backdrop-filter: blur(12px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
   padding: 4px 0;
+  transform-origin: top left;
 }
 
 .context-menu-item {
@@ -117,5 +122,21 @@ onUnmounted(() => {
 
 .context-menu-icon {
   font-size: 14px;
+}
+
+/* 弹出动画 */
+.menu-pop-enter-active {
+  transition: opacity 0.12s ease-out, transform 0.12s ease-out;
+}
+.menu-pop-leave-active {
+  transition: opacity 0.08s ease-in, transform 0.08s ease-in;
+}
+.menu-pop-enter-from {
+  opacity: 0;
+  transform: scale(0.92);
+}
+.menu-pop-leave-to {
+  opacity: 0;
+  transform: scale(0.92);
 }
 </style>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -170,6 +170,15 @@ export interface NarrativeResponse {
   narrative: string
 }
 
+// === 引用 ===
+
+export interface Citation {
+  id: string
+  text: string
+  sourceLabel: string
+  sourceType: 'user_message' | 'assistant_message' | 'tool_result' | 'thinking'
+}
+
 // === 上下文窗口用量 ===
 
 export interface ContextUsage {

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -10,18 +10,23 @@
       :current-turn="currentTurn"
       :error="error"
       @action="handleToolAction"
+      @cite="addCitation"
     />
 
     <ChatInput
       :is-streaming="isStreaming"
       :disabled="!connected"
-      @send="send"
+      :citations="citations"
+      @send="onSend"
       @stop="cancel"
+      @remove-citation="removeCitation"
     />
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
+import type { Citation } from '@/types'
 import { useSession } from '@/composables/useSession'
 import { useChat } from '@/composables/useChat'
 import StatusBadge from '@/components/StatusBadge.vue'
@@ -32,6 +37,21 @@ import ChatInput from '@/components/ChatInput.vue'
 const { sessionId } = useSession()
 const { connected, isStreaming, turns, currentTurn, error, contextUsage, send, cancel, sendUserResponse } =
   useChat(sessionId)
+
+const citations = ref<Citation[]>([])
+
+function addCitation(citation: Citation) {
+  citations.value.push(citation)
+}
+
+function removeCitation(id: string) {
+  citations.value = citations.value.filter(c => c.id !== id)
+}
+
+function onSend(message: string) {
+  send(message)
+  citations.value = []
+}
 
 function handleToolAction(payload: { action: string; data?: unknown }) {
   if (payload.action === 'user_response') {


### PR DESCRIPTION
## 概述

为聊天气泡添加右键上下文菜单，支持引用（Citation）功能及后续扩展。

## 变更内容

- **ContextMenu 组件**：新增通用右键上下文菜单组件，支持动画过渡
- **气泡引用功能**：在 ChatWindow 中集成右键菜单，选中气泡后可引用其内容到输入框
- **动画修复**：使用 `v-show` 替代 `v-if` 修复菜单动画无法播放的问题
- **设计文档**：添加 `dev_docs/context-menu.md` 记录菜单设计规范与扩展指南

## 变更文件

| 文件 | 说明 |
|------|------|
| `web/src/components/ContextMenu.vue` | 新增通用右键菜单组件 |
| `web/src/components/ChatWindow.vue` | 集成右键菜单与引用逻辑 |
| `web/src/components/ChatInput.vue` | 支持引用内容展示 |
| `web/src/views/ChatView.vue` | 更新视图集成 |
| `web/src/types/index.ts` | 添加引用相关类型 |
| `dev_docs/context-menu.md` | 上下文菜单设计文档 |

## 测试计划

- [x] 右键气泡弹出菜单
- [x] 点击「引用」填充到输入框
- [x] 菜单打开/关闭动画正常
- [x] 点击外部区域关闭菜单