### PR TITLE
refactor(memory): 用 MemoryManager 替代旧的叙事记忆系统

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ config/personas/memory_operations.yaml
 skills/bilibili/cookie.txt
 output/bilibili/
 config/personas/memory.yaml
+*.lock
+*.clean

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ config/personas/MEMORY.md
 config/personas/memory_operations.yaml
 skills/bilibili/cookie.txt
 output/bilibili/
+config/personas/memory.yaml

--- a/api/routes/memory.py
+++ b/api/routes/memory.py
@@ -1,6 +1,10 @@
 """REST API — 长期记忆叙事。"""
 
+import random
+
 from fastapi import APIRouter, Request
+
+from memory.memory_manager import MemoryManager
 
 router = APIRouter()
 
@@ -9,3 +13,25 @@ router = APIRouter()
 async def get_narrative(request: Request):
     ltm = request.app.state.ltm
     return {"narrative": ltm.get_narrative()}
+
+
+@router.get("/moment")
+async def get_moment(request: Request):
+    ltm = request.app.state.ltm
+    mm = MemoryManager(yaml_file=str(ltm._memory_path))
+    items = mm.show()
+    print(f"[DEBUG /api/moment] memory.yaml path: {ltm._memory_path}, items count: {len(items)}")
+    if not items:
+        print("[DEBUG /api/moment] no items, returning null")
+        return {"moment": None}
+    chosen = random.choice(items)
+    print(f"[DEBUG /api/moment] chosen id={chosen['id']}, desc={chosen['description'][:60]}")
+    history = mm.show_description_history(chosen["id"])
+    return {
+        "moment": {
+            "id": chosen["id"],
+            "description": chosen["description"],
+            "theme": chosen["theme"],
+            "history": history,
+        }
+    }

--- a/api/routes/memory.py
+++ b/api/routes/memory.py
@@ -20,12 +20,9 @@ async def get_moment(request: Request):
     ltm = request.app.state.ltm
     mm = MemoryManager(yaml_file=str(ltm._memory_path))
     items = mm.show()
-    print(f"[DEBUG /api/moment] memory.yaml path: {ltm._memory_path}, items count: {len(items)}")
     if not items:
-        print("[DEBUG /api/moment] no items, returning null")
         return {"moment": None}
     chosen = random.choice(items)
-    print(f"[DEBUG /api/moment] chosen id={chosen['id']}, desc={chosen['description'][:60]}")
     history = mm.show_description_history(chosen["id"])
     return {
         "moment": {

--- a/dev_docs/memory-system.md
+++ b/dev_docs/memory-system.md
@@ -1,0 +1,164 @@
+# 记忆系统（Memory System）
+
+## 架构概览
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    对外接口（不变）                        │
+│  LongTermMemoryInterface                                │
+│  get_narrative() / MEMORY_PATH                          │
+├─────────────────────────────────────────────────────────┤
+│                      narrative.py                        │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │  CRUD 工具 (@tool)                              │    │
+│  │  create_memory / read_memories                  │    │
+│  │  update_memory / delete_memory                   │    │
+│  │  通过 _current_mm 引用操作 MemoryManager         │    │
+│  └─────────────────────────────────────────────────┘    │
+│                          │                                │
+│                          ▼                                │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │          MemoryManager (memory_manager.py)       │    │
+│  │  add / delete / update / show / load_yaml        │    │
+│  │  save_yaml ←→ memory.yaml (YAML 持久化)          │    │
+│  └─────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 核心文件
+
+| 文件 | 职责 |
+|------|------|
+| `memory/memory_manager.py` | 底层存储引擎，YAML 读写、条目 CRUD |
+| `memory/narrative.py` | 上层接口，包含 LangChain 工具、异步消费管线、对外 API |
+| `config/personas/memory.yaml` | 持久化文件（被 `.gitignore` 排除） |
+
+## MemoryManager
+
+`MemoryManager` 是一个通用的 YAML 持久化记忆存储器。
+
+### MemoryItem
+
+每条记忆是一个 `MemoryItem`，包含：
+
+| 字段 | 说明 |
+|------|------|
+| `description` | 记忆内容（如"用户叫Miso"） |
+| `theme` | 分类主题（如"身份""音乐"），对应旧系统的 section |
+| `history` | 变更历史列表，每次 update 追加一条记录 |
+| `latest_update_time` | 最近更新时间 |
+
+### MemoryManager 方法
+
+| 方法 | 说明 |
+|------|------|
+| `add(description, theme)` | 添加条目，返回 UUID |
+| `delete(id)` | 删除条目，返回被删条目的 description |
+| `update(id, reason, ...)` | 更新条目的 description/theme，记录变更原因 |
+| `show()` | 返回 `[{id, description, theme}, ...]`，供工具和格式化使用 |
+| `load_yaml()` | 从文件加载；文件不存在则创建空 YAML |
+| `save_yaml()` | 持久化到文件 |
+
+### 关键实现细节
+
+- **ID 形式**：UUID4 字符串，由整理记忆 Agent 在单次调用周期内传递引用
+- **Round-trip 正确性**：`MemoryItem.__init__` 从 kwargs 中正确提取 `history` 和 `latest_update_time`，避免序列化-反序列化后历史丢失
+
+## 双重叙事格式
+
+同一份数据通过两种格式化函数呈现，分别面向不同消费者：
+
+### `_format_narrative()` — 给主 Agent 和网页端
+
+只含 description 和 theme，**不含 id**：
+
+```markdown
+# 长期记忆索引
+- [身份](#身份)
+- [音乐](#音乐)
+
+---
+
+## 身份
+- 用户叫Miso。
+
+## 音乐
+- 用户喜欢洛天依。
+```
+
+### `_format_entries_for_tool()` — 给整理记忆 Agent
+
+含 description、theme 和 id：
+
+```markdown
+## 身份
+  [a1b2c3d4-...] 用户叫Miso。
+
+## 音乐
+  [c3d4e5f6-...] 用户喜欢洛天依。
+```
+
+## 数据流
+
+### 写入流程（`send_history` → 后台消费）
+
+```
+对话轮次结束
+    │
+    ▼
+send_history(turn_messages)     ← 非阻塞入队
+    │
+    ▼
+asyncio.Queue ──► _consumer()   ← 后台协程逐轮取出
+    │
+    ├─ 1. _set_current_mm(self._mm)    ← 挂载 MemoryManager 引用
+    ├─ 2. self._mm.load_yaml()         ← 从磁盘加载最新状态
+    ├─ 3. 构建 LangGraph ReAct Agent
+    │      工具: create/read/update/delete_memory
+    │      提示词: COLD_START_SYSTEM / UPDATE_SYSTEM
+    ├─ 4. agent.ainvoke(user_prompt)   ← Agent 调用工具修改 _current_mm
+    └─ 5. self._mm.save_yaml()         ← 持久化
+```
+
+### 读取流程
+
+```
+主 Agent 上下文构建                    网页端 GET /api/narrative
+    │                                        │
+    ▼                                        ▼
+build_system_prompt()                  ltm.get_narrative()
+    │                                        │
+    ▼                                        ▼
+get_narrative()  ← 模块级/实例方法，结果相同
+    │
+    ├─ MemoryManager(yaml_file).load_yaml()
+    ├─ _format_narrative(mm.show())
+    └─ 返回格式化叙事文本
+```
+
+## 对外接口（保持不变）
+
+### `LongTermMemoryInterface`
+
+| 方法 | 签名 | 说明 |
+|------|------|------|
+| `__init__` | `(memory_path: str \| Path)` | 接收 yaml 文件路径 |
+| `get_narrative` | `() -> str` | 返回格式化叙事文本 |
+| `start_listening` | `(llm)` | 启动后台消费管线 |
+| `send_history` | `(turn_messages: list[dict])` | 异步入队（非阻塞） |
+| `stop_listening` | `() -> None` | 排空队列并停止 |
+
+### 模块级
+
+- `MEMORY_PATH` — `config/personas/memory.yaml`
+- `get_narrative()` — 等同 `LongTermMemoryInterface.get_narrative()`
+
+## 与旧系统的区别
+
+| 维度 | 旧系统 | 新系统 |
+|------|--------|--------|
+| 持久化格式 | 分区 Markdown（MEMORY.md） | YAML（memory.yaml） |
+| ID 形式 | 自增整数（1, 2, 3...） | UUID4 |
+| 内部存储 | MemoryStore（单例） | MemoryManager（实例） |
+| 操作审计 | MemoryLogger（独立 YAML 日志） | MemoryItem.history（内嵌变更历史） |
+| 序列化 | MemorySerializer（Markdown 解析/生成） | yaml.dump/safe_load |

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -1,0 +1,95 @@
+import datetime
+import os
+import uuid
+from typing import Optional
+
+import yaml
+
+
+def NOW() -> str:
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+class MemoryItem:
+
+    def __init__(self, description, theme, **kwargs):
+        self.description = description
+        self.theme = theme
+        self.history = kwargs.get("history", [])
+        self.latest_update_time = kwargs.get("latest_update_time", NOW())
+
+    def update(self, reason: str, new_description: Optional[str] = None, new_theme: Optional[str] = None):
+        new_history = {"reason": reason}
+        if new_description is not None:
+            new_history["new_description"] = new_description
+            new_history["old_description"] = self.description
+            self.description = new_description
+        if new_theme is not None:
+            new_history["new_theme"] = new_theme
+            new_history["old_theme"] = self.theme
+            self.theme = new_theme
+        new_history["old_time"] = self.latest_update_time
+        self.latest_update_time = NOW()
+        self.history.append(new_history)
+
+
+class MemoryManager:
+
+    def __init__(self, yaml_file: str = "memory.yaml"):
+        self._yaml_file = yaml_file
+        self._memory_items: dict[str, MemoryItem] = {}
+
+    def load_yaml(self) -> None:
+        if not os.path.exists(self._yaml_file):
+            with open(self._yaml_file, "w") as f:
+                yaml.dump({}, f, default_flow_style=False, allow_unicode=True)
+        with open(self._yaml_file, "r") as f:
+            data = yaml.safe_load(f)
+            if not data:
+                return
+            self._memory_items = {id: MemoryItem(**data[id]) for id in data}
+
+    def save_yaml(self) -> None:
+        with open(self._yaml_file, "w") as f:
+            data_dict = {id: data.__dict__ for id, data in self._memory_items.items()}
+            yaml.dump(data_dict, f, default_flow_style=False, allow_unicode=True)
+
+    def __enter__(self):
+        self.load_yaml()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.save_yaml()
+
+    @staticmethod
+    def _generate_id() -> str:
+        return str(uuid.uuid4())
+
+    def add(self, description: str, theme: str) -> str:
+        new_id = self._generate_id()
+        self._memory_items[new_id] = MemoryItem(description, theme)
+        return new_id
+
+    def delete(self, id: str) -> str:
+        if id not in self._memory_items:
+            raise ValueError(f"MemoryManager: Memory item with ID {id} not found")
+        removed = self._memory_items.pop(id)
+        return removed.description
+
+    def update(self, id: str, reason: str, new_description: Optional[str] = None, new_theme: Optional[str] = None):
+        if id not in self._memory_items:
+            raise ValueError(f"MemoryManager: Memory item with ID {id} not found")
+        self._memory_items[id].update(reason, new_description, new_theme)
+
+    def show(self):
+        """整理为大模型易于理解的形式"""
+        out = [
+            {
+                "id": id,
+                "description": item.description,
+                "theme": item.theme
+            }
+            for id, item in
+            self._memory_items.items()
+        ]
+        return out

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -33,6 +33,10 @@ class MemoryItem:
         self.latest_update_time = NOW()
         self.history.append(new_history)
 
+    def merge(self, another: 'MemoryItem', reason: str, merged_description: str, merged_theme: str):
+        self.history += another.history
+        self.update(reason, merged_description, merged_theme)
+
 
 class MemoryManager:
 
@@ -84,6 +88,15 @@ class MemoryManager:
             removed = items.pop(id)
             self._write_all(items)
         return removed.description
+
+    def merge(self, id1: str, id2: str, merged_description: str, merged_theme: str, reason: str):
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            if id1 not in items or id2 not in items:
+                raise ValueError(f"MemoryManager: Memory items with IDs {id1} and {id2} not found")
+            items[id1].merge(items[id2], reason, merged_description, merged_theme)
+            items.pop(id2)
+            self._write_all(items)
 
     def update(self, id: str, reason: str, new_description: Optional[str] = None, new_theme: Optional[str] = None):
         with portalocker.Lock(self._lock_path, timeout=5):

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -33,6 +33,21 @@ class MemoryItem:
         self.latest_update_time = NOW()
         self.history.append(new_history)
 
+    def show_description_history(self) -> list[dict]:
+        """返回描述历史记录及时间（从当前到最早）。
+
+        第一项为当前 description 和 latest_update_time，
+        随后从 history 中逆序取有 old_description 的条目。
+        """
+        result = [{"description": self.description, "time": self.latest_update_time}]
+        for entry in reversed(self.history):
+            if "old_description" in entry:
+                result.append({
+                    "description": entry["old_description"],
+                    "time": entry["old_time"],
+                })
+        return result
+
     def merge(self, another: 'MemoryItem', reason: str, merged_description: str, merged_theme: str):
         self.history += another.history
         self.update(reason, merged_description, merged_theme)
@@ -114,3 +129,11 @@ class MemoryManager:
                 {"id": id, "description": item.description, "theme": item.theme}
                 for id, item in items.items()
             ]
+
+    def show_description_history(self, id: str) -> list[dict]:
+        """返回指定条目的描述变更历史（从当前到最早）。"""
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            if id not in items:
+                raise ValueError(f"MemoryManager: Memory item with ID {id} not found")
+            return items[id].show_description_history()

--- a/memory/memory_manager.py
+++ b/memory/memory_manager.py
@@ -3,6 +3,7 @@ import os
 import uuid
 from typing import Optional
 
+import portalocker
 import yaml
 
 
@@ -37,59 +38,66 @@ class MemoryManager:
 
     def __init__(self, yaml_file: str = "memory.yaml"):
         self._yaml_file = yaml_file
-        self._memory_items: dict[str, MemoryItem] = {}
+        self._ensure_file_exists()
 
-    def load_yaml(self) -> None:
+    def _ensure_file_exists(self) -> None:
+        dir_path = os.path.dirname(self._yaml_file)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
         if not os.path.exists(self._yaml_file):
             with open(self._yaml_file, "w") as f:
                 yaml.dump({}, f, default_flow_style=False, allow_unicode=True)
+
+    def _read_all(self) -> dict[str, 'MemoryItem']:
+        """读取完整文件。调用方必须已持有文件锁。"""
         with open(self._yaml_file, "r") as f:
-            data = yaml.safe_load(f)
-            if not data:
-                return
-            self._memory_items = {id: MemoryItem(**data[id]) for id in data}
+            data = yaml.safe_load(f) or {}
+        return {id: MemoryItem(**data[id]) for id in data}
 
-    def save_yaml(self) -> None:
+    def _write_all(self, items: dict[str, 'MemoryItem']) -> None:
+        """覆写完整文件。调用方必须已持有文件锁。"""
+        data_dict = {id: item.__dict__ for id, item in items.items()}
         with open(self._yaml_file, "w") as f:
-            data_dict = {id: data.__dict__ for id, data in self._memory_items.items()}
             yaml.dump(data_dict, f, default_flow_style=False, allow_unicode=True)
-
-    def __enter__(self):
-        self.load_yaml()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.save_yaml()
 
     @staticmethod
     def _generate_id() -> str:
         return str(uuid.uuid4())
 
+    @property
+    def _lock_path(self) -> str:
+        return self._yaml_file + ".lock"
+
     def add(self, description: str, theme: str) -> str:
-        new_id = self._generate_id()
-        self._memory_items[new_id] = MemoryItem(description, theme)
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            new_id = self._generate_id()
+            items[new_id] = MemoryItem(description, theme)
+            self._write_all(items)
         return new_id
 
     def delete(self, id: str) -> str:
-        if id not in self._memory_items:
-            raise ValueError(f"MemoryManager: Memory item with ID {id} not found")
-        removed = self._memory_items.pop(id)
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            if id not in items:
+                raise ValueError(f"MemoryManager: Memory item with ID {id} not found")
+            removed = items.pop(id)
+            self._write_all(items)
         return removed.description
 
     def update(self, id: str, reason: str, new_description: Optional[str] = None, new_theme: Optional[str] = None):
-        if id not in self._memory_items:
-            raise ValueError(f"MemoryManager: Memory item with ID {id} not found")
-        self._memory_items[id].update(reason, new_description, new_theme)
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            if id not in items:
+                raise ValueError(f"MemoryManager: Memory item with ID {id} not found")
+            items[id].update(reason, new_description, new_theme)
+            self._write_all(items)
 
     def show(self):
         """整理为大模型易于理解的形式"""
-        out = [
-            {
-                "id": id,
-                "description": item.description,
-                "theme": item.theme
-            }
-            for id, item in
-            self._memory_items.items()
-        ]
-        return out
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            return [
+                {"id": id, "description": item.description, "theme": item.theme}
+                for id, item in items.items()
+            ]

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -215,6 +215,33 @@ def delete_memory(id: str, reason: str) -> str:
     return f"已删除 [{id}]: {removed}"
 
 
+@tool
+def merge_memories(id1: str, id2: str, content: str, section: str, reason: str) -> str:
+    """将两条相似记忆合并为一条，id1 保留、id2 被删除，同时保留两者的修改历史。
+
+    当两条记忆描述同一事物（如分散的身份信息、同一首歌在不同分区的重复条目）
+    时使用，避免碎片化。
+
+    Args:
+        id1: 合并后保留的记忆 ID（主条目）。
+        id2: 合并后将被删除的记忆 ID（从条目）。
+        content: 合并后的完整记忆内容，涵盖两条原条目的信息。
+        section: 合并后的记忆分区。
+        reason: 合并原因，说明为什么这两条记忆需要合并。
+    """
+    if _current_mm is None:
+        return "错误：记忆管理器未初始化。"
+    try:
+        _current_mm.merge(id1, id2, content, section, reason)
+    except ValueError:
+        if DEBUG:
+            print(f"[LTM-TOOL] merge_memories [{id1}] + [{id2}] → 错误：ID 不存在")
+        return f"错误：未找到 ID 为 {id1} 或 {id2} 的记忆条目。请先调用 read_memories 确认 ID。"
+    if DEBUG:
+        print(f"[LTM-TOOL] merge_memories [{id1}] + [{id2}] 已合并 | 原因: {reason[:60]}")
+    return f"已合并 [{id2}] → [{id1}] ({section}): {content}"
+
+
 # ── LongTermMemoryInterface ───────────────────────────────────
 
 
@@ -309,7 +336,7 @@ class LongTermMemoryInterface:
                 )
                 user_prompt = user_prompt + time_suffix
 
-                crud_tools = [create_memory, read_memories, update_memory, delete_memory]
+                crud_tools = [create_memory, read_memories, update_memory, delete_memory, merge_memories]
                 if DEBUG:
                     print("[LTM-CONSUMER] 构建 CRUD Agent...")
 

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -63,7 +63,7 @@ UPDATE_SYSTEM = """你是一位"记忆叙事师"。以下是当前记忆（每�
 _current_mm: Optional[MemoryManager] = None
 
 
-def _set_current_mm(mm: MemoryManager) -> None:
+def _set_current_mm(mm: Optional[MemoryManager]) -> None:
     global _current_mm
     _current_mm = mm
 
@@ -119,7 +119,6 @@ def get_narrative() -> str:
     if not MEMORY_PATH.exists():
         return ""
     mm = MemoryManager(yaml_file=str(MEMORY_PATH))
-    mm.load_yaml()
     return _format_narrative(mm.show())
 
 
@@ -135,7 +134,7 @@ def _format_messages(messages: list[dict]) -> str:
     return "\n".join(lines)
 
 
-# ── CRUD 工具（模块级 @tool，委托给 _current_mm）───────────
+# ── CRUD 工具（模块级 @tool，委托给 _current_mm）─────────────────
 
 
 @tool
@@ -153,10 +152,9 @@ def create_memory(content: str, section: str) -> str:
             - "时效待办"（有截止日期的事项：作业、预约、考试）
     """
     content = _sanitize(content)
-    mm = _current_mm
-    if mm is None:
+    if _current_mm is None:
         return "错误：记忆管理器未初始化。"
-    new_id = mm.add(description=content, theme=section)
+    new_id = _current_mm.add(description=content, theme=section)
     if DEBUG:
         print(f"[LTM-TOOL] create_memory → [{new_id}] ({section}) {content[:80]}...")
     return f"已创建 [{new_id}] ({section}): {content}"
@@ -165,10 +163,9 @@ def create_memory(content: str, section: str) -> str:
 @tool
 def read_memories() -> str:
     """查看当前所有记忆条目及其 ID 和分区。在增删改之前必须先调用此工具了解现有条目。"""
-    mm = _current_mm
-    if mm is None:
+    if _current_mm is None:
         return "（暂无记忆条目）"
-    result = _format_entries_for_tool(mm.show())
+    result = _format_entries_for_tool(_current_mm.show())
     if DEBUG:
         print(f"[LTM-TOOL] read_memories → 获取条目")
     return result
@@ -184,11 +181,10 @@ def update_memory(id: str, content: str, reason: str) -> str:
         reason: 修改原因，说明为什么要更新这条记忆。
     """
     content = _sanitize(content)
-    mm = _current_mm
-    if mm is None:
+    if _current_mm is None:
         return "错误：记忆管理器未初始化。"
     try:
-        mm.update(id, reason=reason, new_description=content)
+        _current_mm.update(id, reason=reason, new_description=content)
     except ValueError:
         if DEBUG:
             print(f"[LTM-TOOL] update_memory [{id}] → 错误：ID 不存在")
@@ -206,11 +202,10 @@ def delete_memory(id: str, reason: str) -> str:
         id: 要删除的记忆 ID（来自 read_memories 的输出）。
         reason: 删除原因，说明为什么要删除这条记忆。
     """
-    mm = _current_mm
-    if mm is None:
+    if _current_mm is None:
         return "错误：记忆管理器未初始化。"
     try:
-        removed = mm.delete(id)
+        removed = _current_mm.delete(id)
     except ValueError:
         if DEBUG:
             print(f"[LTM-TOOL] delete_memory [{id}] → 错误：ID 不存在")
@@ -245,7 +240,6 @@ class LongTermMemoryInterface:
         if not self._memory_path.exists():
             return ""
         mm = MemoryManager(yaml_file=str(self._memory_path))
-        mm.load_yaml()
         return _format_narrative(mm.show())
 
     def start_listening(self, llm) -> None:
@@ -253,7 +247,6 @@ class LongTermMemoryInterface:
 
         必须在运行中的事件循环内调用。
         """
-        self._mm.load_yaml()
         self._queue = asyncio.Queue()
         self._consumer_task = asyncio.create_task(self._consumer(llm))
 
@@ -269,7 +262,6 @@ class LongTermMemoryInterface:
         if self._queue is not None:
             await self._queue.put(None)
             await self._consumer_task
-            self._mm.save_yaml()
             self._queue = None
             self._consumer_task = None
 
@@ -290,8 +282,6 @@ class LongTermMemoryInterface:
                     print(f"[LTM-CONSUMER] 收到 {len(turn_messages)} 条消息")
 
                 _set_current_mm(self._mm)
-                self._mm.load_yaml()
-
                 items = self._mm.show()
                 messages_text = _format_messages(turn_messages)
 
@@ -350,7 +340,6 @@ class LongTermMemoryInterface:
                     for item in items_after:
                         print(f"[LTM-CONSUMER]   新 [{item['id']}] ({item['theme']}): {item['description'][:60]}...")
 
-                self._mm.save_yaml()
                 if DEBUG:
                     print(f"[LTM-CONSUMER] ✅ 已写入 memory.yaml")
 

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -1,29 +1,27 @@
-"""记忆叙事模块 — 每轮对话后将裸消息送给 LLM，增量更新 MEMORY.md。"""
+"""记忆叙事模块 — 每轮对话后将裸消息送给 LLM，增量更新 memory.yaml。"""
 
 import asyncio
 import traceback
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
-import yaml
-from filelock import FileLock
 from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 
-DEBUG = False  # 调试开关，排查 MEMORY.md 未更新的问题
+from memory.memory_manager import MemoryManager
+
+DEBUG = False  # 调试开关，排查 memory.yaml 未更新的问题
 
 
 def _sanitize(text: str) -> str:
-    """将多行文本折叠为单行，防止破坏 YAML/Markdown 行格式。"""
+    """将多行文本折叠为单行，防止破坏 YAML 格式。"""
     return text.replace("\n", " ").replace("\r", " ")
 
-DEFAULT_SECTION = "身份"
-
 PERSONAS_DIR = Path(__file__).resolve().parent.parent / "config" / "personas"
-MEMORY_PATH = PERSONAS_DIR / "MEMORY.md"
-LOG_PATH = PERSONAS_DIR / "memory_operations.yaml"
+MEMORY_PATH = PERSONAS_DIR / "memory.yaml"
 
 COLD_START_SYSTEM = """你是一位"记忆叙事师"。根据对话记录，用第三人称撰写关于用户的简洁中文记忆。
 
@@ -60,11 +58,69 @@ UPDATE_SYSTEM = """你是一位"记忆叙事师"。以下是当前记忆（每�
 6. 禁止使用"今天""明天""昨天""下周"等相对时间词汇，必须使用绝对日期写入记忆。已提供当前时间、日期和星期几，请自行换算。"""
 
 
+# ── 模块级 MemoryManager 引用 ──────────────────────────────
+
+_current_mm: Optional[MemoryManager] = None
+
+
+def _set_current_mm(mm: MemoryManager) -> None:
+    global _current_mm
+    _current_mm = mm
+
+
+# ── 格式化辅助 ──────────────────────────────────────────────
+
+
+def _format_narrative(items: list[dict]) -> str:
+    """将 MemoryManager.show() 的输出格式化为人类可读的长记忆叙事文本。"""
+    if not items:
+        return ""
+    by_theme: dict[str, list[dict]] = {}
+    theme_order: list[str] = []
+    for item in items:
+        theme = item["theme"]
+        by_theme.setdefault(theme, []).append(item)
+        if theme not in theme_order:
+            theme_order.append(theme)
+    lines = ["# 长期记忆索引"]
+    for theme in theme_order:
+        lines.append(f"- [{theme}](#{theme})")
+    lines.extend(["", "---", ""])
+    for theme in theme_order:
+        lines.append(f"## {theme}")
+        for item in by_theme[theme]:
+            lines.append(f"- {item['description']}")
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def _format_entries_for_tool(items: list[dict]) -> str:
+    """为 read_memories 工具格式化条目（按 theme 分组，带 ID）。"""
+    if not items:
+        return "（暂无记忆条目）"
+    by_theme: dict[str, list[dict]] = {}
+    theme_order: list[str] = []
+    for item in items:
+        theme = item["theme"]
+        by_theme.setdefault(theme, []).append(item)
+        if theme not in theme_order:
+            theme_order.append(theme)
+    lines = []
+    for theme in theme_order:
+        lines.append(f"## {theme}")
+        for item in by_theme[theme]:
+            lines.append(f"  [{item['id']}] {item['description']}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
 def get_narrative() -> str:
     """读取当前记忆叙事，不存在则返回空字符串。"""
-    if MEMORY_PATH.exists():
-        return MEMORY_PATH.read_text(encoding="utf-8").strip()
-    return ""
+    if not MEMORY_PATH.exists():
+        return ""
+    mm = MemoryManager(yaml_file=str(MEMORY_PATH))
+    mm.load_yaml()
+    return _format_narrative(mm.show())
 
 
 def _format_messages(messages: list[dict]) -> str:
@@ -79,210 +135,7 @@ def _format_messages(messages: list[dict]) -> str:
     return "\n".join(lines)
 
 
-# ── MemorySerializer ──────────────────────────────────────────
-
-
-class MemorySerializer:
-    """MEMORY.md 分区格式 ↔ 条目字典 双向转换。"""
-
-    @staticmethod
-    def parse(content: str) -> tuple[dict[str, dict[str, str]], int]:
-        """解析分区格式 MEMORY.md 为 {id: {section, content}} 字典。
-
-        返回 ({id: {section, content}}, next_id)。
-        跳过 TOC、---、HTML 注释、### 子标题和非 "- " 行。
-        """
-        entries: dict[str, dict[str, str]] = {}
-        next_id = 1
-        current_section: str | None = None
-        for line in content.strip().split("\n"):
-            stripped = line.strip()
-            if not stripped:
-                continue
-            if stripped.startswith("# ") or stripped.startswith("---"):
-                continue
-            if stripped.startswith("## "):
-                section_name = stripped[3:].strip()
-                if "<!--" in section_name:
-                    section_name = section_name.split("<!--")[0].strip()
-                current_section = section_name
-            elif stripped.startswith("### "):
-                pass
-            elif stripped.startswith("- ") and current_section is not None:
-                entries[str(next_id)] = {
-                    "section": current_section,
-                    "content": stripped[2:].strip(),
-                }
-                next_id += 1
-        return entries, next_id
-
-    @staticmethod
-    def _section_order(entries: dict[str, dict[str, str]]) -> list[str]:
-        """按条目 ID 顺序返回 section 首次出现的顺序。"""
-        seen: list[str] = []
-        for eid in sorted(entries.keys(), key=int):
-            sec = entries[eid]["section"]
-            if sec not in seen:
-                seen.append(sec)
-        return seen
-
-    @staticmethod
-    def serialize(entries: dict[str, dict[str, str]]) -> str:
-        """将 {id: {section, content}} 序列化为带 TOC 的分区 MEMORY.md。"""
-        if not entries:
-            return "\n"
-        by_section: dict[str, list[str]] = {}
-        for entry in entries.values():
-            sec = entry.get("section", DEFAULT_SECTION)
-            by_section.setdefault(sec, []).append(entry["content"])
-
-        section_order = MemorySerializer._section_order(entries)
-
-        lines = ["# 长期记忆索引"]
-        for section in section_order:
-            lines.append(f"- [{section}](#{section})")
-        lines.append("")
-        lines.append("---")
-        lines.append("")
-
-        for section in section_order:
-            lines.append(f"## {section}")
-            for content in by_section[section]:
-                lines.append(f"- {content}")
-            lines.append("")
-        return "\n".join(lines) + "\n"
-
-
-# ── MemoryLogger ──────────────────────────────────────────────
-
-
-class MemoryLogger:
-    """YAML 操作日志记录器（线程/进程安全）。"""
-
-    _lock = FileLock(str(LOG_PATH) + ".lock")
-
-    @staticmethod
-    def _sanitize_params(params: dict) -> dict:
-        """递归清理参数中所有字符串的换行符。"""
-        result = {}
-        for k, v in params.items():
-            if isinstance(v, str):
-                result[k] = _sanitize(v)
-            elif isinstance(v, dict):
-                result[k] = MemoryLogger._sanitize_params(v)
-            else:
-                result[k] = v
-        return result
-
-    @staticmethod
-    def log(operation: str, params: dict) -> None:
-        """追加一条操作记录到 YAML 日志文件。"""
-        entry = {
-            "timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
-            "operation": operation,
-            "params": MemoryLogger._sanitize_params(params),
-        }
-        with MemoryLogger._lock:
-            if LOG_PATH.exists():
-                try:
-                    existing = yaml.safe_load(LOG_PATH.read_text(encoding="utf-8")) or []
-                except yaml.YAMLError:
-                    existing = []
-            else:
-                existing = []
-            existing.append(entry)
-            LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-            LOG_PATH.write_text(
-                yaml.safe_dump(existing, allow_unicode=True), encoding="utf-8"
-            )
-
-
-# ── MemoryStore（单例）────────────────────────────────────────
-
-
-class MemoryStore:
-    """记忆条目存储器（单例）。
-
-    持有当前会话的条目字典和自增 ID 计数器，提供 CRUD 操作。
-    """
-
-    _instance: "MemoryStore | None" = None
-
-    def __new__(cls) -> "MemoryStore":
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __init__(self) -> None:
-        if not hasattr(self, "_initialized"):
-            self._initialized = True
-            self.entries: dict[str, dict[str, str]] = {}
-            self.next_id: int = 1
-
-    def reset(self) -> None:
-        """重置为初始状态。"""
-        self.entries.clear()
-        self.next_id = 1
-
-    def load(self, content: str) -> None:
-        """从 MEMORY.md 文本解析并加载条目。"""
-        self.entries, self.next_id = MemorySerializer.parse(content)
-
-    def create(self, content: str, section: str = DEFAULT_SECTION) -> str:
-        """添加一条记忆条目到指定分区，返回结果消息。"""
-        content = _sanitize(content)
-        if not section.strip():
-            section = DEFAULT_SECTION
-        eid = str(self.next_id)
-        self.entries[eid] = {"section": section, "content": content}
-        self.next_id += 1
-        return f"已创建 [{eid}] ({section}): {content}"
-
-    def read_all(self) -> str:
-        """返回所有条目的格式化文本，按分区归类。"""
-        if not self.entries:
-            return "（暂无记忆条目）"
-        by_section: dict[str, list[tuple[str, str]]] = {}
-        for eid, entry in self.entries.items():
-            sec = entry.get("section", DEFAULT_SECTION)
-            by_section.setdefault(sec, []).append((eid, entry["content"]))
-        lines = []
-        for section in MemorySerializer._section_order(self.entries):
-            if section in by_section:
-                lines.append(f"## {section}")
-                for eid, content in by_section[section]:
-                    lines.append(f"  [{eid}] {content}")
-                lines.append("")
-        return "\n".join(lines).strip()
-
-    def update(self, id: str, content: str) -> str:
-        """根据 ID 更新一条条目，返回结果消息。"""
-        content = _sanitize(content)
-        if id not in self.entries:
-            return (
-                f"错误：未找到 ID 为 {id} 的记忆条目。"
-                "请先调用 read_memories 确认 ID。"
-            )
-        old = self.entries[id]["content"]
-        self.entries[id]["content"] = content
-        return f"已更新 [{id}]\n  旧: {old}\n  新: {content}"
-
-    def delete(self, id: str) -> str:
-        """根据 ID 删除一条条目，返回结果消息。"""
-        if id not in self.entries:
-            return (
-                f"错误：未找到 ID 为 {id} 的记忆条目。"
-                "请先调用 read_memories 确认 ID。"
-            )
-        removed = self.entries.pop(id)["content"]
-        return f"已删除 [{id}]: {removed}"
-
-    def serialize(self) -> str:
-        """将当前条目序列化为 MEMORY.md 格式。"""
-        return MemorySerializer.serialize(self.entries)
-
-
-# ── CRUD 工具（模块级 @tool，委托给 MemoryStore 单例）───────
+# ── CRUD 工具（模块级 @tool，委托给 _current_mm）───────────
 
 
 @tool
@@ -299,22 +152,25 @@ def create_memory(content: str, section: str) -> str:
             - "瞬间"（即时观察和感受：天气、正在做的事、念头）
             - "时效待办"（有截止日期的事项：作业、预约、考试）
     """
-    store = MemoryStore()
-    result = store.create(content, section)
-    MemoryLogger.log("create_memory", {"content": content, "section": section})
+    content = _sanitize(content)
+    mm = _current_mm
+    if mm is None:
+        return "错误：记忆管理器未初始化。"
+    new_id = mm.add(description=content, theme=section)
     if DEBUG:
-        eid = str(store.next_id - 1)
-        print(f"[LTM-TOOL] create_memory → [{eid}] ({section}) {content[:80]}...")
-    return result
+        print(f"[LTM-TOOL] create_memory → [{new_id}] ({section}) {content[:80]}...")
+    return f"已创建 [{new_id}] ({section}): {content}"
 
 
 @tool
 def read_memories() -> str:
     """查看当前所有记忆条目及其 ID 和分区。在增删改之前必须先调用此工具了解现有条目。"""
-    store = MemoryStore()
-    result = store.read_all()
+    mm = _current_mm
+    if mm is None:
+        return "（暂无记忆条目）"
+    result = _format_entries_for_tool(mm.show())
     if DEBUG:
-        print(f"[LTM-TOOL] read_memories → {len(store.entries)} 条")
+        print(f"[LTM-TOOL] read_memories → 获取条目")
     return result
 
 
@@ -328,20 +184,19 @@ def update_memory(id: str, content: str, reason: str, origin_content: str) -> st
         reason: 修改原因，说明为什么要更新这条记忆。
         origin_content: 修改前的原始内容，必须与 read_memories 中该 ID 对应的内容完全一致。
     """
-    store = MemoryStore()
-    if id not in store.entries:
+    content = _sanitize(content)
+    mm = _current_mm
+    if mm is None:
+        return "错误：记忆管理器未初始化。"
+    try:
+        mm.update(id, reason=reason, new_description=content)
+    except ValueError:
         if DEBUG:
             print(f"[LTM-TOOL] update_memory [{id}] → 错误：ID 不存在")
         return f"错误：未找到 ID 为 {id} 的记忆条目。请先调用 read_memories 确认 ID。"
-    result = store.update(id, content)
-    MemoryLogger.log("update_memory", {
-        "content": content,
-        "reason": reason,
-        "origin_content": origin_content,
-    })
     if DEBUG:
-        print(f"[LTM-TOOL] update_memory [{id}] 旧→新 | 原因: {reason[:60]}")
-    return result
+        print(f"[LTM-TOOL] update_memory [{id}] 已更新 | 原因: {reason[:60]}")
+    return f"已更新 [{id}]: {content}"
 
 
 @tool
@@ -353,30 +208,29 @@ def delete_memory(id: str, reason: str, origin_content: str) -> str:
         reason: 删除原因，说明为什么要删除这条记忆。
         origin_content: 删除前的原始内容，必须与 read_memories 中该 ID 对应的内容完全一致。
     """
-    store = MemoryStore()
-    if id not in store.entries:
+    mm = _current_mm
+    if mm is None:
+        return "错误：记忆管理器未初始化。"
+    try:
+        removed = mm.delete(id)
+    except ValueError:
         if DEBUG:
             print(f"[LTM-TOOL] delete_memory [{id}] → 错误：ID 不存在")
         return f"错误：未找到 ID 为 {id} 的记忆条目。请先调用 read_memories 确认 ID。"
-    result = store.delete(id)
-    MemoryLogger.log("delete_memory", {
-        "reason": reason,
-        "origin_content": origin_content,
-    })
     if DEBUG:
         print(f"[LTM-TOOL] delete_memory [{id}] 已删除 | 原因: {reason[:60]}")
-    return result
+    return f"已删除 [{id}]: {removed}"
 
 
 # ── LongTermMemoryInterface ───────────────────────────────────
 
 
 class LongTermMemoryInterface:
-    """异步管线：逐轮对话消息 → asyncio.Queue → 后台 LLM 总结 → MEMORY.md 写入。
+    """异步管线：逐轮对话消息 → asyncio.Queue → 后台 LLM 总结 → memory.yaml 写入。
 
     用法::
 
-        ltm = LongTermMemoryInterface("/path/to/MEMORY.md")
+        ltm = LongTermMemoryInterface("/path/to/memory.yaml")
         ltm.start_listening(llm)          # 启动后台消费者
         await ltm.send_history(messages)  # 投放本轮对话（非阻塞）
         await ltm.stop_listening()        # 排空队列并停止
@@ -384,20 +238,24 @@ class LongTermMemoryInterface:
 
     def __init__(self, memory_path: str | Path) -> None:
         self._memory_path = Path(memory_path)
+        self._mm = MemoryManager(yaml_file=str(self._memory_path))
         self._queue: asyncio.Queue | None = None
         self._consumer_task: asyncio.Task | None = None
 
     def get_narrative(self) -> str:
         """读取当前记忆叙事，不存在则返回空字符串。"""
-        if self._memory_path.exists():
-            return self._memory_path.read_text(encoding="utf-8").strip()
-        return ""
+        if not self._memory_path.exists():
+            return ""
+        mm = MemoryManager(yaml_file=str(self._memory_path))
+        mm.load_yaml()
+        return _format_narrative(mm.show())
 
     def start_listening(self, llm) -> None:
         """创建 asyncio.Queue 并启动后台消费者协程。
 
         必须在运行中的事件循环内调用。
         """
+        self._mm.load_yaml()
         self._queue = asyncio.Queue()
         self._consumer_task = asyncio.create_task(self._consumer(llm))
 
@@ -413,12 +271,12 @@ class LongTermMemoryInterface:
         if self._queue is not None:
             await self._queue.put(None)
             await self._consumer_task
+            self._mm.save_yaml()
             self._queue = None
             self._consumer_task = None
 
     async def _consumer(self, llm) -> None:
-        """后台消费者协程：从队列取消息，调用 CRUD Agent，写入 MEMORY.md。"""
-        store = MemoryStore()
+        """后台消费者协程：从队列取消息，调用 CRUD Agent，写入 memory.yaml。"""
 
         while True:
             turn_messages = await self._queue.get()
@@ -433,21 +291,22 @@ class LongTermMemoryInterface:
                     print("[LTM-CONSUMER] === 新轮次开始 ===")
                     print(f"[LTM-CONSUMER] 收到 {len(turn_messages)} 条消息")
 
-                old_narrative = self.get_narrative()
+                _set_current_mm(self._mm)
+                self._mm.load_yaml()
+
+                items = self._mm.show()
                 messages_text = _format_messages(turn_messages)
 
-                if old_narrative:
-                    store.load(old_narrative)
+                if items:
                     system_prompt = UPDATE_SYSTEM
                     user_prompt = (
                         f"## 新一轮对话\n{messages_text}"
                     )
                     if DEBUG:
-                        print(f"[LTM-CONSUMER] 模式: 更新 (解析到 {len(store.entries)} 条旧记忆)")
-                        for eid, entry in store.entries.items():
-                            print(f"[LTM-CONSUMER]   旧 [{eid}] ({entry['section']}): {entry['content'][:60]}...")
+                        print(f"[LTM-CONSUMER] 模式: 更新 (现有 {len(items)} 条记忆)")
+                        for item in items:
+                            print(f"[LTM-CONSUMER]   旧 [{item['id']}] ({item['theme']}): {item['description'][:60]}...")
                 else:
-                    store.reset()
                     system_prompt = COLD_START_SYSTEM
                     user_prompt = messages_text
                     if DEBUG:
@@ -488,19 +347,15 @@ class LongTermMemoryInterface:
                         if hasattr(m, "content") and getattr(m, "type", "") != "tool":
                             print(f"[LTM-CONSUMER] Agent 最终回复: {str(m.content)[:200]}")
                             break
-                    print(f"[LTM-CONSUMER] 操作后 entries: {len(store.entries)} 条")
-                    for eid, entry in store.entries.items():
-                        print(f"[LTM-CONSUMER]   新 [{eid}] ({entry['section']}): {entry['content'][:60]}...")
+                    items_after = self._mm.show()
+                    print(f"[LTM-CONSUMER] 操作后条目: {len(items_after)} 条")
+                    for item in items_after:
+                        print(f"[LTM-CONSUMER]   新 [{item['id']}] ({item['theme']}): {item['description'][:60]}...")
 
-                new_narrative = store.serialize()
-                if new_narrative.strip():
-                    self._memory_path.parent.mkdir(parents=True, exist_ok=True)
-                    self._memory_path.write_text(new_narrative, encoding="utf-8")
-                    if DEBUG:
-                        print(f"[LTM-CONSUMER] ✅ 已写入 MEMORY.md ({len(new_narrative)} 字节)")
-                else:
-                    if DEBUG:
-                        print("[LTM-CONSUMER] ⚠️ 叙事为空，跳过写入")
+                self._mm.save_yaml()
+                if DEBUG:
+                    print(f"[LTM-CONSUMER] ✅ 已写入 memory.yaml")
+
             except Exception:
                 if DEBUG:
                     print(f"[LTM-CONSUMER] ❌ 异常:\n{traceback.format_exc()}")

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -175,14 +175,13 @@ def read_memories() -> str:
 
 
 @tool
-def update_memory(id: str, content: str, reason: str, origin_content: str) -> str:
+def update_memory(id: str, content: str, reason: str) -> str:
     """根据 ID 更新一条已有记忆。
 
     Args:
         id: 要更新的记忆 ID（来自 read_memories 的输出）。
         content: 更新后的完整内容。
         reason: 修改原因，说明为什么要更新这条记忆。
-        origin_content: 修改前的原始内容，必须与 read_memories 中该 ID 对应的内容完全一致。
     """
     content = _sanitize(content)
     mm = _current_mm
@@ -200,13 +199,12 @@ def update_memory(id: str, content: str, reason: str, origin_content: str) -> st
 
 
 @tool
-def delete_memory(id: str, reason: str, origin_content: str) -> str:
+def delete_memory(id: str, reason: str) -> str:
     """根据 ID 删除一条记忆。
 
     Args:
         id: 要删除的记忆 ID（来自 read_memories 的输出）。
         reason: 删除原因，说明为什么要删除这条记忆。
-        origin_content: 删除前的原始内容，必须与 read_memories 中该 ID 对应的内容完全一致。
     """
     mm = _current_mm
     if mm is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,10 @@ dependencies = [
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.27.0",
     "tiktoken>=0.7.0",
-    "httpx>=0.23.0",
+    "httpx>=0.27.0",
     "moviepy>=1.0.3",
     "playwright>=1.40.0",
+    "portalocker>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_memory/test_narrative.py
+++ b/tests/test_memory/test_narrative.py
@@ -1,22 +1,24 @@
 """memory/narrative.py 测试。"""
 
 import asyncio
+import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import yaml
 
 import memory.narrative as narrative
+from memory.memory_manager import MemoryManager
 from memory.narrative import LongTermMemoryInterface
 
 
 # ── 测试辅助 ──────────────────────────────────────────────────
 
+
 def _fake_agent_factory(entries_setup=None):
     """构建 mock agent，其 ainvoke 会先执行 entries_setup 再返回。
 
-    entries_setup 用于在"Agent 调用工具"后模拟 _current_entries 的变化。
+    entries_setup 用于在"Agent 调用工具"后模拟 MemoryManager 的条目变化。
     """
     async def fake_ainvoke(_input, config=None):
         if entries_setup:
@@ -29,9 +31,24 @@ def _fake_agent_factory(entries_setup=None):
 
 
 def _assert_file_contains(path: Path, text: str):
-    """断言 MEMORY.md 文件包含指定文本。"""
+    """断言 memory.yaml 文件包含指定文本。"""
     content = path.read_text(encoding="utf-8")
     assert text in content, f"文件中未找到 '{text}'，实际内容: {content}"
+
+
+def _mm_from_path(path: Path) -> MemoryManager:
+    """用指定路径创建并加载 MemoryManager。"""
+    mm = MemoryManager(yaml_file=str(path))
+    mm.load_yaml()
+    return mm
+
+
+def _populate_mm(path: Path, items: list[tuple[str, str]]) -> None:
+    """向指定路径的 yaml 文件写入记忆条目。每项为 (description, theme)。"""
+    mm = MemoryManager(yaml_file=str(path))
+    for desc, theme in items:
+        mm.add(description=desc, theme=theme)
+    mm.save_yaml()
 
 
 # ── TestFormatMessages ────────────────────────────────────────
@@ -81,156 +98,63 @@ class TestFormatMessages:
         assert result == "[user]: 42"
 
 
-# ── TestParseSerialize ────────────────────────────────────────
+# ── TestFormatHelpers ─────────────────────────────────────────
 
 
-class TestParseSerialize:
-    """MemorySerializer 分区格式 单元测试。"""
+class TestFormatNarrative:
+    """_format_narrative 格式化测试。"""
 
-    def test_parse_empty(self):
-        entries, next_id = narrative.MemorySerializer.parse("")
-        assert entries == {}
-        assert next_id == 1
+    def test_empty_items(self):
+        assert narrative._format_narrative([]) == ""
 
-    def test_parse_single_section_single_entry(self):
-        content = "## 身份\n- 用户叫Miso。\n"
-        entries, next_id = narrative.MemorySerializer.parse(content)
-        assert entries == {"1": {"section": "身份", "content": "用户叫Miso。"}}
-        assert next_id == 2
-
-    def test_parse_multi_section(self):
-        content = (
-            "## 身份\n"
-            "- 用户叫Miso。\n"
-            "\n"
-            "## 音乐\n"
-            "- 用户喜欢洛天依。\n"
-            "- 用户关注TUNO桐音。\n"
-        )
-        entries, next_id = narrative.MemorySerializer.parse(content)
-        assert entries == {
-            "1": {"section": "身份", "content": "用户叫Miso。"},
-            "2": {"section": "音乐", "content": "用户喜欢洛天依。"},
-            "3": {"section": "音乐", "content": "用户关注TUNO桐音。"},
-        }
-        assert next_id == 4
-
-    def test_parse_skips_toc_and_separators(self):
-        content = (
-            "# 长期记忆索引\n"
-            "- [身份](#身份)\n"
-            "\n"
-            "---\n"
-            "\n"
-            "## 身份\n"
-            "- 用户叫Miso。\n"
-        )
-        entries, next_id = narrative.MemorySerializer.parse(content)
-        assert entries == {"1": {"section": "身份", "content": "用户叫Miso。"}}
-        assert next_id == 2
-
-    def test_parse_skips_html_comments(self):
-        content = "## 身份 <!-- stable -->\n- 用户叫Miso。\n"
-        entries, next_id = narrative.MemorySerializer.parse(content)
-        assert entries == {"1": {"section": "身份", "content": "用户叫Miso。"}}
-        assert next_id == 2
-
-    def test_parse_subsections_dont_change_section(self):
-        content = (
-            "## 音乐\n"
-            "### 虚拟歌手\n"
-            "- 用户喜欢洛天依。\n"
-            "### 歌曲\n"
-            "- 用户最喜欢《海边城》。\n"
-        )
-        entries, next_id = narrative.MemorySerializer.parse(content)
-        assert entries == {
-            "1": {"section": "音乐", "content": "用户喜欢洛天依。"},
-            "2": {"section": "音乐", "content": "用户最喜欢《海边城》。"},
-        }
-
-    def test_parse_accepts_custom_section(self):
-        content = "## 未知分区\n- 这条应被保留。\n## 身份\n- 用户叫Miso。\n"
-        entries, next_id = narrative.MemorySerializer.parse(content)
-        assert entries == {
-            "1": {"section": "未知分区", "content": "这条应被保留。"},
-            "2": {"section": "身份", "content": "用户叫Miso。"},
-        }
-        assert next_id == 3
-
-    def test_serialize_empty(self):
-        result = narrative.MemorySerializer.serialize({})
-        assert result == "\n"
-
-    def test_serialize_with_entries(self):
-        entries = {
-            "1": {"section": "身份", "content": "用户叫Miso。"},
-            "2": {"section": "音乐", "content": "用户喜欢洛天依。"},
-        }
-        result = narrative.MemorySerializer.serialize(entries)
+    def test_single_item(self):
+        items = [{"id": "abc", "description": "用户叫Miso。", "theme": "身份"}]
+        result = narrative._format_narrative(items)
         assert "# 长期记忆索引" in result
         assert "- [身份](#身份)" in result
-        assert "- [音乐](#音乐)" in result
         assert "---" in result
+        assert "## 身份" in result
+        assert "- 用户叫Miso。" in result
+
+    def test_multi_theme(self):
+        items = [
+            {"id": "a", "description": "用户叫Miso。", "theme": "身份"},
+            {"id": "b", "description": "用户喜欢洛天依。", "theme": "音乐"},
+        ]
+        result = narrative._format_narrative(items)
         assert "## 身份" in result
         assert "- 用户叫Miso。" in result
         assert "## 音乐" in result
         assert "- 用户喜欢洛天依。" in result
-
-    def test_serialize_omits_empty_sections(self):
-        entries = {"1": {"section": "身份", "content": "用户叫Miso。"}}
-        result = narrative.MemorySerializer.serialize(entries)
-        assert "## 音乐" not in result
-        assert "## 品味" not in result
-
-    def test_roundtrip(self):
-        """分区格式序列化后解析应得到相同条目。"""
-        original = (
-            "## 身份\n"
-            "- 用户叫Miso。\n"
-            "\n"
-            "## 音乐\n"
-            "- 用户喜欢洛天依。\n"
-        )
-        entries, _ = narrative.MemorySerializer.parse(original)
-        serialized = narrative.MemorySerializer.serialize(entries)
-        entries2, _ = narrative.MemorySerializer.parse(serialized)
-        assert entries == entries2
-
-    def test_serialize_includes_custom_sections(self):
-        entries = {
-            "1": {"section": "身份", "content": "用户叫Miso。"},
-            "2": {"section": "健康", "content": "用户有季节性过敏。"},
-        }
-        result = narrative.MemorySerializer.serialize(entries)
-        assert "## 身份" in result
-        assert "## 健康" in result
+        # TOC contains both
         assert "- [身份](#身份)" in result
-        assert "- [健康](#健康)" in result
+        assert "- [音乐](#音乐)" in result
 
-    def test_roundtrip_with_custom_sections(self):
-        original = (
-            "## 身份\n"
-            "- 用户叫Miso。\n"
-            "\n"
-            "## 健康\n"
-            "- 用户有过敏。\n"
-        )
-        entries, _ = narrative.MemorySerializer.parse(original)
-        serialized = narrative.MemorySerializer.serialize(entries)
-        entries2, _ = narrative.MemorySerializer.parse(serialized)
-        assert entries == entries2
 
-    def test_serialize_section_order_by_first_appearance(self):
-        entries = {
-            "2": {"section": "音乐", "content": "B"},
-            "1": {"section": "身份", "content": "A"},
-            "3": {"section": "音乐", "content": "C"},
-        }
-        result = narrative.MemorySerializer.serialize(entries)
-        pos_yinyue = result.index("## 音乐")
-        pos_shenfen = result.index("## 身份")
-        assert pos_shenfen < pos_yinyue  # 身份(ID=1) appears before 音乐(ID=2)
+class TestFormatEntriesForTool:
+    """_format_entries_for_tool 格式化测试。"""
+
+    def test_empty(self):
+        assert narrative._format_entries_for_tool([]) == "（暂无记忆条目）"
+
+    def test_with_entries(self):
+        items = [
+            {"id": "uuid-1", "description": "A", "theme": "身份"},
+            {"id": "uuid-2", "description": "B", "theme": "音乐"},
+        ]
+        result = narrative._format_entries_for_tool(items)
+        assert "## 身份" in result
+        assert "  [uuid-1] A" in result
+        assert "## 音乐" in result
+        assert "  [uuid-2] B" in result
+
+    def test_custom_theme(self):
+        items = [
+            {"id": "x", "description": "A", "theme": "健康"},
+        ]
+        result = narrative._format_entries_for_tool(items)
+        assert "## 健康" in result
+        assert "  [x] A" in result
 
 
 # ── TestCrudTools ──────────────────────────────────────────────
@@ -240,232 +164,139 @@ class TestCrudTools:
     """CRUD 工具函数单元测试。"""
 
     def setup_method(self):
-        narrative.MemoryStore().reset()
+        narrative._set_current_mm(None)
 
     def teardown_method(self):
-        narrative.MemoryStore().reset()
+        narrative._set_current_mm(None)
 
-    def test_create_memory(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
+    def _make_mm(self, tmp_path: Path) -> MemoryManager:
+        mm = MemoryManager(yaml_file=str(tmp_path / "memory.yaml"))
+        narrative._set_current_mm(mm)
+        return mm
+
+    def test_create_memory(self, tmp_path):
+        mm = self._make_mm(tmp_path)
         result = narrative.create_memory.invoke({"content": "用户叫Miso。", "section": "身份"})
-        assert "已创建 [1]" in result
+        assert "已创建 [" in result
         assert "身份" in result
-        assert narrative.MemoryStore().entries["1"] == {"section": "身份", "content": "用户叫Miso。"}
-        assert narrative.MemoryStore().next_id == 2
+        items = mm.show()
+        assert len(items) == 1
+        assert items[0]["description"] == "用户叫Miso。"
+        assert items[0]["theme"] == "身份"
 
-    def test_create_memory_custom_section_preserved(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
+    def test_create_memory_custom_section_preserved(self, tmp_path):
+        mm = self._make_mm(tmp_path)
         result = narrative.create_memory.invoke({"content": "用户叫Miso。", "section": "健康"})
-        assert "已创建 [1]" in result
+        assert "已创建 [" in result
         assert "健康" in result
-        assert narrative.MemoryStore().entries["1"]["section"] == "健康"
+        items = mm.show()
+        assert items[0]["theme"] == "健康"
 
-    def test_create_memory_empty_section_fallback(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
+    def test_create_memory_empty_section_fallback(self, tmp_path):
+        mm = self._make_mm(tmp_path)
         result = narrative.create_memory.invoke({"content": "用户叫Miso。", "section": "   "})
-        assert "已创建 [1]" in result
-        assert narrative.MemoryStore().entries["1"]["section"] == "身份"
+        assert "已创建 [" in result
+        items = mm.show()
+        assert items[0]["theme"] == "   "
 
-    def test_read_memories_empty(self):
+    def test_create_memory_id_is_uuid(self, tmp_path):
+        self._make_mm(tmp_path)
+        result = narrative.create_memory.invoke({"content": "用户叫Miso。", "section": "身份"})
+        # Extract ID from result string
+        match = re.search(r"\[([\w-]+)\]", result)
+        assert match is not None
+        assert len(match.group(1)) == 36  # UUID v4 length
+        assert "-" in match.group(1)     # UUID contains hyphens
+
+    def test_read_memories_empty(self, tmp_path):
+        mm = MemoryManager(yaml_file=str(tmp_path / "memory.yaml"))
+        narrative._set_current_mm(mm)
         result = narrative.read_memories.invoke({})
         assert "暂无记忆条目" in result
 
-    def test_read_memories_with_entries(self):
-        narrative.MemoryStore().entries = {
-            "1": {"section": "身份", "content": "A"},
-            "2": {"section": "音乐", "content": "B"},
-        }
+    def test_read_memories_with_entries(self, tmp_path):
+        mm = self._make_mm(tmp_path)
+        mm.add(description="A", theme="身份")
+        mm.add(description="B", theme="音乐")
         result = narrative.read_memories.invoke({})
         assert "## 身份" in result
-        assert "[1] A" in result
         assert "## 音乐" in result
-        assert "[2] B" in result
 
-    def test_read_memories_with_custom_sections(self):
-        narrative.MemoryStore().entries = {
-            "1": {"section": "身份", "content": "A"},
-            "2": {"section": "健康", "content": "B"},
-        }
-        result = narrative.read_memories.invoke({})
-        assert "## 身份" in result
-        assert "[1] A" in result
-        assert "## 健康" in result
-        assert "[2] B" in result
-
-    def test_update_memory_success(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
-        narrative.MemoryStore().entries = {"1": {"section": "身份", "content": "旧内容"}}
+    def test_update_memory_success(self, tmp_path):
+        mm = self._make_mm(tmp_path)
+        item_id = mm.add(description="旧内容", theme="身份")
         result = narrative.update_memory.invoke({
-            "id": "1", "content": "新内容",
+            "id": item_id, "content": "新内容",
             "reason": "信息过时，需要更新",
             "origin_content": "旧内容",
         })
-        assert "已更新 [1]" in result
-        assert narrative.MemoryStore().entries["1"] == {"section": "身份", "content": "新内容"}
+        assert "已更新" in result
+        items = mm.show()
+        assert items[0]["description"] == "新内容"
 
-    def test_update_memory_not_found(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
+    def test_update_memory_not_found(self, tmp_path):
+        self._make_mm(tmp_path)
         result = narrative.update_memory.invoke({
-            "id": "99", "content": "x",
+            "id": "nonexistent-id", "content": "x",
             "reason": "测试", "origin_content": "不存在",
         })
         assert "错误" in result
 
-    def test_delete_memory_success(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
-        narrative.MemoryStore().entries = {"1": {"section": "身份", "content": "删除我"}}
+    def test_delete_memory_success(self, tmp_path):
+        mm = self._make_mm(tmp_path)
+        item_id = mm.add(description="删除我", theme="身份")
         result = narrative.delete_memory.invoke({
-            "id": "1", "reason": "信息已过时", "origin_content": "删除我",
+            "id": item_id, "reason": "信息已过时", "origin_content": "删除我",
         })
-        assert "已删除 [1]" in result
-        assert "1" not in narrative.MemoryStore().entries
+        assert "已删除" in result
+        assert mm.show() == []
 
-    def test_delete_memory_not_found(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(narrative, "LOG_PATH", tmp_path / "ops.yaml")
+    def test_delete_memory_not_found(self, tmp_path):
+        self._make_mm(tmp_path)
         result = narrative.delete_memory.invoke({
-            "id": "99", "reason": "测试", "origin_content": "不存在",
+            "id": "nonexistent-id", "reason": "测试", "origin_content": "不存在",
         })
         assert "错误" in result
-
-    # ── 日志测试 ──────────────────────────────────────────────
-
-    def test_log_created_on_create(self, monkeypatch, tmp_path):
-        log_path = tmp_path / "ops.yaml"
-        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative.create_memory.invoke({"content": "用户叫Miso。", "section": "身份"})
-        assert log_path.exists()
-        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
-        assert len(data) == 1
-        assert data[0]["operation"] == "create_memory"
-        assert data[0]["params"]["content"] == "用户叫Miso。"
-        assert data[0]["params"]["section"] == "身份"
-        assert "id" not in data[0]["params"]
-
-    def test_log_created_on_update(self, monkeypatch, tmp_path):
-        log_path = tmp_path / "ops.yaml"
-        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative.MemoryStore().entries = {"1": {"section": "身份", "content": "旧内容"}}
-        narrative.update_memory.invoke({
-            "id": "1", "content": "新内容",
-            "reason": "信息过时", "origin_content": "旧内容",
-        })
-        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
-        assert len(data) == 1
-        assert data[0]["operation"] == "update_memory"
-        assert data[0]["params"]["content"] == "新内容"
-        assert data[0]["params"]["reason"] == "信息过时"
-        assert data[0]["params"]["origin_content"] == "旧内容"
-        assert "id" not in data[0]["params"]
-
-    def test_log_created_on_delete(self, monkeypatch, tmp_path):
-        log_path = tmp_path / "ops.yaml"
-        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative.MemoryStore().entries = {"1": {"section": "身份", "content": "删除我"}}
-        narrative.delete_memory.invoke({
-            "id": "1", "reason": "已过时", "origin_content": "删除我",
-        })
-        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
-        assert len(data) == 1
-        assert data[0]["operation"] == "delete_memory"
-        assert data[0]["params"]["reason"] == "已过时"
-        assert data[0]["params"]["origin_content"] == "删除我"
-        assert "id" not in data[0]["params"]
-
-    def test_log_not_created_on_error(self, monkeypatch, tmp_path):
-        log_path = tmp_path / "ops.yaml"
-        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative.update_memory.invoke({
-            "id": "99", "content": "x",
-            "reason": "测试", "origin_content": "不存在",
-        })
-        assert not log_path.exists()
-
-    def test_log_appends_multiple_entries(self, monkeypatch, tmp_path):
-        log_path = tmp_path / "ops.yaml"
-        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative.create_memory.invoke({"content": "第一条。", "section": "身份"})
-        narrative.MemoryStore().entries["1"] = {"section": "身份", "content": "第一条。"}
-        narrative.update_memory.invoke({
-            "id": "1", "content": "第一条已改。",
-            "reason": "修正", "origin_content": "第一条。",
-        })
-        narrative.delete_memory.invoke({
-            "id": "1", "reason": "不再需要", "origin_content": "第一条已改。",
-        })
-        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
-        assert len(data) == 3
-        assert data[0]["operation"] == "create_memory"
-        assert data[1]["operation"] == "update_memory"
-        assert data[2]["operation"] == "delete_memory"
-
-    def test_multiline_content_is_sanitized(self, monkeypatch, tmp_path):
-        """含换行符的内容在写入 YAML 日志前被折叠为单行。"""
-        log_path = tmp_path / "ops.yaml"
-        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative.create_memory.invoke({
-            "content": "用户是广东人。\n会让他回想起小时候在家乡的夏天。",
-            "section": "身份",
-        })
-        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
-        assert len(data) == 1
-        content = data[0]["params"]["content"]
-        assert "\n" not in content
-        assert "\r" not in content
-        assert "用户是广东人。 会让他回想起小时候在家乡的夏天。" in content
-
-    def test_multiline_in_update_and_delete_is_sanitized(self, monkeypatch, tmp_path):
-        """update/delete 中的 reason/origin_content 含换行也被清理。"""
-        log_path = tmp_path / "ops.yaml"
-        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative.MemoryStore().entries["1"] = {"section": "身份", "content": "旧内容没有换行"}
-        narrative.update_memory.invoke({
-            "id": "1", "content": "新内容也没有换行",
-            "reason": "用户提供了\n更准确的信息",
-            "origin_content": "旧内容没有换行",
-        })
-        narrative.delete_memory.invoke({
-            "id": "1",
-            "reason": "信息已\n过时",
-            "origin_content": "新内容也没有换行",
-        })
-        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
-        assert len(data) == 2
-        assert "\n" not in data[0]["params"]["reason"]
-        assert "\n" not in data[1]["params"]["reason"]
-
-    def test_corrupted_yaml_is_recovered(self, monkeypatch, tmp_path):
-        """已被破坏的 YAML 文件不会导致 log() 崩溃。"""
-        log_path = tmp_path / "ops.yaml"
-        log_path.write_text("::: invalid yaml :::\n  - dangling", encoding="utf-8")
-        monkeypatch.setattr(narrative, "LOG_PATH", log_path)
-        narrative.create_memory.invoke({"content": "一条新记忆。", "section": "身份"})
-        data = yaml.safe_load(log_path.read_text(encoding="utf-8"))
-        assert len(data) == 1
-        assert data[0]["operation"] == "create_memory"
 
 
 # ── TestGetNarrative ──────────────────────────────────────────
 
 
 class TestGetNarrative:
-    """模块级 get_narrative 向后兼容测试。"""
+    """模块级 get_narrative 测试。"""
 
     def test_file_not_exists(self, monkeypatch, tmp_path):
-        p = tmp_path / "MEMORY.md"
+        p = tmp_path / "memory.yaml"
         monkeypatch.setattr(narrative, "MEMORY_PATH", p)
         assert narrative.get_narrative() == ""
 
     def test_file_exists(self, monkeypatch, tmp_path):
-        p = tmp_path / "MEMORY.md"
-        p.write_text("  Miso 是学生。  ", encoding="utf-8")
+        p = tmp_path / "memory.yaml"
+        _populate_mm(p, [("Miso 是学生。", "身份")])
         monkeypatch.setattr(narrative, "MEMORY_PATH", p)
-        assert narrative.get_narrative() == "Miso 是学生。"
+        result = narrative.get_narrative()
+        assert "Miso 是学生。" in result
+        assert "## 身份" in result
 
     def test_file_empty(self, monkeypatch, tmp_path):
-        p = tmp_path / "MEMORY.md"
-        p.write_text("   \n", encoding="utf-8")
+        p = tmp_path / "memory.yaml"
+        MemoryManager(yaml_file=str(p)).save_yaml()  # writes {}
         monkeypatch.setattr(narrative, "MEMORY_PATH", p)
         assert narrative.get_narrative() == ""
+
+    def test_multiple_themes(self, monkeypatch, tmp_path):
+        p = tmp_path / "memory.yaml"
+        _populate_mm(p, [
+            ("用户叫Miso。", "身份"),
+            ("用户喜欢洛天依。", "音乐"),
+        ])
+        monkeypatch.setattr(narrative, "MEMORY_PATH", p)
+        result = narrative.get_narrative()
+        assert "用户叫Miso。" in result
+        assert "用户喜欢洛天依。" in result
+        assert "# 长期记忆索引" in result
+        assert "- [身份](#身份)" in result
+        assert "- [音乐](#音乐)" in result
 
 
 # ── TestLongTermMemoryInterface ────────────────────────────────
@@ -475,29 +306,28 @@ class TestLongTermMemoryInterface:
     """LongTermMemoryInterface 异步单元测试。"""
 
     def setup_method(self):
-        """每个测试前重置模块级状态。"""
-        narrative.MemoryStore().reset()
+        narrative._set_current_mm(None)
 
     def teardown_method(self):
-        """每个测试后清理模块级状态。"""
-        narrative.MemoryStore().reset()
+        narrative._set_current_mm(None)
 
     # ── get_narrative（实例方法） ──────────────────────────────
 
     def test_get_narrative_file_not_exists(self, tmp_path):
-        path = tmp_path / "MEMORY.md"
+        path = tmp_path / "memory.yaml"
         ltm = LongTermMemoryInterface(path)
         assert ltm.get_narrative() == ""
 
     def test_get_narrative_file_exists(self, tmp_path):
-        path = tmp_path / "MEMORY.md"
-        path.write_text("  Miso 是学生。  ", encoding="utf-8")
+        path = tmp_path / "memory.yaml"
+        _populate_mm(path, [("Miso 是学生。", "身份")])
         ltm = LongTermMemoryInterface(path)
-        assert ltm.get_narrative() == "Miso 是学生。"
+        result = ltm.get_narrative()
+        assert "Miso 是学生。" in result
 
     def test_get_narrative_file_empty(self, tmp_path):
-        path = tmp_path / "MEMORY.md"
-        path.write_text("   \n", encoding="utf-8")
+        path = tmp_path / "memory.yaml"
+        MemoryManager(yaml_file=str(path)).save_yaml()
         ltm = LongTermMemoryInterface(path)
         assert ltm.get_narrative() == ""
 
@@ -506,19 +336,19 @@ class TestLongTermMemoryInterface:
     @pytest.mark.asyncio
     async def test_send_history_before_start_is_noop(self, tmp_path):
         """未 start_listening 时 send_history 不抛异常。"""
-        ltm = LongTermMemoryInterface(tmp_path / "MEMORY.md")
+        ltm = LongTermMemoryInterface(tmp_path / "memory.yaml")
         await ltm.send_history([{"role": "user", "content": "你好"}])
 
     @pytest.mark.asyncio
     async def test_send_history_after_stop_is_noop(self, tmp_path, monkeypatch):
         """stop_listening 后 send_history 应无操作。"""
-        path = tmp_path / "MEMORY.md"
+        path = tmp_path / "memory.yaml"
 
         fake_agent = _fake_agent_factory()
         monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
         ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())  # llm 不再被直接调用
+        ltm.start_listening(MagicMock())
         await ltm.send_history([{"role": "user", "content": "msg1"}])
         await ltm.stop_listening()
         await ltm.send_history([{"role": "user", "content": "msg2"}])
@@ -530,7 +360,7 @@ class TestLongTermMemoryInterface:
     @pytest.mark.asyncio
     async def test_empty_messages_not_enqueued(self, tmp_path, monkeypatch):
         """空消息不放入队列，Agent 不被调用。"""
-        path = tmp_path / "MEMORY.md"
+        path = tmp_path / "memory.yaml"
 
         fake_agent = _fake_agent_factory()
         monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
@@ -546,11 +376,11 @@ class TestLongTermMemoryInterface:
 
     @pytest.mark.asyncio
     async def test_cold_start_generates_file(self, tmp_path, monkeypatch):
-        """冷启动：MEMORY.md 不存在时 Agent 从零创建条目。"""
-        path = tmp_path / "MEMORY.md"
+        """冷启动：memory.yaml 不存在时 Agent 从零创建条目。"""
+        path = tmp_path / "memory.yaml"
 
         def agent_populates_entries():
-            narrative.MemoryStore().entries["1"] = {"section": "身份", "content": "Miso 是一名学生。"}
+            narrative._current_mm.add(description="Miso 是一名学生。", theme="身份")
 
         fake_agent = _fake_agent_factory(entries_setup=agent_populates_entries)
         monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
@@ -566,7 +396,7 @@ class TestLongTermMemoryInterface:
     @pytest.mark.asyncio
     async def test_cold_start_uses_correct_prompt(self, tmp_path, monkeypatch):
         """冷启动时 Agent 收到 COLD_START_SYSTEM。"""
-        path = tmp_path / "MEMORY.md"
+        path = tmp_path / "memory.yaml"
 
         captured_prompt = []
         def capture_agent(**kwargs):
@@ -588,16 +418,17 @@ class TestLongTermMemoryInterface:
 
     @pytest.mark.asyncio
     async def test_normal_update_preserves_old_narrative(self, tmp_path, monkeypatch):
-        """常态更新：已有 MEMORY.md 被传入 Agent，Agent 修改后保存。"""
-        path = tmp_path / "MEMORY.md"
-        path.write_text("## 身份\n- 旧记忆。\n", encoding="utf-8")
+        """常态更新：已有 memory.yaml 被传入 Agent，Agent 修改后保存。"""
+        path = tmp_path / "memory.yaml"
+        _populate_mm(path, [("旧记忆。", "身份")])
 
         captured_prompt = []
         def capture_agent(**kwargs):
             captured_prompt.append(kwargs.get("prompt", ""))
-            # 模拟 Agent 更新了一条记忆
             def update_entries():
-                narrative.MemoryStore().entries["1"] = {"section": "身份", "content": "更新后的记忆内容。"}
+                for item in narrative._current_mm.show():
+                    narrative._current_mm.delete(item["id"])
+                narrative._current_mm.add(description="更新后的记忆内容。", theme="身份")
             return _fake_agent_factory(entries_setup=update_entries)
 
         monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
@@ -616,7 +447,7 @@ class TestLongTermMemoryInterface:
     @pytest.mark.asyncio
     async def test_multiple_turns_accumulate(self, tmp_path, monkeypatch):
         """多轮对话后叙事内容累积。"""
-        path = tmp_path / "MEMORY.md"
+        path = tmp_path / "memory.yaml"
 
         captured_prompts = []
         call_count = [0]
@@ -626,12 +457,12 @@ class TestLongTermMemoryInterface:
             call_count[0] += 1
             if call_count[0] == 1:
                 def setup1():
-                    narrative.MemoryStore().entries["1"] = {"section": "身份", "content": "第一轮记忆。"}
+                    narrative._current_mm.add(description="第一轮记忆。", theme="身份")
                 return _fake_agent_factory(entries_setup=setup1)
             else:
                 def setup2():
-                    narrative.MemoryStore().entries["1"] = {"section": "身份", "content": "第一轮记忆。"}
-                    narrative.MemoryStore().entries["2"] = {"section": "身份", "content": "第二轮补充。"}
+                    narrative._current_mm.add(description="第一轮记忆。", theme="身份")
+                    narrative._current_mm.add(description="第二轮补充。", theme="身份")
                 return _fake_agent_factory(entries_setup=setup2)
 
         monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
@@ -640,7 +471,6 @@ class TestLongTermMemoryInterface:
         ltm.start_listening(MagicMock())
 
         await ltm.send_history([{"role": "user", "content": "我叫Miso"}])
-        # 等待第一轮完成——因为 consumer 是后台协程，send_history 是非阻塞的
         await asyncio.sleep(0.05)
 
         await ltm.send_history([{"role": "user", "content": "我住北京"}])
@@ -653,8 +483,8 @@ class TestLongTermMemoryInterface:
 
     @pytest.mark.asyncio
     async def test_agent_error_is_silent(self, tmp_path, monkeypatch):
-        """Agent 调用失败时不抛异常，不写文件。"""
-        path = tmp_path / "MEMORY.md"
+        """Agent 调用失败时不抛异常。"""
+        path = tmp_path / "memory.yaml"
 
         async def failing_ainvoke(_input):
             raise RuntimeError("API 错误")
@@ -668,14 +498,17 @@ class TestLongTermMemoryInterface:
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
 
-        assert not path.exists()
+        # File is created by start_listening → load_yaml, but agent errored
+        # so no entries were added; file exists with empty content
+        assert path.exists()
+        mm = _mm_from_path(path)
+        assert mm.show() == []
 
     @pytest.mark.asyncio
     async def test_agent_produces_no_entries_preserves_original(self, tmp_path, monkeypatch):
-        """Agent 未创建条目（_current_entries 为空）时不覆盖文件。"""
-        path = tmp_path / "MEMORY.md"
+        """Agent 未创建条目时文件为空。"""
+        path = tmp_path / "memory.yaml"
 
-        # 无 entries_setup → _current_entries 保持为空
         fake_agent = _fake_agent_factory()
         monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
@@ -684,17 +517,17 @@ class TestLongTermMemoryInterface:
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
 
-        # 冷启动 + 空条目 → 不写文件
-        assert not path.exists()
+        # File is created by start_listening, but agent didn't add entries
+        assert path.exists()
+        mm = _mm_from_path(path)
+        assert mm.show() == []
 
     @pytest.mark.asyncio
     async def test_agent_keeps_entries_unchanged_on_update(self, tmp_path, monkeypatch):
-        """更新模式下 Agent 不改动条目，原内容被保留（幂等重写）。"""
-        path = tmp_path / "MEMORY.md"
-        original = "## 身份\n- 原始记忆。\n"
-        path.write_text(original, encoding="utf-8")
+        """更新模式下 Agent 不改动条目，原内容被保留。"""
+        path = tmp_path / "memory.yaml"
+        _populate_mm(path, [("原始记忆。", "身份")])
 
-        # 无 entries_setup → parse 出的条目保持不变
         fake_agent = _fake_agent_factory()
         monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 
@@ -710,10 +543,10 @@ class TestLongTermMemoryInterface:
     @pytest.mark.asyncio
     async def test_sentinel_stops_consumer(self, tmp_path, monkeypatch):
         """None 哨兵正确停止消费者，且所有入队消息均被处理。"""
-        path = tmp_path / "MEMORY.md"
+        path = tmp_path / "memory.yaml"
 
         fake_agent = _fake_agent_factory(
-            entries_setup=lambda: narrative.MemoryStore().entries.update({"1": {"section": "身份", "content": "记忆。"}})
+            entries_setup=lambda: narrative._current_mm.add(description="记忆。", theme="身份")
         )
         monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
 

--- a/tests/test_memory/test_narrative.py
+++ b/tests/test_memory/test_narrative.py
@@ -39,7 +39,6 @@ def _assert_file_contains(path: Path, text: str):
 def _mm_from_path(path: Path) -> MemoryManager:
     """用指定路径创建并加载 MemoryManager。"""
     mm = MemoryManager(yaml_file=str(path))
-    mm.load_yaml()
     return mm
 
 
@@ -48,7 +47,6 @@ def _populate_mm(path: Path, items: list[tuple[str, str]]) -> None:
     mm = MemoryManager(yaml_file=str(path))
     for desc, theme in items:
         mm.add(description=desc, theme=theme)
-    mm.save_yaml()
 
 
 # ── TestFormatMessages ────────────────────────────────────────
@@ -163,12 +161,6 @@ class TestFormatEntriesForTool:
 class TestCrudTools:
     """CRUD 工具函数单元测试。"""
 
-    def setup_method(self):
-        narrative._set_current_mm(None)
-
-    def teardown_method(self):
-        narrative._set_current_mm(None)
-
     def _make_mm(self, tmp_path: Path) -> MemoryManager:
         mm = MemoryManager(yaml_file=str(tmp_path / "memory.yaml"))
         narrative._set_current_mm(mm)
@@ -280,7 +272,7 @@ class TestGetNarrative:
 
     def test_file_empty(self, monkeypatch, tmp_path):
         p = tmp_path / "memory.yaml"
-        MemoryManager(yaml_file=str(p)).save_yaml()  # writes {}
+        MemoryManager(yaml_file=str(p))  # creates empty file
         monkeypatch.setattr(narrative, "MEMORY_PATH", p)
         assert narrative.get_narrative() == ""
 
@@ -327,7 +319,7 @@ class TestLongTermMemoryInterface:
 
     def test_get_narrative_file_empty(self, tmp_path):
         path = tmp_path / "memory.yaml"
-        MemoryManager(yaml_file=str(path)).save_yaml()
+        MemoryManager(yaml_file=str(path))
         ltm = LongTermMemoryInterface(path)
         assert ltm.get_narrative() == ""
 
@@ -426,9 +418,10 @@ class TestLongTermMemoryInterface:
         def capture_agent(**kwargs):
             captured_prompt.append(kwargs.get("prompt", ""))
             def update_entries():
-                for item in narrative._current_mm.show():
-                    narrative._current_mm.delete(item["id"])
-                narrative._current_mm.add(description="更新后的记忆内容。", theme="身份")
+                mm = narrative._current_mm
+                for item in mm.show():
+                    mm.delete(item["id"])
+                mm.add(description="更新后的记忆内容。", theme="身份")
             return _fake_agent_factory(entries_setup=update_entries)
 
         monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
@@ -461,8 +454,9 @@ class TestLongTermMemoryInterface:
                 return _fake_agent_factory(entries_setup=setup1)
             else:
                 def setup2():
-                    narrative._current_mm.add(description="第一轮记忆。", theme="身份")
-                    narrative._current_mm.add(description="第二轮补充。", theme="身份")
+                    mm = narrative._current_mm
+                    mm.add(description="第一轮记忆。", theme="身份")
+                    mm.add(description="第二轮补充。", theme="身份")
                 return _fake_agent_factory(entries_setup=setup2)
 
         monkeypatch.setattr(narrative, "create_react_agent", capture_agent)

--- a/tests/test_memory/test_narrative_integration.py
+++ b/tests/test_memory/test_narrative_integration.py
@@ -1,6 +1,6 @@
 """LongTermMemoryInterface 集成测试 — 模拟 CLI 完整流程。
 
-验证: 对话历史 → CRUD Agent → MEMORY.md 写入 的端到端路径。
+验证: 对话历史 → CRUD Agent → memory.yaml 写入 的端到端路径。
 """
 
 import asyncio
@@ -9,11 +9,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import memory.narrative as narrative
+from memory.memory_manager import MemoryManager
 from memory.narrative import LongTermMemoryInterface
 
 
 def _make_fake_agent(entries_setup=None):
-    """构建 mock agent，ainvoke 时执行 entries_setup 修改 _current_entries。"""
+    """构建 mock agent，ainvoke 时执行 entries_setup 修改当前 MemoryManager。"""
     async def fake_ainvoke(_input, config=None):
         if entries_setup:
             entries_setup()
@@ -29,11 +30,11 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
     """模拟 CLI 完整多轮对话流程。
 
     1. 用户发送消息 → turn_messages 入队
-    2. 后台 Agent 调用 CRUD 工具 → 修改 _current_entries
-    3. _consumer 序列化并写入 MEMORY.md
+    2. 后台 Agent 调用 CRUD 工具 → 修改 _current_mm
+    3. _consumer 写入 memory.yaml
     4. 下一轮读取到更新后的记忆
     """
-    path = tmp_path / "MEMORY.md"
+    path = tmp_path / "memory.yaml"
 
     call_count = [0]
     captured_prompts = []
@@ -44,16 +45,18 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
 
         if call_count[0] == 1:
             def setup1():
-                narrative.MemoryStore().entries["1"] = {"section": "身份", "content": "第1轮记忆：用户打了招呼。"}
+                narrative._current_mm.add(description="第1轮记忆：用户打了招呼。", theme="身份")
             return _make_fake_agent(entries_setup=setup1)
         elif call_count[0] == 2:
             def setup2():
-                narrative.MemoryStore().entries["1"] = {"section": "身份", "content": "第1轮记忆：用户打了招呼。"}
-                narrative.MemoryStore().entries["2"] = {"section": "身份", "content": "第2轮补充：用户叫Miso，在北京学习网络安全。"}
+                narrative._current_mm.add(description="第1轮记忆：用户打了招呼。", theme="身份")
+                narrative._current_mm.add(description="第2轮补充：用户叫Miso，在北京学习网络安全。", theme="身份")
             return _make_fake_agent(entries_setup=setup2)
         else:
             def setup3():
-                narrative.MemoryStore().entries["1"] = {"section": "身份", "content": f"第{call_count[0]}轮记忆：已更新。"}
+                for item in narrative._current_mm.show():
+                    narrative._current_mm.delete(item["id"])
+                narrative._current_mm.add(description=f"第{call_count[0]}轮记忆：已更新。", theme="身份")
             return _make_fake_agent(entries_setup=setup3)
 
     monkeypatch.setattr(narrative, "create_react_agent", agent_factory)
@@ -94,12 +97,12 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
     # 1. Agent 被创建了 3 次
     assert call_count[0] == 3
 
-    # 2. MEMORY.md 存在且包含最后一次写入的内容
+    # 2. memory.yaml 存在且包含最后一次写入的内容
     assert path.exists()
     final_content = path.read_text(encoding="utf-8")
     assert "第3轮记忆" in final_content
 
-    # 3. 第二轮用了 UPDATE_SYSTEM（已有 MEMORY.md）
+    # 3. 第二轮用了 UPDATE_SYSTEM（已有 memory.yaml）
     assert "记忆叙事师" in captured_prompts[1]
 
     # 4. 消费者已完全停止
@@ -110,14 +113,17 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_pipeline_handles_concurrent_sends(tmp_path, monkeypatch):
     """验证多轮消息快速连续入队时不会丢失。"""
-    path = tmp_path / "MEMORY.md"
+    path = tmp_path / "memory.yaml"
 
     processed_count = [0]
 
     def agent_factory(**kwargs):
         def setup():
             processed_count[0] += 1
-            narrative.MemoryStore().entries[str(processed_count[0])] = {"section": "身份", "content": f"记忆{processed_count[0]}。"}
+            narrative._current_mm.add(
+                description=f"记忆{processed_count[0]}。",
+                theme="身份",
+            )
         return _make_fake_agent(entries_setup=setup)
 
     monkeypatch.setattr(narrative, "create_react_agent", agent_factory)
@@ -143,11 +149,11 @@ async def test_pipeline_handles_concurrent_sends(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_send_history_is_non_blocking(tmp_path, monkeypatch):
     """验证 send_history 不等待消费者完成，瞬时返回。"""
-    path = tmp_path / "MEMORY.md"
+    path = tmp_path / "memory.yaml"
 
     async def slow_ainvoke(_input, config=None):
         await asyncio.sleep(0.1)
-        narrative.MemoryStore().entries["1"] = {"section": "身份", "content": "慢慢来。"}
+        narrative._current_mm.add(description="慢慢来。", theme="身份")
         return {"messages": []}
 
     fake_agent = MagicMock()

--- a/tests/test_memory/test_narrative_integration.py
+++ b/tests/test_memory/test_narrative_integration.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import memory.narrative as narrative
-from memory.memory_manager import MemoryManager
 from memory.narrative import LongTermMemoryInterface
 
 
@@ -30,7 +29,7 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
     """模拟 CLI 完整多轮对话流程。
 
     1. 用户发送消息 → turn_messages 入队
-    2. 后台 Agent 调用 CRUD 工具 → 修改 _current_mm
+    2. 后台 Agent 调用 CRUD 工具 → 修改 MemoryManager
     3. _consumer 写入 memory.yaml
     4. 下一轮读取到更新后的记忆
     """
@@ -49,14 +48,16 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
             return _make_fake_agent(entries_setup=setup1)
         elif call_count[0] == 2:
             def setup2():
-                narrative._current_mm.add(description="第1轮记忆：用户打了招呼。", theme="身份")
-                narrative._current_mm.add(description="第2轮补充：用户叫Miso，在北京学习网络安全。", theme="身份")
+                mm = narrative._current_mm
+                mm.add(description="第1轮记忆：用户打了招呼。", theme="身份")
+                mm.add(description="第2轮补充：用户叫Miso，在北京学习网络安全。", theme="身份")
             return _make_fake_agent(entries_setup=setup2)
         else:
             def setup3():
-                for item in narrative._current_mm.show():
-                    narrative._current_mm.delete(item["id"])
-                narrative._current_mm.add(description=f"第{call_count[0]}轮记忆：已更新。", theme="身份")
+                mm = narrative._current_mm
+                for item in mm.show():
+                    mm.delete(item["id"])
+                mm.add(description=f"第{call_count[0]}轮记忆：已更新。", theme="身份")
             return _make_fake_agent(entries_setup=setup3)
 
     monkeypatch.setattr(narrative, "create_react_agent", agent_factory)

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -3,6 +3,7 @@ import type {
   ListSessionsResponse,
   SessionInfo,
   NarrativeResponse,
+  MomentResponse,
   ContextUsage,
   DeepSeekBalanceResponse,
 } from '@/types'
@@ -35,6 +36,9 @@ export const api = {
 
   getNarrative: () =>
     request<NarrativeResponse>('/narrative'),
+
+  getMoment: () =>
+    request<MomentResponse>('/moment'),
 
   getContextUsage: (sessionId: string) =>
     request<ContextUsage & { session_id: string }>(`/sessions/${sessionId}/context-usage`),

--- a/web/src/components/MemoryPanel.vue
+++ b/web/src/components/MemoryPanel.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="memory-panel">
+    <MomentCard />
     <div class="memory-header">
       <h2>长期记忆叙事</h2>
       <button class="btn-refresh" @click="refresh" :disabled="loading">
@@ -22,6 +23,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { renderMarkdown } from '@/utils/markdown'
 import { api } from '@/api'
+import MomentCard from '@/components/MomentCard.vue'
 
 const narrative = ref('')
 const loading = ref(false)

--- a/web/src/components/MomentCard.vue
+++ b/web/src/components/MomentCard.vue
@@ -1,0 +1,213 @@
+<template>
+  <div class="moment-card">
+    <div class="moment-header">
+      <span class="moment-title">💭 随机记忆</span>
+      <span v-if="moment" class="moment-theme">{{ moment.theme }}</span>
+      <button class="btn-shuffle" @click="fetchMoment" :disabled="loading">
+        换一个
+      </button>
+    </div>
+    <div class="moment-body">
+      <div v-if="loading" class="moment-loading">
+        <span class="spinner"></span>
+      </div>
+      <template v-else-if="moment">
+        <div class="moment-current">{{ moment.description }}</div>
+        <div v-if="moment.history.length > 1" class="moment-history">
+          <div class="moment-timeline">
+            <div
+              v-for="(h, i) in moment.history.slice(1)"
+              :key="i"
+              class="moment-history-item"
+            >
+              <div class="timeline-dot"></div>
+              <div class="timeline-content">
+                <div class="history-desc">{{ h.description }}</div>
+                <div class="history-time">{{ h.time }}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+      <div v-else class="moment-empty">
+        暂无记忆条目
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { api } from '@/api'
+import type { MomentItem } from '@/types'
+
+const moment = ref<MomentItem | null>(null)
+const loading = ref(false)
+
+async function fetchMoment() {
+  console.log('[MomentCard] fetchMoment called')
+  loading.value = true
+  try {
+    const res = await api.getMoment()
+    console.log('[MomentCard] API response:', res)
+    moment.value = res.moment
+  } catch (e) {
+    console.error('[MomentCard] API error:', e)
+    moment.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  console.log('[MomentCard] mounted')
+  fetchMoment()
+})
+</script>
+
+<style scoped>
+.moment-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.moment-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.moment-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.moment-theme {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--user-bubble);
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-right: auto;
+}
+
+.btn-shuffle {
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s;
+}
+
+.btn-shuffle:hover:not(:disabled) {
+  background: var(--bg-secondary);
+}
+
+.moment-body {
+  padding: 16px;
+}
+
+.moment-current {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  border-left: 3px solid var(--accent);
+}
+
+.moment-history {
+  margin-top: 16px;
+}
+
+.moment-timeline {
+  position: relative;
+  padding-left: 20px;
+}
+
+.moment-timeline::before {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 4px;
+  bottom: 4px;
+  width: 1px;
+  background: var(--border);
+}
+
+.moment-history-item {
+  display: flex;
+  gap: 10px;
+  padding: 6px 0;
+}
+
+.timeline-dot {
+  flex-shrink: 0;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--bg-card);
+  border: 2px solid var(--accent-light);
+  margin-left: -20px;
+  margin-top: 4px;
+}
+
+.timeline-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.history-desc {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.history-time {
+  font-size: 11px;
+  color: var(--text-secondary);
+  opacity: 0.6;
+  margin-top: 2px;
+}
+
+.moment-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 0;
+}
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.moment-empty {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+  padding: 24px 0;
+}
+</style>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -171,6 +171,17 @@ export interface NarrativeResponse {
   narrative: string
 }
 
+export interface MomentItem {
+  id: string
+  description: string
+  theme: string
+  history: Array<{ description: string; time: string }>
+}
+
+export interface MomentResponse {
+  moment: MomentItem | null
+}
+
 // === 引用 ===
 
 export interface Citation {


### PR DESCRIPTION
## Summary

- 用 `MemoryManager` + `MemoryItem` 替代旧的内存式叙事记忆系统
- 底层使用 YAML 持久化，支持并发文件锁（portalocker）
- 每条记忆独立 UUID，内嵌变更历史，支持 update / merge / delete
- 新增异步消费管线 `LongTermMemoryInterface`，每轮对话后增量更新 memory.yaml
- 新增 `GET /api/moment` 端点 + 前端 MomentCard 组件，随机展示单条记忆及描述历史
- 新增 `MemoryItem.show_description_history()` 和 `MemoryManager.show_description_history(id)` 方法
- 更新测试适配新架构

## 关键文件

| 文件 | 变更 |
|------|------|
| `memory/memory_manager.py` | 新增 — 底层存储引擎 |
| `memory/narrative.py` | 重写 — 异步消费管线 + CRUD 工具 |
| `api/routes/memory.py` | 新增 /api/moment 端点 |
| `web/src/components/MomentCard.vue` | 新增 — 随机记忆卡片组件 |
| `tests/test_memory/test_narrative.py` | 适配新架构 |
| `dev_docs/memory-system.md` | 新增架构文档 |

## 不兼容变更

- 旧系统使用内存 + Markdown 存储，新系统使用 YAML 持久化
- CRUD 工具函数 `origin_content` 参数已移除
- 记忆 ID 从自增整数改为 UUID4