### PR TITLE
feat(api): 每轮工具执行后实时推送上下文用量

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -31,12 +31,16 @@ def _get_final_answer(event) -> str:
     return final_answer
 
 
-async def _stream_turn(graph, inputs, config) -> str:
+async def _stream_turn(graph, inputs, config, ws, session, system_prompt) -> str:
     """流式执行 Agent 图，返回最终回答。"""
     final_answer = ""
     async for event in graph.astream_events(inputs, config=config, version="v2"):
         if event.get("event") == "on_chain_end" and event.get("name") == "agent":
             final_answer = _get_final_answer(event)
+        # 一轮工具执行完毕，ToolMessage 已写入 checkpoint，推送上下文用量
+        if event.get("event") == "on_chain_end" and event.get("name") == "tools":
+            usage = await _calculate_context_usage(session, system_prompt)
+            await ws.send_json({"type": "context_usage", "payload": usage})
     return final_answer
 
 
@@ -105,7 +109,11 @@ async def _run_agent_turn(
     # 2. [执行轮次] 流式执行 Agent 图，副作用推送最终回答，另有config回调副作用
     final_answer = ""
     try:
-        final_answer = await _stream_turn(agent_sonetto, inputs, config)  # 核心运算 执行 Agent 图，返回最终回答，以config回调作为副作用
+        # turn 开始时推送当前上下文用量（含刚加入的 user message）
+        initial_turn_usage = await _calculate_context_usage(session, system_prompt)
+        await ws.send_json({"type": "context_usage", "payload": initial_turn_usage})
+
+        final_answer = await _stream_turn(agent_sonetto, inputs, config, ws, session, system_prompt)
         await ws.send_json({                                                # [向前端通信] 1. 向客户端推送最终答案
             "type": "answer",
             "payload": {"content": final_answer}


### PR DESCRIPTION
## Summary

- 上下文用量之前仅在 turn 结束时通过 `done` 事件推送一次
- 新增 turn 开始时推送（含刚加入的 user message，反映最新基数）
- 在 `_stream_turn` 中检测 `on_chain_end(name="tools")` 事件，每轮工具执行完后推送

## Performance

每次推送开销约 5-10ms（`aget_tuple` + tiktoken encode），对于 LLM 推理的数秒级耗时可忽略。

## Test plan

1. 启动后端，发送需要多轮工具调用的请求（如\“逐一读取 dev_docs 下所有文件\”）
2. 观察前端 context_usage 是否在每轮工具执行后更新