### PR TITLE
fix(kaleidoscope): KEP修复—冗余spinner与Todoist任务名

### DIFF
--- a/skills/todo/skill_complete.py
+++ b/skills/todo/skill_complete.py
@@ -36,9 +36,14 @@ class TodoCompleteSkill(SkillBase):
             return format_error(str(e))
 
         try:
+            current_task = api.get_task(task_id)
             ok = api.complete_task(task_id)
             if ok:
-                return format_success({"task_id": task_id, "message": "任务已标记为完成"})
+                return format_success({
+                    "task_id": task_id,
+                    "content": current_task.content,
+                    "message": "任务已标记为完成",
+                })
             return format_error("标记任务完成失败")
         except Exception as e:
             return format_error(f"任务不存在或完成失败: {e}")

--- a/skills/todo/skill_uncomplete.py
+++ b/skills/todo/skill_uncomplete.py
@@ -36,9 +36,14 @@ class TodoUncompleteSkill(SkillBase):
             return format_error(str(e))
 
         try:
+            current_task = api.get_task(task_id)
             ok = api.uncomplete_task(task_id)
             if ok:
-                return format_success({"task_id": task_id, "message": "任务已重新打开"})
+                return format_success({
+                    "task_id": task_id,
+                    "content": current_task.content,
+                    "message": "任务已重新打开",
+                })
             return format_error("重新打开任务失败")
         except Exception as e:
             return format_error(f"任务不存在或重新打开失败: {e}")

--- a/web/src/components/tools/AnswerBookBubble.vue
+++ b/web/src/components/tools/AnswerBookBubble.vue
@@ -1,7 +1,6 @@
 <template>
   <BubbleChrome :tool-call="toolCall">
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>翻阅答案之书...</span>
     </div>
 

--- a/web/src/components/tools/AskUserBubble.vue
+++ b/web/src/components/tools/AskUserBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 等待交互数据到达 -->
     <div v-if="toolCall.status === 'running' && !submitted && !interactionData.interactionId" class="ask-waiting">
-      <span class="spinner"></span>
       <span>等待询问...</span>
     </div>
 
@@ -80,7 +79,6 @@
 
     <!-- 已提交，等待回复 -->
     <div v-else-if="toolCall.status === 'running' && submitted" class="ask-waiting">
-      <span class="spinner"></span>
       <span>已提交，等待回复...</span>
     </div>
 
@@ -309,17 +307,6 @@ function submitMulti() {
   font-size: 13px;
   color: var(--text-secondary);
 }
-.spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent);
-  border-radius: 50%;
-  animation: spin 0.6s linear infinite;
-  flex-shrink: 0;
-}
-@keyframes spin { to { transform: rotate(360deg); } }
-
 /* 错误 */
 .ask-error {
   font-size: 13px;

--- a/web/src/components/tools/BilibiliDownloadBubble.vue
+++ b/web/src/components/tools/BilibiliDownloadBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 下载中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>正在下载视频...</span>
     </div>
 

--- a/web/src/components/tools/CodeQualityBubble.vue
+++ b/web/src/components/tools/CodeQualityBubble.vue
@@ -1,7 +1,6 @@
 <template>
   <BubbleChrome :tool-call="toolCall">
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>分析代码质量...</span>
     </div>
 

--- a/web/src/components/tools/CookieBubble.vue
+++ b/web/src/components/tools/CookieBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>正在设置 Cookie...</span>
     </div>
 

--- a/web/src/components/tools/DebuggerBubble.vue
+++ b/web/src/components/tools/DebuggerBubble.vue
@@ -1,7 +1,6 @@
 <template>
   <BubbleChrome :tool-call="toolCall">
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>执行调试...</span>
     </div>
 

--- a/web/src/components/tools/DocReaderBubble.vue
+++ b/web/src/components/tools/DocReaderBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>{{ runningLabel }}</span>
     </div>
 

--- a/web/src/components/tools/FilesBubble.vue
+++ b/web/src/components/tools/FilesBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>{{ runningLabel }}</span>
     </div>
 

--- a/web/src/components/tools/HolidayBubble.vue
+++ b/web/src/components/tools/HolidayBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>{{ isDateMode ? '查询节日...' : '查询日历...' }}</span>
     </div>
 

--- a/web/src/components/tools/MapBubble.vue
+++ b/web/src/components/tools/MapBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>{{ runningLabel }}</span>
     </div>
 

--- a/web/src/components/tools/PdfReaderBubble.vue
+++ b/web/src/components/tools/PdfReaderBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>{{ runningLabel }}</span>
     </div>
 

--- a/web/src/components/tools/PythonBubble.vue
+++ b/web/src/components/tools/PythonBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>正在执行代码...</span>
     </div>
 

--- a/web/src/components/tools/ScraperBubble.vue
+++ b/web/src/components/tools/ScraperBubble.vue
@@ -1,7 +1,6 @@
 <template>
   <BubbleChrome :tool-call="toolCall">
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>抓取网页...</span>
     </div>
 
@@ -166,8 +165,7 @@ const displayOutput = computed(() => {
 
 <style scoped>
 .bubble-running { display: flex; align-items: center; gap: 8px; padding: 8px 0; font-size: 13px; color: var(--text-secondary); }
-.spinner { width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: spin 0.6s linear infinite; flex-shrink: 0; }
-@keyframes spin { to { transform: rotate(360deg); } }
+
 .bubble-error { font-size: 13px; color: #b91c1c; padding: 4px 0; }
 
 .sc-result { display: flex; flex-direction: column; gap: 12px; padding: 4px 0; }

--- a/web/src/components/tools/SyntaxBubble.vue
+++ b/web/src/components/tools/SyntaxBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>正在检查语法...</span>
     </div>
 

--- a/web/src/components/tools/TarotBubble.vue
+++ b/web/src/components/tools/TarotBubble.vue
@@ -1,7 +1,6 @@
 <template>
   <BubbleChrome :tool-call="toolCall">
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>塔罗占卜中...</span>
     </div>
 

--- a/web/src/components/tools/TaskTrackerBubble.vue
+++ b/web/src/components/tools/TaskTrackerBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>正在追踪任务...</span>
     </div>
 

--- a/web/src/components/tools/TimeBubble.vue
+++ b/web/src/components/tools/TimeBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>获取时间...</span>
     </div>
 

--- a/web/src/components/tools/TodoBubble.vue
+++ b/web/src/components/tools/TodoBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>正在操作 Todoist...</span>
     </div>
 

--- a/web/src/components/tools/UnitTestBubble.vue
+++ b/web/src/components/tools/UnitTestBubble.vue
@@ -1,7 +1,6 @@
 <template>
   <BubbleChrome :tool-call="toolCall">
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>运行单元测试...</span>
     </div>
 

--- a/web/src/components/tools/WeatherBubble.vue
+++ b/web/src/components/tools/WeatherBubble.vue
@@ -2,7 +2,6 @@
   <BubbleChrome :tool-call="toolCall">
     <!-- 运行中 -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span class="spinner"></span>
       <span>正在查询天气...</span>
     </div>
 


### PR DESCRIPTION
## 修复内容

根据 KEP 审查结果，修复以下两个问题：

### 1. 移除气泡 body 中冗余的加载转圈
BubbleChrome 的 header 在 `running` 状态下已有一个 10px spinner，但所有气泡的 body 也各自画了一个，导致上下双圈同时旋转。移除了 19 个气泡 body 中的 `<span class="spinner"></span>`，仅保留文字提示。

### 2. 修复 Todoist 完成任务时显示"未命名任务"
`skill_complete.py` 和 `skill_uncomplete.py` 执行操作前先调用 `get_task()` 获取任务名，将 `content` 字段纳入响应，确保前端气泡能正确显示原任务名。