### PR TITLE
perf(agent): 将当前时间移到 system prompt 末尾以提升前缀缓存命中率

### DIFF
--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -31,8 +31,6 @@ def build_system_prompt() -> str:
     ensure_user_md()
     now = datetime.now().strftime("%Y年%m月%d日 %H:%M:%S")
     parts = [
-        f"当前时间：{now}",
-        "",
         "## 行为规则",
         _read_persona("AGENTS.md"),
         "",
@@ -44,6 +42,8 @@ def build_system_prompt() -> str:
         "",
         "## 我对用户的记忆",
         get_narrative(),
+        "",
+        f"当前时间：{now}",
     ]
     return "\n".join(parts)
 


### PR DESCRIPTION
## Summary

- 将 `当前时间` 从 system prompt 开头移到末尾，避免破坏 DeepSeek 服务端 KV 前缀缓存
- 让 AGENTS.md、SOUL.md 等静态内容成为稳定前缀，提高跨轮次/跨会话的缓存复用率
- CLI 模式下每轮都 rebuild system prompt，移动后至少保证静态部分的 KV cache 可命中

## Test plan

- [x] 确认 `agent/prompts.py` 中 `build_system_prompt()` 输出顺序正确
- [ ] CLI 模式启动验证输出正常
- [ ] Web 模式启动验证输出正常