### PR TITLE
style(web): 增大字体、统一思考块样式、悬停阴影

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -154,7 +154,7 @@ html, body {
 
 /* ── Shared markdown rendered content ── */
 .markdown-body {
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.6;
   color: var(--text-primary);
   word-break: break-word;

--- a/web/src/components/MessageBubble.vue
+++ b/web/src/components/MessageBubble.vue
@@ -17,10 +17,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { renderMarkdown } from '@/utils/markdown'
-import { parseReferences } from '@/utils/references'
-import ReferenceChip from './ReferenceChip.vue'
+import { renderMarkdown } from '@/utils/markdown';
+import { parseReferences } from '@/utils/references';
+import { computed } from 'vue';
+import ReferenceChip from './ReferenceChip.vue';
 
 const props = defineProps<{ role: 'user' | 'assistant'; content: string }>()
 
@@ -49,7 +49,7 @@ const rendered = computed(() => renderMarkdown(parsed.value.cleanText))
   max-width: 72%;
   padding: 10px 16px;
   border-radius: 14px;
-  font-size: 14px;
+  font-size: 16px;
   line-height: 1.6;
   word-break: break-word;
   box-shadow: var(--shadow);

--- a/web/src/components/ThinkingBlock.vue
+++ b/web/src/components/ThinkingBlock.vue
@@ -39,6 +39,9 @@ const renderedTokens = computed(() => renderMarkdown(props.block.tokens))
   margin: 4px 0;
   opacity: 1;
 }
+.thinking-block.done:hover {
+  box-shadow: var(--shadow);
+}
 .thinking-block.done .thinking-header {
   max-height: 0;
   padding-top: 0;

--- a/web/src/components/ThinkingBlock.vue
+++ b/web/src/components/ThinkingBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="thinking-block" :class="{ done: block.done, 'became-answer': block.becameAnswer }">
+  <div class="thinking-block" :class="{ done: block.done }">
     <div class="thinking-header">
       <span class="thinking-label">
         <span class="spinner" v-if="!block.done"></span>
@@ -47,25 +47,6 @@ const renderedTokens = computed(() => renderMarkdown(props.block.tokens))
   overflow: hidden;
 }
 .thinking-block.done .thinking-body {
-  border-top: none;
-  padding: 10px 16px;
-}
-.thinking-block.became-answer {
-  background: var(--bg-card);
-  border: none;
-  border-radius: 14px;
-  border-bottom-left-radius: 4px;
-  margin: 4px 0;
-  opacity: 1;
-}
-.thinking-block.became-answer .thinking-header {
-  max-height: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  opacity: 0;
-  overflow: hidden;
-}
-.thinking-block.became-answer .thinking-body {
   border-top: none;
   padding: 10px 16px;
 }

--- a/web/src/components/ThinkingBlock.vue
+++ b/web/src/components/ThinkingBlock.vue
@@ -28,16 +28,14 @@ const renderedTokens = computed(() => renderMarkdown(props.block.tokens))
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-secondary);
-  box-shadow: var(--shadow);
   overflow: hidden;
   transition: all 0.4s ease;
 }
 .thinking-block.done {
   background: var(--bg-card);
-  border-color: var(--border);
+  border: none;
   border-radius: 14px;
   border-bottom-left-radius: 4px;
-  max-width: 72%;
   margin: 4px 0;
   opacity: 1;
 }
@@ -54,10 +52,9 @@ const renderedTokens = computed(() => renderMarkdown(props.block.tokens))
 }
 .thinking-block.became-answer {
   background: var(--bg-card);
-  border-color: var(--border);
+  border: none;
   border-radius: 14px;
   border-bottom-left-radius: 4px;
-  max-width: 72%;
   margin: 4px 0;
   opacity: 1;
 }


### PR DESCRIPTION
## Summary
- `.markdown-body` 和 `.bubble` 字体从 14px 增大至 16px
- ThinkingBlock 移除阴影、边框和 max-width 限制，避免完成时收缩
- 合并 `.done` 与 `.became-answer` CSS（两者样式完全一致）
- done 气泡鼠标悬停时显示阴影，与工具气泡阴影参数一致

## Test plan
- [ ] 刷新页面确认字体增大
- [ ] 思考块完成时无收缩动画
- [ ] 鼠标悬停 done 气泡显示阴影