### PR TITLE
feat(web,api): 模型名悬停显示DeepSeek余额弹窗

### DIFF
--- a/api/routes/balance.py
+++ b/api/routes/balance.py
@@ -1,0 +1,32 @@
+"""DeepSeek 余额查询"""
+
+import httpx
+from fastapi import APIRouter, HTTPException
+
+from config.settings import get_settings
+
+router = APIRouter()
+
+DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance"
+
+@router.get("/deepseek-balance")
+async def get_deepseek_balance():
+    settings = get_settings()
+    if not settings.deepseek_api_key:
+        raise HTTPException(status_code=400, detail="DeepSeek API key not set")
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {settings.deepseek_api_key}",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.get(DEEPSEEK_BALANCE_URL, headers=headers)
+            data = response.json()
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="DeepSeek API timeout")
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=500, detail=f"DeepSeek API error:{e}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"DeepSeek API error:{e}")
+    return data
+

--- a/api/server.py
+++ b/api/server.py
@@ -9,7 +9,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
 from api.dependencies import get_llm, get_system_prompt, get_tools
-from api.routes import chat, files, memory, sessions
+from api.routes import chat, files, memory, sessions, balance
 from api.session_manager import SessionManager
 from memory.narrative import MEMORY_PATH, LongTermMemoryInterface
 from version import __version__
@@ -52,6 +52,7 @@ def create_app() -> FastAPI:
     app.include_router(sessions.router, prefix="/api")
     app.include_router(memory.router, prefix="/api")
     app.include_router(files.router, prefix="/api")
+    app.include_router(balance.router, prefix="/api")
 
     # WebSocket 路由（无 /api 前缀）
     app.include_router(chat.router)

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -4,6 +4,7 @@ import type {
   SessionInfo,
   NarrativeResponse,
   ContextUsage,
+  DeepSeekBalanceResponse,
 } from '@/types'
 
 const BASE = '/api'
@@ -37,4 +38,7 @@ export const api = {
 
   getContextUsage: (sessionId: string) =>
     request<ContextUsage & { session_id: string }>(`/sessions/${sessionId}/context-usage`),
+
+  getDeepSeekBalance: () =>
+    request<DeepSeekBalanceResponse>('/deepseek-balance'),
 }

--- a/web/src/components/ContextUsageBadge.vue
+++ b/web/src/components/ContextUsageBadge.vue
@@ -1,50 +1,101 @@
 <template>
   <div v-if="usage" class="context-usage" :class="level">
-    <svg class="ring" viewBox="0 0 32 32">
-      <circle
-        class="ring-bg"
-        cx="16" cy="16" r="13"
-        fill="none"
-        stroke-width="3"
-      />
-      <circle
-        class="ring-fill"
-        cx="16" cy="16" r="13"
-        fill="none"
-        stroke-width="3"
-        stroke-linecap="round"
-        :stroke-dasharray="circumference"
-        :stroke-dashoffset="dashOffset"
-      />
-    </svg>
-    <span class="label">{{ Math.round(usage.usage_percent) }}%</span>
-    <span class="model-name">{{ usage.model_name }}</span>
 
-    <div class="hover-card">
-      <div class="card-row">
-        <span class="card-label">Current</span>
-        <span class="card-value">{{ formatTokens(usage.current_tokens) }}</span>
+    <!-- 圆环 + 用量百分比 → 用量弹窗 -->
+    <span class="ring-group hover-trigger">
+      <svg class="ring" viewBox="0 0 32 32">
+        <circle
+          class="ring-bg"
+          cx="16" cy="16" r="13"
+          fill="none"
+          stroke-width="3"
+        />
+        <circle
+          class="ring-fill"
+          cx="16" cy="16" r="13"
+          fill="none"
+          stroke-width="3"
+          stroke-linecap="round"
+          :stroke-dasharray="circumference"
+          :stroke-dashoffset="dashOffset"
+        />
+      </svg>
+      <span class="label">{{ Math.round(usage.usage_percent) }}%</span>
+      <div class="hover-card card-usage">
+        <div class="card-row">
+          <span class="card-label">Current</span>
+          <span class="card-value">{{ formatTokens(usage.current_tokens) }}</span>
+        </div>
+        <div class="card-row">
+          <span class="card-label">Max</span>
+          <span class="card-value">{{ formatTokens(usage.max_tokens) }}</span>
+        </div>
+        <div class="card-divider"></div>
+        <div class="card-row">
+          <span class="card-label">Used</span>
+          <span class="card-value">{{ Math.round(usage.usage_percent) }}%</span>
+        </div>
       </div>
-      <div class="card-row">
-        <span class="card-label">Max</span>
-        <span class="card-value">{{ formatTokens(usage.max_tokens) }}</span>
+    </span>
+
+    <!-- 模型名 → 余额弹窗 -->
+    <span class="model-name hover-trigger" @mouseenter="onBalanceHover">
+      {{ usage.model_name }}
+      <div class="hover-card card-balance">
+        <template v-if="balanceLoading">
+          <div class="balance-loading">查询中…</div>
+        </template>
+        <template v-else-if="balanceError">
+          <div class="balance-error">{{ balanceError }}</div>
+        </template>
+        <template v-else-if="balanceData">
+          <div
+            v-for="info in balanceData.balance_infos"
+            :key="info.currency"
+            class="card-row"
+          >
+            <span class="card-label">余额 ({{ info.currency }})</span>
+            <span class="card-value">{{ info.total_balance }}</span>
+          </div>
+          <div class="card-divider"></div>
+          <div class="card-row">
+            <span class="card-label">充值</span>
+            <span class="card-value">{{ balanceData.balance_infos[0]?.topped_up_balance }}</span>
+          </div>
+          <div class="card-row">
+            <span class="card-label">赠送</span>
+            <span class="card-value">{{ balanceData.balance_infos[0]?.granted_balance }}</span>
+          </div>
+          <div class="card-divider"></div>
+          <div class="card-row">
+            <span class="card-label">状态</span>
+            <span
+              class="card-value"
+              :class="balanceData.is_available ? 'status-ok' : 'status-err'"
+            >{{ balanceData.is_available ? '可用' : '不可用' }}</span>
+          </div>
+        </template>
+        <template v-else>
+          <div class="balance-idle">悬停查询余额</div>
+        </template>
       </div>
-      <div class="card-divider"></div>
-      <div class="card-row">
-        <span class="card-label">Used</span>
-        <span class="card-value">{{ Math.round(usage.usage_percent) }}%</span>
-      </div>
-    </div>
+    </span>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import type { ContextUsage } from '@/types'
+import { ref, computed } from 'vue'
+import type { ContextUsage, DeepSeekBalanceResponse } from '@/types'
+import { api } from '@/api'
 
 const props = defineProps<{ usage: ContextUsage | null }>()
 
 const circumference = 2 * Math.PI * 13
+
+const balanceData = ref<DeepSeekBalanceResponse | null>(null)
+const balanceLoading = ref(false)
+const balanceError = ref<string | null>(null)
+let balanceFetched = false
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
@@ -64,6 +115,20 @@ const level = computed(() => {
   if (props.usage.usage_percent < 85) return 'warn'
   return 'danger'
 })
+
+async function onBalanceHover() {
+  if (balanceFetched || balanceLoading.value) return
+  balanceFetched = true
+  balanceLoading.value = true
+  balanceError.value = null
+  try {
+    balanceData.value = await api.getDeepSeekBalance()
+  } catch (e) {
+    balanceError.value = (e as Error).message
+  } finally {
+    balanceLoading.value = false
+  }
+}
 </script>
 
 <style scoped>
@@ -73,6 +138,7 @@ const level = computed(() => {
   gap: 6px;
   font-size: 12px;
   color: var(--text-secondary);
+  position: relative;
 }
 .ring {
   width: 15px;
@@ -105,18 +171,28 @@ const level = computed(() => {
 .danger .label {
   color: #ef4444;
 }
-.context-usage {
-  position: relative;
-}
-.context-usage:hover .hover-card {
-  visibility: visible;
-  opacity: 1;
-  transform: translateY(0);
-}
 .model-name {
   color: var(--text-secondary);
   opacity: 1;
 }
+.ring-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* hover-trigger 容器：让弹窗相对自己定位 */
+.hover-trigger {
+  position: relative;
+  cursor: default;
+}
+.hover-trigger:hover .hover-card {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* 共用弹窗样式 */
 .hover-card {
   visibility: hidden;
   opacity: 0;
@@ -127,7 +203,7 @@ const level = computed(() => {
   top: calc(100% + 8px);
   left: 0;
   z-index: 100;
-  min-width: 160px;
+  min-width: 170px;
   padding: 8px 12px;
   background: var(--bg-card);
   border: 1px solid var(--border);
@@ -153,5 +229,27 @@ const level = computed(() => {
   height: 1px;
   background: var(--border);
   margin: 4px 0;
+}
+.status-ok {
+  color: #22c55e;
+}
+.status-err {
+  color: #ef4444;
+}
+
+/* 余额弹窗专用 */
+.card-balance {
+  left: 0;
+  right: auto;
+}
+.balance-loading,
+.balance-error,
+.balance-idle {
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 2px 0;
+}
+.balance-error {
+  color: #ef4444;
 }
 </style>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -180,6 +180,20 @@ export interface Citation {
   sourceType: 'user_message' | 'assistant_message' | 'tool_result' | 'thinking'
 }
 
+// === DeepSeek 余额 ===
+
+export interface BalanceInfo {
+  currency: string
+  total_balance: string
+  topped_up_balance: string
+  granted_balance: string
+}
+
+export interface DeepSeekBalanceResponse {
+  is_available: boolean
+  balance_infos: BalanceInfo[]
+}
+
 // === 上下文窗口用量 ===
 
 export interface ContextUsage {


### PR DESCRIPTION
## Summary

- 用量百分比悬停 → 保持上下文用量弹窗
- 模型名悬停 → 改为查询并展示 DeepSeek 账户余额（总余额/充值/赠送/状态）
- 余额数据首次悬停时懒加载，结果缓存避免重复请求
- 后端新增 `GET /api/deepseek-balance` 路由

## Changes

| 文件 | 变更 |
|------|------|
| `api/routes/balance.py` | 新增 DeepSeek 余额查询路由 |
| `api/server.py` | 注册余额路由 |
| `web/src/types/index.ts` | 新增余额响应类型 |
| `web/src/api/index.ts` | 新增 getDeepSeekBalance 方法 |
| `web/src/components/ContextUsageBadge.vue` | 拆分悬停弹窗：用量% → 用量弹窗，模型名 → 余额弹窗 |