### PR TITLE
feat(web): 会话状态灯增加等待用户输入态（橙色脉冲）

### DIFF
--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -18,7 +18,12 @@
         </div>
         <div class="session-item-right">
           <span
-            v-if="(sessionStatuses ?? {})[s.session_id]?.isStreaming"
+            v-if="(sessionStatuses ?? {})[s.session_id]?.isAwaitingUser"
+            class="status-dot awaiting-user"
+            title="等待用户输入"
+          />
+          <span
+            v-else-if="(sessionStatuses ?? {})[s.session_id]?.isStreaming"
             class="status-dot streaming"
             title="Agent 运行中"
           />
@@ -49,7 +54,7 @@ import type { SessionInfo } from '@/types'
 defineProps<{
   sessions: SessionInfo[]
   activeId: string
-  sessionStatuses?: Record<string, { connected: boolean; isStreaming: boolean }>
+  sessionStatuses?: Record<string, { connected: boolean; isStreaming: boolean; isAwaitingUser: boolean }>
 }>()
 
 defineEmits<{
@@ -181,6 +186,11 @@ function formatId(id: string): string {
 }
 
 .status-dot.streaming {
+  background: #22c55e;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.status-dot.awaiting-user {
   background: #f59e0b;
   animation: pulse 1.2s ease-in-out infinite;
 }

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -54,21 +54,23 @@ interface SessionChannel {
   ws: WebSocket | null
   connected: boolean
   isStreaming: boolean
+  isAwaitingUser: boolean
   turns: ChatTurn[]
   currentTurn: ChatTurn | null
   error: string | null
   contextUsage: ContextUsage | null
   reconnectTimer: ReturnType<typeof setTimeout> | null
   initialized: boolean
+  _awaitingToolName: string | null
 }
 
 const channels = reactive(new Map<string, SessionChannel>())
 
 // 所有 Session 的连接/流式状态（模块级，供 sidebar 使用）
 export const allSessionStatuses = computed(() => {
-  const map: Record<string, { connected: boolean; isStreaming: boolean }> = {}
+  const map: Record<string, { connected: boolean; isStreaming: boolean; isAwaitingUser: boolean }> = {}
   for (const [sid, ch] of channels) {
-    map[sid] = { connected: ch.connected, isStreaming: ch.isStreaming }
+    map[sid] = { connected: ch.connected, isStreaming: ch.isStreaming, isAwaitingUser: ch.isAwaitingUser }
   }
   return map
 })
@@ -79,12 +81,14 @@ function getOrCreateChannel(sid: string): SessionChannel {
       ws: null,
       connected: false,
       isStreaming: false,
+      isAwaitingUser: false,
       turns: [] as ChatTurn[],
       currentTurn: null,
       error: null,
       contextUsage: null,
       reconnectTimer: null,
       initialized: false,
+      _awaitingToolName: null,
     })
   }
   return channels.get(sid)!
@@ -209,6 +213,11 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
           session: sid,
         })
       }
+      // ask_user 工具执行完毕 → 用户已回应，回到工作态
+      if (ch.isAwaitingUser && event.payload.tool_name === ch._awaitingToolName) {
+        ch.isAwaitingUser = false
+        ch._awaitingToolName = null
+      }
       break
     }
 
@@ -230,6 +239,8 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
     }
 
     case 'done':
+      ch.isAwaitingUser = false
+      ch._awaitingToolName = null
       if (event.payload.context_usage) {
         ch.contextUsage = event.payload.context_usage
       }
@@ -258,6 +269,8 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
       break
 
     case 'error':
+      ch.isAwaitingUser = false
+      ch._awaitingToolName = null
       ch.error = event.payload.message
       ch.isStreaming = false
       break
@@ -267,6 +280,8 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
 
     case 'ask_user': {
       const ae = event as AskUserEvent
+      ch.isAwaitingUser = true
+      ch._awaitingToolName = ae.payload.tool_name
       console.log('[useChat] received ask_user event:', {
         tool_name: ae.payload.tool_name,
         question: ae.payload.question?.slice(0, 50),


### PR DESCRIPTION
## Summary

- 新增 `isAwaitingUser` 状态：ask_user 事件触发时设为 true，工具执行完毕时清空
- 状态灯三态：绿色常亮（已连接）、绿色脉冲（Agent 工作）、橙色脉冲（等待用户输入）
- 三种 ask_user 模式（qa/single_choice/multi_choice）均通过同一事件触发，全部覆盖

## Test plan

1. 触发普通 Agent 对话 → 绿色脉冲
2. 触发 ask_user 交互（任意模式）→ 橙色脉冲
3. 用户回应后 → 回到绿色脉冲
4. Turn 结束 → 绿色常亮