### PR TITLE
fix(web): 修复对话结束后侧边栏消息数不刷新的问题

### DIFF
--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -1,5 +1,6 @@
 import { reactive, computed, watch, nextTick, type Ref } from 'vue'
 import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, AskUserEvent } from '@/types'
+import { refreshSessions } from '@/composables/useSession'
 
 const TURNS_KEY_PREFIX = 'sonetto_turns_'
 
@@ -250,6 +251,7 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
           ch.isStreaming = false
           persistTurns(sid)
         }
+        void refreshSessions()  // 轮次结束，刷新会话列表以更新 message_count
       } else {
         ch.isStreaming = false
       }

--- a/web/src/composables/useSession.ts
+++ b/web/src/composables/useSession.ts
@@ -28,7 +28,7 @@ async function initIfNeeded() {
   await refreshSessions()
 }
 
-async function refreshSessions() {
+export async function refreshSessions() {
   try {
     const res = await api.listSessions()
     sessions.value = res.sessions


### PR DESCRIPTION
## Summary

- 导出 `useSession.ts` 中的 `refreshSessions`，在 `useChat.ts` 的 `done` 事件处理中调用
- 对话轮次完成后，侧边栏的 `session-count` 无需手动刷新即可自动更新

## Test plan

1. 开始一个新对话，发送一条消息
2. Agent 回复完成后，侧边栏该会话的 `message_count` 应自动递增为 2
3. 再次发送消息，完成后 `message_count` 应递增为 4
4. 切换会话再切回，数据应保持一致