### PR TITLE
feat(web): 会话列表悬停显示详情卡片

### DIFF
--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -48,30 +48,32 @@
       </div>
     </div>
 
-    <div v-if="hoveredSession" ref="hoverCardRef" class="session-hover-card" :style="cardStyle">
-      <div class="card-row">
-        <span class="card-label">ID</span>
-        <span class="card-value">{{ hoveredSession.session_id }}</span>
+    <Transition name="card">
+      <div v-if="hoveredSession" :key="hoveredSession.session_id" ref="hoverCardRef" class="session-hover-card" :style="cardStyle">
+        <div class="card-row">
+          <span class="card-label">ID</span>
+          <span class="card-value">{{ hoveredSession.session_id }}</span>
+        </div>
+        <div class="card-row">
+          <span class="card-label">消息</span>
+          <span class="card-value">{{ hoveredSession.message_count }}</span>
+        </div>
+        <div class="card-divider"></div>
+        <div class="card-row">
+          <span class="card-label">创建时间</span>
+          <span class="card-value">{{ formatRelativeTime(hoveredSession.created_at) }}</span>
+        </div>
+        <div class="card-row" v-if="hoveredSession.last_active">
+          <span class="card-label">最近活跃</span>
+          <span class="card-value">{{ formatRelativeTime(hoveredSession.last_active) }}</span>
+        </div>
+        <div class="card-divider" v-if="hoveredSession.last_active"></div>
+        <div class="card-row">
+          <span class="card-label">Agent</span>
+          <span class="card-value">{{ getAgentStatus(hoveredSession.session_id) }}</span>
+        </div>
       </div>
-      <div class="card-row">
-        <span class="card-label">消息</span>
-        <span class="card-value">{{ hoveredSession.message_count }}</span>
-      </div>
-      <div class="card-divider"></div>
-      <div class="card-row">
-        <span class="card-label">创建时间</span>
-        <span class="card-value">{{ formatRelativeTime(hoveredSession.created_at) }}</span>
-      </div>
-      <div class="card-row" v-if="hoveredSession.last_active">
-        <span class="card-label">最近活跃</span>
-        <span class="card-value">{{ formatRelativeTime(hoveredSession.last_active) }}</span>
-      </div>
-      <div class="card-divider" v-if="hoveredSession.last_active"></div>
-      <div class="card-row">
-        <span class="card-label">Agent</span>
-        <span class="card-value">{{ getAgentStatus(hoveredSession.session_id) }}</span>
-      </div>
-    </div>
+    </Transition>
   </div>
 </template>
 
@@ -335,5 +337,15 @@ const cardStyle = computed(() => {
   height: 1px;
   background: var(--border);
   margin: 4px 0;
+}
+
+.card-enter-active,
+.card-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.card-enter-from,
+.card-leave-to {
+  opacity: 0;
+  transform: translateX(-8px);
 }
 </style>

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -40,25 +40,6 @@
             &times;
           </button>
         </div>
-        <div class="tooltip-card">
-          <div class="card-row">
-            <span class="card-label">创建时间</span>
-            <span class="card-value">{{ formatTime(s.created_at) }}</span>
-          </div>
-          <div v-if="s.last_active" class="card-row">
-            <span class="card-label">最后活跃</span>
-            <span class="card-value">{{ relativeTime(s.last_active) }}</span>
-          </div>
-          <div class="card-divider"></div>
-          <div class="card-row">
-            <span class="card-label">消息数</span>
-            <span class="card-value">{{ s.message_count }}</span>
-          </div>
-          <div class="card-row">
-            <span class="card-label">状态</span>
-            <span class="card-value">{{ statusText(s.session_id) }}</span>
-          </div>
-        </div>
       </button>
       <div v-if="sessions.length === 0" class="no-sessions">
         暂无会话
@@ -70,7 +51,7 @@
 <script setup lang="ts">
 import type { SessionInfo } from '@/types'
 
-const props = defineProps<{
+defineProps<{
   sessions: SessionInfo[]
   activeId: string
   sessionStatuses?: Record<string, { connected: boolean; isStreaming: boolean; isAwaitingUser: boolean }>
@@ -84,31 +65,6 @@ defineEmits<{
 
 function formatId(id: string): string {
   return id.length > 10 ? id.slice(0, 10) + '…' : id
-}
-
-function formatTime(ts: number): string {
-  const d = new Date(ts * 1000)
-  const pad = (n: number) => n.toString().padStart(2, '0')
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
-
-function relativeTime(ts: number): string {
-  const diff = Math.floor((Date.now() / 1000 - ts) / 60)
-  if (diff < 1) return '刚刚'
-  if (diff < 60) return `${diff} 分钟前`
-  const hours = Math.floor(diff / 60)
-  if (hours < 24) return `${hours} 小时前`
-  const days = Math.floor(hours / 24)
-  return `${days} 天前`
-}
-
-function statusText(sessionId: string): string {
-  const st = props.sessionStatuses?.[sessionId]
-  if (!st) return '断开'
-  if (st.isAwaitingUser) return '等待用户输入'
-  if (st.isStreaming) return 'Agent 运行中'
-  if (st.connected) return '就绪'
-  return '断开'
 }
 </script>
 
@@ -164,7 +120,6 @@ function statusText(sessionId: string): string {
   cursor: pointer;
   text-align: left;
   font-family: inherit;
-  position: relative;
   transition: background 0.15s;
 }
 .session-item:hover {
@@ -238,54 +193,6 @@ function statusText(sessionId: string): string {
 .status-dot.awaiting-user {
   background: #f59e0b;
   animation: pulse 1.2s ease-in-out infinite;
-}
-
-.tooltip-card {
-  visibility: hidden;
-  opacity: 0;
-  transform: translateX(-4px);
-  transition: visibility 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
-  pointer-events: none;
-  position: absolute;
-  left: calc(100% + 8px);
-  top: 0;
-  z-index: 100;
-  min-width: 160px;
-  padding: 8px 12px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  font-size: 12px;
-  line-height: 1.6;
-  white-space: nowrap;
-}
-
-.session-item:hover .tooltip-card {
-  visibility: visible;
-  opacity: 1;
-  transform: translateX(0);
-}
-
-.card-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.card-label {
-  color: var(--text-secondary);
-}
-
-.card-value {
-  font-variant-numeric: tabular-nums;
-  color: var(--text-primary);
-}
-
-.card-divider {
-  height: 1px;
-  background: var(--border);
-  margin: 4px 0;
 }
 
 @keyframes pulse {

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -11,6 +11,8 @@
         class="session-item"
         :class="{ active: s.session_id === activeId }"
         @click="$emit('switch', s.session_id)"
+        @mouseenter="onSessionMouseEnter($event, s)"
+        @mouseleave="onSessionMouseLeave"
       >
         <div class="session-item-main">
           <span class="session-id">{{ formatId(s.session_id) }}</span>
@@ -45,10 +47,36 @@
         暂无会话
       </div>
     </div>
+
+    <div v-if="hoveredSession" ref="hoverCardRef" class="session-hover-card" :style="cardStyle">
+      <div class="card-row">
+        <span class="card-label">ID</span>
+        <span class="card-value">{{ hoveredSession.session_id }}</span>
+      </div>
+      <div class="card-row">
+        <span class="card-label">消息</span>
+        <span class="card-value">{{ hoveredSession.message_count }}</span>
+      </div>
+      <div class="card-divider"></div>
+      <div class="card-row">
+        <span class="card-label">创建时间</span>
+        <span class="card-value">{{ formatDate(hoveredSession.created_at) }}</span>
+      </div>
+      <div class="card-row" v-if="hoveredSession.last_active">
+        <span class="card-label">最近活跃</span>
+        <span class="card-value">{{ formatDate(hoveredSession.last_active) }}</span>
+      </div>
+      <div class="card-divider" v-if="hoveredSession.last_active"></div>
+      <div class="card-row">
+        <span class="card-label">Agent 运行中</span>
+        <span class="card-value">{{ hoveredSession.has_active_agent ? '是' : '否' }}</span>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, computed, nextTick } from 'vue'
 import type { SessionInfo } from '@/types'
 
 defineProps<{
@@ -63,9 +91,69 @@ defineEmits<{
   delete: [id: string]
 }>()
 
+const hoveredSession = ref<SessionInfo | null>(null)
+const hoverCardRef = ref<HTMLElement | null>(null)
+const cardTop = ref(0)
+const cardLeft = ref(0)
+
+let hoverLeaveTimer: ReturnType<typeof setTimeout> | null = null
+
 function formatId(id: string): string {
   return id.length > 10 ? id.slice(0, 10) + '…' : id
 }
+
+function formatDate(ts: number): string {
+  return new Date(ts * 1000).toLocaleString()
+}
+
+function onSessionMouseEnter(event: MouseEvent, session: SessionInfo) {
+  if (hoverLeaveTimer !== null) {
+    clearTimeout(hoverLeaveTimer)
+    hoverLeaveTimer = null
+  }
+  const button = event.currentTarget as HTMLElement
+  const rect = button.getBoundingClientRect()
+  cardTop.value = rect.top
+  cardLeft.value = rect.right + 8
+  hoveredSession.value = session
+  nextTick(() => adjustCardPosition(rect))
+}
+
+function onSessionMouseLeave() {
+  if (hoverLeaveTimer !== null) clearTimeout(hoverLeaveTimer)
+  hoverLeaveTimer = setTimeout(() => {
+    hoveredSession.value = null
+  }, 150)
+}
+
+function adjustCardPosition(buttonRect: DOMRect) {
+  const cardEl = hoverCardRef.value
+  if (!cardEl || !hoveredSession.value) return
+  const cardWidth = cardEl.offsetWidth
+  const cardHeight = cardEl.offsetHeight
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+  const margin = 8
+
+  if (cardLeft.value + cardWidth > vw - margin) {
+    const leftPos = buttonRect.left - cardWidth - margin
+    cardLeft.value = leftPos >= margin ? leftPos : Math.max(margin, vw - cardWidth - margin)
+  }
+  if (cardTop.value + cardHeight > vh - margin) {
+    cardTop.value = Math.max(margin, vh - cardHeight - margin)
+  }
+}
+
+const cardStyle = computed(() => {
+  if (!hoveredSession.value) return {}
+  return {
+    position: 'fixed' as const,
+    top: `${cardTop.value}px`,
+    left: `${cardLeft.value}px`,
+    zIndex: 100,
+    pointerEvents: 'none' as const,
+  }
+})
 </script>
 
 <style scoped>
@@ -198,5 +286,38 @@ function formatId(id: string): string {
 @keyframes pulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.5; transform: scale(1.3); }
+}
+
+/* ── Hover card ── */
+.session-hover-card {
+  min-width: 220px;
+  padding: 8px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+.card-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+.card-label {
+  color: var(--text-secondary);
+}
+.card-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.card-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
 }
 </style>

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -40,6 +40,25 @@
             &times;
           </button>
         </div>
+        <div class="tooltip-card">
+          <div class="card-row">
+            <span class="card-label">创建时间</span>
+            <span class="card-value">{{ formatTime(s.created_at) }}</span>
+          </div>
+          <div v-if="s.last_active" class="card-row">
+            <span class="card-label">最后活跃</span>
+            <span class="card-value">{{ relativeTime(s.last_active) }}</span>
+          </div>
+          <div class="card-divider"></div>
+          <div class="card-row">
+            <span class="card-label">消息数</span>
+            <span class="card-value">{{ s.message_count }}</span>
+          </div>
+          <div class="card-row">
+            <span class="card-label">状态</span>
+            <span class="card-value">{{ statusText(s.session_id) }}</span>
+          </div>
+        </div>
       </button>
       <div v-if="sessions.length === 0" class="no-sessions">
         暂无会话
@@ -51,7 +70,7 @@
 <script setup lang="ts">
 import type { SessionInfo } from '@/types'
 
-defineProps<{
+const props = defineProps<{
   sessions: SessionInfo[]
   activeId: string
   sessionStatuses?: Record<string, { connected: boolean; isStreaming: boolean; isAwaitingUser: boolean }>
@@ -65,6 +84,31 @@ defineEmits<{
 
 function formatId(id: string): string {
   return id.length > 10 ? id.slice(0, 10) + '…' : id
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts * 1000)
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+function relativeTime(ts: number): string {
+  const diff = Math.floor((Date.now() / 1000 - ts) / 60)
+  if (diff < 1) return '刚刚'
+  if (diff < 60) return `${diff} 分钟前`
+  const hours = Math.floor(diff / 60)
+  if (hours < 24) return `${hours} 小时前`
+  const days = Math.floor(hours / 24)
+  return `${days} 天前`
+}
+
+function statusText(sessionId: string): string {
+  const st = props.sessionStatuses?.[sessionId]
+  if (!st) return '断开'
+  if (st.isAwaitingUser) return '等待用户输入'
+  if (st.isStreaming) return 'Agent 运行中'
+  if (st.connected) return '就绪'
+  return '断开'
 }
 </script>
 
@@ -120,6 +164,7 @@ function formatId(id: string): string {
   cursor: pointer;
   text-align: left;
   font-family: inherit;
+  position: relative;
   transition: background 0.15s;
 }
 .session-item:hover {
@@ -193,6 +238,54 @@ function formatId(id: string): string {
 .status-dot.awaiting-user {
   background: #f59e0b;
   animation: pulse 1.2s ease-in-out infinite;
+}
+
+.tooltip-card {
+  visibility: hidden;
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: visibility 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 0;
+  z-index: 100;
+  min-width: 160px;
+  padding: 8px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+
+.session-item:hover .tooltip-card {
+  visibility: visible;
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.card-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.card-label {
+  color: var(--text-secondary);
+}
+
+.card-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.card-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
 }
 
 @keyframes pulse {

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -60,16 +60,16 @@
       <div class="card-divider"></div>
       <div class="card-row">
         <span class="card-label">创建时间</span>
-        <span class="card-value">{{ formatDate(hoveredSession.created_at) }}</span>
+        <span class="card-value">{{ formatRelativeTime(hoveredSession.created_at) }}</span>
       </div>
       <div class="card-row" v-if="hoveredSession.last_active">
         <span class="card-label">最近活跃</span>
-        <span class="card-value">{{ formatDate(hoveredSession.last_active) }}</span>
+        <span class="card-value">{{ formatRelativeTime(hoveredSession.last_active) }}</span>
       </div>
       <div class="card-divider" v-if="hoveredSession.last_active"></div>
       <div class="card-row">
-        <span class="card-label">Agent 运行中</span>
-        <span class="card-value">{{ hoveredSession.has_active_agent ? '是' : '否' }}</span>
+        <span class="card-label">Agent</span>
+        <span class="card-value">{{ getAgentStatus(hoveredSession.session_id) }}</span>
       </div>
     </div>
   </div>
@@ -79,7 +79,7 @@
 import { ref, computed, nextTick } from 'vue'
 import type { SessionInfo } from '@/types'
 
-defineProps<{
+const props = defineProps<{
   sessions: SessionInfo[]
   activeId: string
   sessionStatuses?: Record<string, { connected: boolean; isStreaming: boolean; isAwaitingUser: boolean }>
@@ -102,8 +102,24 @@ function formatId(id: string): string {
   return id.length > 10 ? id.slice(0, 10) + '…' : id
 }
 
-function formatDate(ts: number): string {
-  return new Date(ts * 1000).toLocaleString()
+function formatRelativeTime(ts: number): string {
+  const diff = Date.now() - ts * 1000
+  const minutes = Math.floor(diff / 60000)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+  if (minutes < 1) return '刚刚'
+  if (minutes < 60) return `${minutes}分钟前`
+  if (hours < 24) return `${hours}小时前`
+  if (days < 7) return `${days}天前`
+  return new Date(ts * 1000).toLocaleDateString()
+}
+
+function getAgentStatus(sessionId: string): string {
+  const status = props.sessionStatuses?.[sessionId]
+  if (!status?.connected) return '就绪'
+  if (status.isAwaitingUser) return '需处理'
+  if (status.isStreaming) return '工作中'
+  return '就绪'
 }
 
 function onSessionMouseEnter(event: MouseEvent, session: SessionInfo) {


### PR DESCRIPTION
## Summary

- 鼠标悬停左侧会话时弹出详情卡片，显示完整 session ID、消息数、创建时间、最近活跃、Agent 状态
- 使用 `position: fixed` 避免 `overflow` 裁剪，150ms 防抖防止快速划过时闪烁
- Agent 状态三态：工作中（流式输出）、需处理（等待用户）、就绪（已连接空闲）
- 时间显示为相对时间（刚刚、X分钟前、X小时前、X天前）
- 使用 Vue Transition 实现向右弹出/缩回动画
- 卡片视觉风格与上下文用量弹窗一致

## Test plan

- 悬停会话查看卡片弹出，切换会话观察过渡动画
- 验证 Agent 三态显示与状态灯一致
- 验证视口边缘卡片位置自适应
- 验证快速划过多个会话无闪烁