### PR TITLE
docs(dev_docs): 修正 communication.md 中 reconnectTimer 类型

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -14,9 +14,15 @@ def build_agent(
     tools: list[BaseTool],
     system_prompt: str,
     recursion_limit: int = 30,
+    checkpointer: MemorySaver | None = None,
 ) -> CompiledStateGraph:
-    """构建 ReAct Agent 图。"""
-    checkpointer = MemorySaver()
+    """构建 ReAct Agent 图。
+
+    若提供 checkpointer 则复用（跨轮次持久化状态），
+    否则每次新建 MemorySaver（原有行为）。
+    """
+    if checkpointer is None:
+        checkpointer = MemorySaver()
 
     return create_react_agent(
         model=model,

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -9,6 +9,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 
 from agent.graph import build_agent
 from agent.prompts import build_enhanced_prompt
+from langgraph.checkpoint.memory import MemorySaver
 from api import interaction
 from api.callbacks.websocket_callback import WebSocketCallback, _extract_content
 from api.context_usage import estimate_context_usage
@@ -32,15 +33,20 @@ async def _run_agent_turn(
         app_state.system_prompt, user_message
     )
 
+    # 使用 session 级别的持久 checkpointer
+    if session.checkpointer is None:
+        session.checkpointer = MemorySaver()
+
     graph = build_agent(
         model=app_state.llm,
         tools=app_state.tools,
         system_prompt=enhanced_prompt,
+        checkpointer=session.checkpointer,
     )
 
-    history = session.short_term_memory.messages
+    # checkpointer 按 thread_id 自动恢复历史消息
     inputs = {
-        "messages": history + [HumanMessage(content=user_message)]
+        "messages": [HumanMessage(content=user_message)]
     }
 
     config = {

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -31,6 +31,7 @@ async def get_session(session_id: str, request: Request):
         "session_id": session.session_id,
         "message_count": len(session.message_history),
         "created_at": session.created_at,
+        "has_active_agent": session._active_task is not None and not session._active_task.done(),
     }
 
 

--- a/api/session_manager.py
+++ b/api/session_manager.py
@@ -6,6 +6,7 @@ import uuid
 from dataclasses import dataclass, field
 
 from langchain_core.chat_history import InMemoryChatMessageHistory
+from langgraph.checkpoint.memory import MemorySaver
 
 
 @dataclass
@@ -16,6 +17,7 @@ class SessionState:
     short_term_memory: InMemoryChatMessageHistory = field(default_factory=InMemoryChatMessageHistory)
     message_history: list[dict] = field(default_factory=list)
     _active_task: asyncio.Task | None = field(default=None, repr=False)
+    checkpointer: MemorySaver | None = field(default=None, repr=False)
 
 
 class SessionManager:
@@ -52,11 +54,16 @@ class SessionManager:
         now = time.time()
         result = []
         for s in self._sessions.values():
+            has_active = (
+                s._active_task is not None
+                and not s._active_task.done()
+            )
             result.append({
                 "session_id": s.session_id,
                 "message_count": len(s.message_history),
                 "created_at": s.created_at,
                 "last_active": s.last_active,
+                "has_active_agent": has_active,
             })
         result.sort(key=lambda x: x["last_active"], reverse=True)
         return result

--- a/dev_docs/communication.md
+++ b/dev_docs/communication.md
@@ -1,0 +1,299 @@
+# 前后端通信方式
+
+## 概述
+
+SonettoHere Web 端采用 **REST + WebSocket 双通道**通信架构：
+
+- **REST API**：会话 CRUD、记忆查询、文件操作等请求-响应式操作
+- **WebSocket**：流式 Agent 对话、实时 tool call 推送、ask_user 交互
+
+后端基于 FastAPI，前端基于 Vue 3 + TypeScript。
+
+---
+
+## REST API
+
+基础路径：`/api`
+
+### 会话管理
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `POST` | `/sessions` | 创建新会话 |
+| `GET` | `/sessions` | 列出所有会话 |
+| `GET` | `/sessions/{id}` | 获取单个会话信息 |
+| `GET` | `/sessions/{id}/messages` | 获取会话消息历史 |
+| `GET` | `/sessions/{id}/context-usage` | 获取上下文用量估算 |
+| `DELETE` | `/sessions/{id}` | 删除会话 |
+
+**请求/响应示例：**
+
+```jsonc
+// POST /sessions
+// → { "session_id": "a1b2c3...", "created_at": 1715000000.0 }
+
+// GET /sessions
+// → {
+//     "sessions": [
+//       {
+//         "session_id": "a1b2c3...",
+//         "message_count": 5,
+//         "created_at": 1715000000.0,
+//         "last_active": 1715000100.0,
+//         "has_active_agent": false   // 该会话是否有正在运行的 Agent
+//       }
+//     ]
+//   }
+
+// GET /sessions/{id}
+// → { "session_id": "a1b2c3...", "message_count": 5, "created_at": 1715000000.0, "has_active_agent": false }
+
+// GET /sessions/{id}/messages
+// → { "session_id": "a1b2c3...", "messages": [{ "role": "user", "content": "你好" }, { "role": "assistant", "content": "你好！" }] }
+
+// GET /sessions/{id}/context-usage
+// → { "current_tokens": 1520, "max_tokens": 8192, "usage_percent": 18.6, "model_name": "deepseek-v4-flash", "session_id": "a1b2c3..." }
+
+// DELETE /sessions/{id}
+// → { "status": "deleted" }
+```
+
+### 记忆
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `GET` | `/narrative` | 获取长期记忆叙事（MEMORY.md 全文） |
+
+```jsonc
+// GET /narrative
+// → { "narrative": "## 用户信息\n..." }
+```
+
+### 文件
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `GET` | `/select-file` | 打开系统文件选择对话框（参数 `type: "file" | "folder"`） |
+| `GET` | `/file` | 读取文件内容（参数 `path`，含路径穿越防护） |
+
+```jsonc
+// GET /select-file?type=file
+// → { "path": "C:/Users/.../file.txt" }   // 用户取消则 path 为 null
+
+// GET /file?path=./README.md
+// → FileResponse (文件二进制内容)
+```
+
+### 健康检查
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| `GET` | `/health` | 服务健康检查 |
+
+```jsonc
+// GET /health
+// → { "status": "ok", "version": "1.0.0" }
+```
+
+---
+
+## WebSocket 协议
+
+### 连接
+
+```
+ws[s]://<host>/ws/chat/{session_id}
+```
+
+连接建立后，服务端立即推送初始 `context_usage` 事件。随后进入双工通信循环。
+
+### 客户端 → 服务端消息
+
+所有消息均为 JSON 格式，包含 `type` 和 `payload` 字段：
+
+| type | payload | 触发时机 |
+|------|---------|---------|
+| `"chat"` | `{ "message": string }` | 用户发送对话消息 |
+| `"cancel"` | `{}` | 用户取消当前生成 |
+| `"ping"` | `{}` | 心跳保活 |
+| `"user_response"` | `{ "interaction_id": string, "response": string \| string[] }` | 用户回复 ask_user 交互 |
+
+```jsonc
+// → { "type": "chat",          "payload": { "message": "北京的天气怎么样？" } }
+// → { "type": "cancel",        "payload": {} }
+// → { "type": "ping",          "payload": {} }
+// → { "type": "user_response", "payload": { "interaction_id": "abc123", "response": "海淀区" } }
+```
+
+### 服务端 → 客户端事件
+
+单轮对话中事件按以下顺序推送：
+
+```
+context_usage (仅连接时)
+  → thinking_start → token* → thinking_end
+  → (tool_start → tool_end/tool_error)*
+  → (ask_user → 等待用户回复)*
+  → answer
+  → done (含 context_usage)
+```
+
+| type | payload | 说明 |
+|------|---------|------|
+| `"context_usage"` | `{ current_tokens, max_tokens, usage_percent, model_name }` | 连接时推送初始值，done 事件中附最终值 |
+| `"thinking_start"` | `{ timestamp }` | LLM 开始生成 |
+| `"token"` | `{ token: string }` | 流式 token |
+| `"thinking_end"` | `{ timestamp }` | LLM 生成结束 |
+| `"tool_start"` | `{ tool_name, input }` | 工具开始执行（input 截断至 500 字符） |
+| `"tool_end"` | `{ tool_name, output, elapsed, tool_data? }` | 工具执行完成（output 截断至 300 字符，tool_data 为结构化结果） |
+| `"tool_error"` | `{ tool_name, error }` | 工具执行出错 |
+| `"ask_user"` | `{ tool_name, question, mode, options, interaction_id }` | Agent 向用户提问 |
+| `"answer"` | `{ content }` | Agent 最终回答 |
+| `"done"` | `{ turn_id, context_usage? }` | 本轮对话完成 |
+| `"error"` | `{ code, message }` | 任务取消或异常 |
+| `"pong"` | `{}` | 心跳回复 |
+
+```jsonc
+// ← { "type": "context_usage", "payload": { "current_tokens": 120, "max_tokens": 8192, "usage_percent": 1.5, "model_name": "deepseek-v4-flash" } }
+// ← { "type": "thinking_start", "payload": { "timestamp": 1715000000 } }
+// ← { "type": "token",          "payload": { "token": "北京" } }
+// ← { "type": "token",          "payload": { "token": "的" } }
+// ← { "type": "thinking_end",   "payload": { "timestamp": 1715000001 } }
+// ← { "type": "tool_start",     "payload": { "tool_name": "get_current_weather", "input": "北京" } }
+// ← { "type": "tool_end",       "payload": { "tool_name": "get_current_weather", "output": "晴 22°C", "elapsed": 0.8, "tool_data": { "city": "北京", "temp": "22" } } }
+// ← { "type": "answer",         "payload": { "content": "北京今天晴，22°C。" } }
+// ← { "type": "done",           "payload": { "turn_id": "xyz789", "context_usage": { "current_tokens": 350, "max_tokens": 8192, "usage_percent": 4.3, "model_name": "deepseek-v4-flash" } } }
+```
+
+### tool_data 结构化输出
+
+`tool_end` 事件的 `tool_data` 字段由服务端 `tool_extractors.py` 根据工具名称注册的提取器生成，前端通过 [ToolBubbleRouter](web/src/components/ToolBubbleRouter.vue) 路由到对应的气泡组件渲染。常见的 tool_data 结构：
+
+| 工具 | tool_data 结构 |
+|------|---------------|
+| `get_current_weather` | `{ city, temp, condition, humidity, wind }` |
+| `todo_list` | `{ tool_type: "task_list", total, tasks: [...] }` |
+| `nearby_search` | `{ count, pois: [...], location }` |
+| `run_python` | `{ tool_type: "run_python", stdout, code }` |
+| `smart_search` | `{ query, total_results, results: [...], sources }` |
+| ... | 详见 [tool_extractors.py](api/callbacks/tool_extractors.py) |
+
+---
+
+## 多会话通道架构
+
+前端使用 **多通道（Multi-Channel）** 架构管理 WebSocket 连接，每个 Session 拥有独立的通信通道。
+
+### SessionChannel
+
+```typescript
+interface SessionChannel {
+  ws: WebSocket | null          // 该会话的 WebSocket 连接
+  connected: boolean             // 连接状态
+  isStreaming: boolean           // 是否正在流式生成
+  turns: ChatTurn[]             // 已完成的对话轮次
+  currentTurn: ChatTurn | null  // 当前正在进行的轮次
+  error: string | null
+  contextUsage: ContextUsage | null
+  reconnectTimer: Timer | null  // 断线重连定时器
+  initialized: boolean          // 是否已初始化
+}
+```
+
+所有通道存储在模块级 `Map<string, SessionChannel>` 中（[useChat.ts](web/src/composables/useChat.ts#L64)）。
+
+### 连接管理
+
+- **惰性连接**：只有当 Session 被切换为"活跃"状态时才建立 WebSocket 连接
+- **断线重连**：连接断开后自动以 3 秒间隔重连
+- **不中断切换**：切换活跃 Session 时，原 Session 的 WebSocket **不断开**，后台 Agent 持续运行并接收事件
+- **显式清理**：删除 Session 时调用 `disconnectSession()` 关闭对应 WebSocket
+
+```
+Page Load → 切换 Session A
+  → ensureConnected('session-a')
+    → 建立 ws://host/ws/chat/session-a
+    → 开始接收事件，存入 Session A 的 Channel
+
+用户切换到 Session B（Session A 的 WS 保持打开）
+  → ensureConnected('session-b')
+    → 建立 ws://host/ws/chat/session-b
+    → Session A 的 Agent 持续运行，事件继续写入 Session A 的 Channel
+
+用户切回 Session A
+  → 直接显示 Session A Channel 中的 turns（包含后台完成的新数据）
+```
+
+### 事件路由
+
+所有 WebSocket 事件通过 `handleEventForChannel(sid, event)` 路由到对应 Session 的 Channel，操作该 Channel 的 `turns` 和 `currentTurn`，与前端的计算属性联动。
+
+---
+
+## ask_user 交互机制
+
+Agent 在需要用户输入时（如询问确认、选择选项），通过 **Future + WebSocket** 模式实现同步等待：
+
+```
+Agent 调用 ask_user_qa / ask_user_single_choice / ask_user_multi_choice
+  │
+  ├─ 服务端：register() → 创建 Future，存入 _pending 字典
+  ├─ 服务端：发送 "ask_user" WS 事件 → 前端
+  │
+  ├─ 前端：AskUserBubble 渲染表单
+  │
+  └─ 用户提交 →
+      前端发送 "user_response" WS 事件
+        → 服务端 resolve() → Future set_result()
+          → Agent 继续执行
+```
+
+- 超时时间：300 秒
+- 取消：Agent 任务取消时 `asyncio.CancelledError` 被捕获，清理 Future
+
+---
+
+## Context Usage 计算
+
+基于 `tiktoken` 的 `cl100k_base` 编码器：
+
+```python
+estimate_context_usage(messages, system_prompt, max_tokens, model_name)
+  → { current_tokens, max_tokens, usage_percent, model_name }
+```
+
+计算公式：
+
+```text
+current_tokens = system_prompt_token_count
+               + sum(count_tokens(m.content) for m in messages)
+               + 4 * len(messages)    # 每条消息的开销
+```
+
+计算时机：
+
+1. **WebSocket 连接建立时**：基于 `short_term_memory.messages` 估算
+2. **每轮对话结束时**：基于 Graph Checkpointer 的完整状态（含 tool call/result）估算，随 `done` 事件推送
+3. **REST API**：`GET /sessions/{id}/context-usage`，基于 `short_term_memory.messages`
+
+---
+
+## 关键文件索引
+
+| 文件 | 内容 |
+|------|------|
+| [api/server.py](api/server.py) | FastAPI 工厂、路由挂载、CORS、静态文件 |
+| [api/routes/sessions.py](api/routes/sessions.py) | REST 会话 CRUD |
+| [api/routes/memory.py](api/routes/memory.py) | 记忆 API |
+| [api/routes/files.py](api/routes/files.py) | 文件选择/读取 API |
+| [api/routes/chat.py](api/routes/chat.py) | WebSocket 端点、Agent 执行 |
+| [api/session_manager.py](api/session_manager.py) | 会话状态管理 |
+| [api/interaction.py](api/interaction.py) | ask_user 交互 Future 注册表 |
+| [api/context_usage.py](api/context_usage.py) | Token 用量估算 |
+| [api/callbacks/websocket_callback.py](api/callbacks/websocket_callback.py) | LangGraph → WS 事件翻译 |
+| [api/callbacks/tool_extractors.py](api/callbacks/tool_extractors.py) | 工具结构化数据提取 |
+| [web/src/types/index.ts](web/src/types/index.ts) | TypeScript 类型定义 |
+| [web/src/api/index.ts](web/src/api/index.ts) | REST 客户端 |
+| [web/src/composables/useChat.ts](web/src/composables/useChat.ts) | WebSocket 多通道管理 |
+| [web/src/composables/useSession.ts](web/src/composables/useSession.ts) | 会话生命周期编排 |
+| [web/src/components/tools/AskUserBubble.vue](web/src/components/tools/AskUserBubble.vue) | 用户交互表单 |

--- a/dev_docs/communication.md
+++ b/dev_docs/communication.md
@@ -195,7 +195,7 @@ interface SessionChannel {
   currentTurn: ChatTurn | null  // 当前正在进行的轮次
   error: string | null
   contextUsage: ContextUsage | null
-  reconnectTimer: Timer | null  // 断线重连定时器
+  reconnectTimer: ReturnType<typeof setTimeout> | null  // 断线重连定时器
   initialized: boolean          // 是否已初始化
 }
 ```

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -12,6 +12,7 @@
       <SessionSidebar
         :sessions="sessions"
         :active-id="sessionId"
+        :session-statuses="allSessionStatuses"
         @create="createSession"
         @switch="switchSession"
         @delete="deleteSession"
@@ -25,6 +26,7 @@
 
 <script setup lang="ts">
 import { useSession } from '@/composables/useSession'
+import { allSessionStatuses } from '@/composables/useChat'
 import SessionSidebar from '@/components/SessionSidebar.vue'
 
 const { sessionId, sessions, createSession, switchSession, deleteSession } =

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -16,13 +16,25 @@
           <span class="session-id">{{ formatId(s.session_id) }}</span>
           <span class="session-count">{{ s.message_count }} 条消息</span>
         </div>
-        <button
-          class="btn-delete"
-          @click.stop="$emit('delete', s.session_id)"
-          title="删除会话"
-        >
-          &times;
-        </button>
+        <div class="session-item-right">
+          <span
+            v-if="(sessionStatuses ?? {})[s.session_id]?.isStreaming"
+            class="status-dot streaming"
+            title="Agent 运行中"
+          />
+          <span
+            v-else-if="(sessionStatuses ?? {})[s.session_id]?.connected"
+            class="status-dot connected"
+            title="已连接"
+          />
+          <button
+            class="btn-delete"
+            @click.stop="$emit('delete', s.session_id)"
+            title="删除会话"
+          >
+            &times;
+          </button>
+        </div>
       </button>
       <div v-if="sessions.length === 0" class="no-sessions">
         暂无会话
@@ -37,6 +49,7 @@ import type { SessionInfo } from '@/types'
 defineProps<{
   sessions: SessionInfo[]
   activeId: string
+  sessionStatuses?: Record<string, { connected: boolean; isStreaming: boolean }>
 }>()
 
 defineEmits<{
@@ -148,5 +161,32 @@ function formatId(id: string): string {
   font-size: 12px;
   color: var(--text-secondary);
   padding: 8px;
+}
+
+.session-item-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-dot.connected {
+  background: #6bcf7f;
+}
+
+.status-dot.streaming {
+  background: #f5a623;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(1.3); }
 }
 </style>

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -1,4 +1,4 @@
-import { ref, reactive, watch, onUnmounted, nextTick, type Ref } from 'vue'
+import { reactive, computed, watch, nextTick, type Ref } from 'vue'
 import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, AskUserEvent } from '@/types'
 
 const TURNS_KEY_PREFIX = 'sonetto_turns_'
@@ -31,63 +31,300 @@ export function removeTurnsFromStorage(sid: string) {
   localStorage.removeItem(TURNS_KEY_PREFIX + sid)
 }
 
+export function disconnectSession(sid: string) {
+  const ch = channels.get(sid)
+  if (!ch) return
+  if (ch.reconnectTimer) {
+    clearTimeout(ch.reconnectTimer)
+    ch.reconnectTimer = null
+  }
+  ch.ws?.close()
+  ch.ws = null
+  ch.connected = false
+  ch.initialized = false
+  channels.delete(sid)
+}
+
 const turnsCache = loadAllTurnsFromStorage()
 
+// ── 多会话通道 ─────────────────────────────────────────────
+
+interface SessionChannel {
+  ws: WebSocket | null
+  connected: boolean
+  isStreaming: boolean
+  turns: ChatTurn[]
+  currentTurn: ChatTurn | null
+  error: string | null
+  contextUsage: ContextUsage | null
+  reconnectTimer: ReturnType<typeof setTimeout> | null
+  initialized: boolean
+}
+
+const channels = reactive(new Map<string, SessionChannel>())
+
+// 所有 Session 的连接/流式状态（模块级，供 sidebar 使用）
+export const allSessionStatuses = computed(() => {
+  const map: Record<string, { connected: boolean; isStreaming: boolean }> = {}
+  for (const [sid, ch] of channels) {
+    map[sid] = { connected: ch.connected, isStreaming: ch.isStreaming }
+  }
+  return map
+})
+
+function getOrCreateChannel(sid: string): SessionChannel {
+  if (!channels.has(sid)) {
+    channels.set(sid, {
+      ws: null,
+      connected: false,
+      isStreaming: false,
+      turns: [] as ChatTurn[],
+      currentTurn: null,
+      error: null,
+      contextUsage: null,
+      reconnectTimer: null,
+      initialized: false,
+    })
+  }
+  return channels.get(sid)!
+}
+
+function persistTurns(sid: string) {
+  const ch = channels.get(sid)
+  if (!ch) return
+  const snapshot = [...ch.turns]
+  turnsCache.set(sid, snapshot)
+  saveTurnsToStorage(sid, snapshot)
+}
+
+// ── WebSocket 生命周期（每 Session 独立管理） ──────────────
+
+function connectSession(sid: string) {
+  const ch = getOrCreateChannel(sid)
+  if (ch.ws?.readyState === WebSocket.OPEN) return
+
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const url = `${protocol}//${location.host}/ws/chat/${sid}`
+  ch.ws = new WebSocket(url)
+
+  ch.ws.onopen = () => {
+    ch.connected = true
+    if (ch.reconnectTimer) {
+      clearTimeout(ch.reconnectTimer)
+      ch.reconnectTimer = null
+    }
+  }
+
+  ch.ws.onclose = () => {
+    ch.connected = false
+    ch.reconnectTimer = setTimeout(() => connectSession(sid), 3000)
+  }
+
+  ch.ws.onmessage = (event) => {
+    try {
+      const msg: ServerEvent = JSON.parse(event.data)
+      console.log('[useChat] WS event received:', msg.type, 'session:', sid, msg.type === 'ask_user' ? {
+        tool_name: (msg as AskUserEvent).payload.tool_name,
+        interaction_id: (msg as AskUserEvent).payload.interaction_id,
+      } : '')
+      handleEventForChannel(sid, msg)
+    } catch (e) {
+      console.error('[useChat] WS message parse/handle error:', e)
+    }
+  }
+}
+
+function ensureConnected(sid: string) {
+  const ch = getOrCreateChannel(sid)
+  if (ch.initialized) return
+  ch.initialized = true
+  connectSession(sid)
+}
+
+// ── 事件路由 ──────────────────────────────────────────────
+
+function handleEventForChannel(sid: string, event: ServerEvent) {
+  const ch = channels.get(sid)
+  if (!ch) return
+
+  // context_usage 可以在无活跃轮次时接收（如连接初始化）
+  if (event.type === 'context_usage') {
+    ch.contextUsage = event.payload
+    return
+  }
+
+  const turn = ch.currentTurn
+  if (!turn) return
+
+  switch (event.type) {
+    case 'thinking_start':
+      turn.events.push({ kind: 'thinking', tokens: '', done: false, becameAnswer: false })
+      break
+
+    case 'token': {
+      const lastThink = findLastThinking(turn.events)
+      if (lastThink) {
+        lastThink.tokens += event.payload.token
+      }
+      break
+    }
+
+    case 'thinking_end': {
+      const lastThink = findLastThinking(turn.events)
+      if (lastThink) {
+        lastThink.done = true
+      }
+      break
+    }
+
+    case 'tool_start': {
+      console.log(`[useChat] tool_start: "${event.payload.tool_name}"`, { input: event.payload.input, session: sid })
+      turn.events.push({
+        kind: 'tool',
+        name: event.payload.tool_name,
+        input: event.payload.input,
+        output: null,
+        elapsed: null,
+        status: 'running',
+      })
+      break
+    }
+
+    case 'tool_end': {
+      const tc = findRunningTool(turn.events, event.payload.tool_name)
+      if (tc) {
+        tc.output = event.payload.output
+        tc.elapsed = event.payload.elapsed
+        tc.status = 'done'
+        if (event.payload.tool_data) {
+          tc.toolData = event.payload.tool_data
+        }
+        console.log(`[useChat] tool_end: "${event.payload.tool_name}"`, {
+          output_len: (event.payload.output || '').length,
+          output_preview: (event.payload.output || '').slice(0, 100),
+          has_tool_data: !!event.payload.tool_data,
+          elapsed: event.payload.elapsed,
+          session: sid,
+        })
+      }
+      break
+    }
+
+    case 'tool_error': {
+      const tc = findRunningTool(turn.events, event.payload.tool_name)
+      if (tc) {
+        tc.status = 'error'
+      }
+      break
+    }
+
+    case 'answer': {
+      const lastThink = findLastThinking(turn.events)
+      if (lastThink) {
+        lastThink.becameAnswer = true
+      }
+      turn.finalAnswer = event.payload.content
+      break
+    }
+
+    case 'done':
+      if (event.payload.context_usage) {
+        ch.contextUsage = event.payload.context_usage
+      }
+      if (ch.currentTurn) {
+        const lastThink = findLastThinking(ch.currentTurn.events)
+        if (lastThink?.becameAnswer) {
+          const turnToFinalize = ch.currentTurn
+          void nextTick(() => {
+            setTimeout(() => {
+              ch.turns.push(turnToFinalize)
+              ch.currentTurn = null
+              ch.isStreaming = false
+              persistTurns(sid)
+            }, 420)
+          })
+        } else {
+          ch.turns.push(ch.currentTurn)
+          ch.currentTurn = null
+          ch.isStreaming = false
+          persistTurns(sid)
+        }
+      } else {
+        ch.isStreaming = false
+      }
+      break
+
+    case 'error':
+      ch.error = event.payload.message
+      ch.isStreaming = false
+      break
+
+    case 'pong':
+      break
+
+    case 'ask_user': {
+      const ae = event as AskUserEvent
+      console.log('[useChat] received ask_user event:', {
+        tool_name: ae.payload.tool_name,
+        question: ae.payload.question?.slice(0, 50),
+        mode: ae.payload.mode,
+        interaction_id: ae.payload.interaction_id,
+        session: sid,
+      })
+      const runningTool = findRunningTool(turn.events, ae.payload.tool_name)
+      console.log('[useChat] findRunningTool result:', runningTool ? {
+        name: runningTool.name,
+        status: runningTool.status,
+        has_interaction: !!runningTool.interaction,
+      } : 'NOT FOUND')
+      if (runningTool) {
+        runningTool.interaction = {
+          question: ae.payload.question,
+          mode: ae.payload.mode,
+          options: ae.payload.options,
+          interactionId: ae.payload.interaction_id,
+          submitted: false,
+        }
+      }
+      break
+    }
+  }
+}
+
+// ── useChat composable ─────────────────────────────────────
+
 export function useChat(sessionId: Ref<string>) {
-  const ws = ref<WebSocket | null>(null)
-  const connected = ref(false)
-  const isStreaming = ref(false)
-  const turns = reactive<ChatTurn[]>([])
-  const currentTurn = ref<ChatTurn | null>(null)
-  const error = ref<string | null>(null)
-  const contextUsage = ref<ContextUsage | null>(null)
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  const activeChannel = computed(() => getOrCreateChannel(sessionId.value))
 
-  function persistTurns() {
-    const snapshot = [...turns]
-    turnsCache.set(sessionId.value, snapshot)
-    saveTurnsToStorage(sessionId.value, snapshot)
-  }
+  // 暴露给 ChatView 的响应式属性（指向当前 Session 通道）
+  const connected = computed(() => activeChannel.value.connected)
+  const isStreaming = computed(() => activeChannel.value.isStreaming)
+  const turns = computed(() => activeChannel.value.turns)
+  const currentTurn = computed(() => activeChannel.value.currentTurn)
+  const error = computed(() => activeChannel.value.error)
+  const contextUsage = computed(() => activeChannel.value.contextUsage)
 
-  function connect() {
-    if (ws.value?.readyState === WebSocket.OPEN) return
-
-    const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const url = `${protocol}//${location.host}/ws/chat/${sessionId.value}`
-
-    ws.value = new WebSocket(url)
-
-    ws.value.onopen = () => {
-      connected.value = true
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer)
-        reconnectTimer = null
+  // Session 切换：只确保新 Session 的 WS 连接，不断开旧的
+  watch(
+    sessionId,
+    (newId, oldId) => {
+      if (oldId) persistTurns(oldId)
+      ensureConnected(newId)
+      // 恢复新会话的消息缓存（页面刷新场景）
+      const cached = turnsCache.get(newId)
+      const ch = getOrCreateChannel(newId)
+      if (cached && ch.turns.length === 0) {
+        ch.turns.push(...cached)
       }
-    }
-
-    ws.value.onclose = () => {
-      connected.value = false
-      reconnectTimer = setTimeout(connect, 3000)
-    }
-
-    ws.value.onmessage = (event) => {
-      try {
-        const msg: ServerEvent = JSON.parse(event.data)
-        console.log('[useChat] WS event received:', msg.type, msg.type === 'ask_user' ? {
-          tool_name: (msg as AskUserEvent).payload.tool_name,
-          interaction_id: (msg as AskUserEvent).payload.interaction_id,
-        } : '')
-        handleEvent(msg)
-      } catch (e) {
-        console.error('[useChat] WS message parse/handle error:', e)
-      }
-    }
-  }
+    },
+    { immediate: true }
+  )
 
   function send(message: string) {
-    if (!ws.value || ws.value.readyState !== WebSocket.OPEN) return
-    isStreaming.value = true
-    error.value = null
+    const ch = activeChannel.value
+    if (!ch.ws || ch.ws.readyState !== WebSocket.OPEN) return
+    ch.isStreaming = true
+    ch.error = null
 
     const turn: ChatTurn = {
       id: crypto.randomUUID(),
@@ -95,214 +332,33 @@ export function useChat(sessionId: Ref<string>) {
       events: [],
       finalAnswer: null,
     }
-    currentTurn.value = turn
+    ch.currentTurn = turn
 
     const payload: ClientMessage = { type: 'chat', payload: { message } }
-    ws.value.send(JSON.stringify(payload))
+    ch.ws.send(JSON.stringify(payload))
   }
 
   function cancel() {
-    if (!ws.value || ws.value.readyState !== WebSocket.OPEN) return
+    const ch = activeChannel.value
+    if (!ch.ws || ch.ws.readyState !== WebSocket.OPEN) return
     const payload: ClientMessage = { type: 'cancel', payload: {} }
-    ws.value.send(JSON.stringify(payload))
+    ch.ws.send(JSON.stringify(payload))
   }
 
   function sendUserResponse(interactionId: string, response: string | string[]) {
-    if (!ws.value || ws.value.readyState !== WebSocket.OPEN) return
+    const ch = activeChannel.value
+    if (!ch.ws || ch.ws.readyState !== WebSocket.OPEN) return
     const payload: ClientMessage = {
       type: 'user_response',
       payload: { interaction_id: interactionId, response },
     }
-    ws.value.send(JSON.stringify(payload))
+    ch.ws.send(JSON.stringify(payload))
   }
 
-  function handleEvent(event: ServerEvent) {
-    // context_usage 可以在无活跃轮次时接收（如连接初始化）
-    if (event.type === 'context_usage') {
-      contextUsage.value = event.payload
-      return
-    }
-
-    const turn = currentTurn.value
-    if (!turn) return
-
-    switch (event.type) {
-      case 'thinking_start':
-        turn.events.push({ kind: 'thinking', tokens: '', done: false, becameAnswer: false })
-        break
-
-      case 'token': {
-        const lastThink = findLastThinking(turn.events)
-        if (lastThink) {
-          lastThink.tokens += event.payload.token
-        }
-        break
-      }
-
-      case 'thinking_end': {
-        const lastThink = findLastThinking(turn.events)
-        if (lastThink) {
-          lastThink.done = true
-        }
-        break
-      }
-
-      case 'tool_start': {
-        console.log(`[useChat] tool_start: "${event.payload.tool_name}"`, { input: event.payload.input })
-        turn.events.push({
-          kind: 'tool',
-          name: event.payload.tool_name,
-          input: event.payload.input,
-          output: null,
-          elapsed: null,
-          status: 'running',
-        })
-        break
-      }
-
-      case 'tool_end': {
-        const tc = findRunningTool(turn.events, event.payload.tool_name)
-        if (tc) {
-          tc.output = event.payload.output
-          tc.elapsed = event.payload.elapsed
-          tc.status = 'done'
-          if (event.payload.tool_data) {
-            tc.toolData = event.payload.tool_data
-          }
-          console.log(`[useChat] tool_end: "${event.payload.tool_name}"`, {
-            output_len: (event.payload.output || '').length,
-            output_preview: (event.payload.output || '').slice(0, 100),
-            has_tool_data: !!event.payload.tool_data,
-            tool_data_keys: event.payload.tool_data ? Object.keys(event.payload.tool_data as object) : null,
-            elapsed: event.payload.elapsed,
-          })
-        }
-        break
-      }
-
-      case 'tool_error': {
-        const tc = findRunningTool(turn.events, event.payload.tool_name)
-        if (tc) {
-          tc.status = 'error'
-        }
-        break
-      }
-
-      case 'answer': {
-        const lastThink = findLastThinking(turn.events)
-        if (lastThink) {
-          lastThink.becameAnswer = true
-        }
-        turn.finalAnswer = event.payload.content
-        break
-      }
-
-      case 'done':
-        if (event.payload.context_usage) {
-          contextUsage.value = event.payload.context_usage
-        }
-        if (currentTurn.value) {
-          const lastThink = findLastThinking(currentTurn.value.events)
-          if (lastThink?.becameAnswer) {
-            void nextTick(() => {
-              setTimeout(() => {
-                if (currentTurn.value) {
-                  turns.push(currentTurn.value)
-                  currentTurn.value = null
-                }
-                isStreaming.value = false
-                persistTurns()
-              }, 420)
-            })
-          } else {
-            turns.push(currentTurn.value)
-            currentTurn.value = null
-            isStreaming.value = false
-            persistTurns()
-          }
-        } else {
-          isStreaming.value = false
-        }
-        break
-
-      case 'error':
-        error.value = event.payload.message
-        isStreaming.value = false
-        break
-
-      case 'pong':
-        break
-
-      case 'ask_user': {
-        const ae = event as AskUserEvent
-        console.log('[useChat] received ask_user event:', {
-          tool_name: ae.payload.tool_name,
-          question: ae.payload.question?.slice(0, 50),
-          mode: ae.payload.mode,
-          interaction_id: ae.payload.interaction_id,
-        })
-        const runningTool = findRunningTool(turn.events, ae.payload.tool_name)
-        console.log('[useChat] findRunningTool result:', runningTool ? {
-          name: runningTool.name,
-          status: runningTool.status,
-          has_interaction: !!runningTool.interaction,
-        } : 'NOT FOUND')
-        if (runningTool) {
-          runningTool.interaction = {
-            question: ae.payload.question,
-            mode: ae.payload.mode,
-            options: ae.payload.options,
-            interactionId: ae.payload.interaction_id,
-            submitted: false,
-          }
-          console.log('[useChat] interaction SET on toolCall:', {
-            name: runningTool.name,
-            interactionId: runningTool.interaction.interactionId,
-          })
-        }
-        break
-      }
-    }
+  return {
+    connected, isStreaming, turns, currentTurn, error, contextUsage,
+    send, cancel, sendUserResponse,
   }
-
-  function disconnect() {
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer)
-      reconnectTimer = null
-    }
-    ws.value?.close()
-    ws.value = null
-    connected.value = false
-  }
-
-  watch(
-    sessionId,
-    (newId, oldId) => {
-      // 切出旧会话前持久化
-      if (oldId) {
-        turnsCache.set(oldId, [...turns])
-        saveTurnsToStorage(oldId, [...turns])
-      }
-      disconnect()
-      // 恢复新会话消息（优先内存缓存，其次 localStorage 已在模块加载时读入）
-      const cached = newId ? turnsCache.get(newId) : undefined
-      turns.splice(0, turns.length)
-      if (cached) {
-        turns.push(...cached)
-      }
-      currentTurn.value = null
-      error.value = null
-      contextUsage.value = null
-      if (newId) {
-        connect()
-      }
-    },
-    { immediate: true }
-  )
-
-  onUnmounted(() => disconnect())
-
-  return { connected, isStreaming, turns, currentTurn, error, contextUsage, send, cancel, sendUserResponse, connect, disconnect }
 }
 
 function findLastThinking(events: TurnEvent[]): ThinkingBlock | undefined {
@@ -323,4 +379,3 @@ function findRunningTool(events: TurnEvent[], toolName: string): ToolCall | unde
   }
   return undefined
 }
-

--- a/web/src/composables/useSession.ts
+++ b/web/src/composables/useSession.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue'
 import { api } from '@/api'
-import { removeTurnsFromStorage } from '@/composables/useChat'
+import { removeTurnsFromStorage, disconnectSession } from '@/composables/useChat'
 import type { SessionInfo } from '@/types'
 
 const STORAGE_KEY = 'sonetto_session_id'
@@ -55,6 +55,7 @@ async function switchSession(id: string) {
 
 async function deleteSession(id: string) {
   await api.deleteSession(id)
+  disconnectSession(id)
   removeTurnsFromStorage(id)
   if (sessionId.value === id) {
     await refreshSessions()

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -155,6 +155,7 @@ export interface SessionInfo {
   message_count: number
   created_at: number
   last_active?: number
+  has_active_agent?: boolean
 }
 
 export interface CreateSessionResponse {


### PR DESCRIPTION
## 修改内容

修复 `dev_docs/communication.md` 中 `SessionChannel` 接口的 `reconnectTimer` 字段类型：

- `Timer | null` → `ReturnType<typeof setTimeout> | null`

`Timer` 并非浏览器 TypeScript 标准 DOM 类型，实际代码中使用了 `ReturnType<typeof setTimeout>` 以确保在浏览器和 Node.js 两种类型环境下均能正确解析。

## 审核来源

此问题在文档事实审核中发现（`reconnectTimer` 类型与实际代码不一致）。

## 相关文件

- `dev_docs/communication.md`