### PR TITLE
fix(web): 修复空 sessionId 导致 WebSocket 403

### DIFF
--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -135,6 +135,7 @@ function connectSession(sid: string) {
 }
 
 function ensureConnected(sid: string) {
+  if (!sid) return
   const ch = getOrCreateChannel(sid)
   if (ch.initialized) return
   ch.initialized = true


### PR DESCRIPTION
## Summary

- 修复 sessionId 为空时 WebSocket 误连 `/ws/chat/` 导致 403 的问题
- `ensureConnected` 中添加空值守卫，跳过 sessionId 为空时的无效连接

## Root Cause

`sessionId` ref 初始值为 `''`，`initIfNeeded()` 是异步 API 调用，但 `useChat` 的 `watch({ immediate: true })` 在初始化完成前就触发，导致 `ensureConnected('')` → `connectSession('')` → 连接无 session_id 的 `/ws/chat/` 路径，后端路由不匹配返回 403。

## Test Plan

- [ ] 确认应用启动后不再有 `"WebSocket /ws/chat/" 403` 日志
- [ ] 确认正常 session 的 WebSocket 连接不受影响