### PR TITLE
feat(word-bubble): MCP Word工具结构化气泡展示及提取器

### DIFF
--- a/api/callbacks/tool_extractors.py
+++ b/api/callbacks/tool_extractors.py
@@ -958,3 +958,275 @@ def _extract_scrape(
     if "screenshot_base64" in data:
         result["screenshot_base64"] = data["screenshot_base64"]
     return result
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Word MCP 工具系列（word_* 前缀）
+# ═══════════════════════════════════════════════════════════════════════
+
+import re as _re
+
+# ── 工具名 → 动作名映射 ──
+
+_WORD_ACTION_MAP: dict[str, str] = {
+    "create_document": "create_document",
+    "copy_document": "copy_document",
+    "merge_documents": "merge_documents",
+    "get_document_info": "get_document_info",
+    "get_document_text": "get_document_text",
+    "get_document_outline": "get_document_outline",
+    "list_available_documents": "list_documents",
+    "get_document_xml": "get_document_xml",
+    "add_paragraph": "add_paragraph",
+    "add_heading": "add_heading",
+    "add_table": "add_table",
+    "add_picture": "add_picture",
+    "add_page_break": "add_page_break",
+    "add_table_of_contents": "add_toc",
+    "delete_paragraph": "delete_paragraph",
+    "search_and_replace": "search_replace",
+    "insert_header_near_text": "insert_heading",
+    "insert_line_or_paragraph_near_text": "insert_paragraph",
+    "insert_numbered_list_near_text": "insert_list",
+    "replace_paragraph_block_below_header": "replace_block",
+    "replace_block_between_manual_anchors": "replace_anchors",
+    "format_text": "format_text",
+    "create_custom_style": "create_style",
+    "format_table": "format_table",
+    "set_table_column_width": "table_set_column_width",
+    "set_table_column_widths": "table_set_column_widths",
+    "set_table_width": "table_set_width",
+    "set_table_cell_shading": "table_cell_shading",
+    "set_table_cell_alignment": "table_cell_alignment",
+    "set_table_alignment_all": "table_alignment",
+    "apply_table_alternating_rows": "table_alternating",
+    "highlight_table_header": "table_highlight_header",
+    "merge_table_cells": "table_merge_cells",
+    "merge_table_cells_horizontal": "table_merge_horizontal",
+    "merge_table_cells_vertical": "table_merge_vertical",
+    "auto_fit_table_columns": "table_auto_fit",
+    "format_table_cell_text": "table_format_cell",
+    "set_table_cell_padding": "table_cell_padding",
+    "protect_document": "protect",
+    "unprotect_document": "unprotect",
+    "add_footnote_to_document": "add_footnote",
+    "add_footnote_after_text": "add_footnote_after",
+    "add_footnote_before_text": "add_footnote_before",
+    "add_footnote_enhanced": "add_footnote_enhanced",
+    "add_footnote_robust": "add_footnote_robust",
+    "add_endnote_to_document": "add_endnote",
+    "customize_footnote_style": "customize_footnote_style",
+    "delete_footnote_from_document": "delete_footnote",
+    "delete_footnote_robust": "delete_footnote_robust",
+    "validate_document_footnotes": "validate_footnotes",
+    "get_paragraph_text_from_document": "get_paragraph",
+    "find_text_in_document": "find_text",
+    "convert_to_pdf": "convert_to_pdf",
+    "get_all_comments": "get_comments",
+    "get_comments_by_author": "get_comments_author",
+    "get_comments_for_paragraph": "get_comments_paragraph",
+}
+
+
+def _get_word_short_name(tool_name: str) -> str:
+    """从 word_create_document 提取 create_document。"""
+    return tool_name[len("word_"):] if tool_name.startswith("word_") else tool_name
+
+
+def _parse_word_raw_output(raw: str, tool_name: str) -> dict[str, Any]:
+    """解析 Word 工具的纯文本输出，返回结构化数据。"""
+    short_name = _get_word_short_name(tool_name)
+    action = _WORD_ACTION_MAP.get(short_name, short_name)
+
+    result: dict[str, Any] = {
+        "tool_type": "word",
+        "action": action,
+        "success": False,
+        "message": raw[:300] if len(raw) > 300 else raw,
+    }
+
+    # 提取文件名：匹配 .docx 路径
+    fn_match = _re.search(r"([^\s]+\.docx)", raw)
+    if fn_match:
+        result["filename"] = fn_match.group(1)
+
+    # 判断成功/失败
+    if raw.startswith("Cannot") or raw.startswith("Failed") or raw.startswith("Invalid"):
+        result["success"] = False
+        # 提取错误信息
+        err_match = _re.search(r"(?:Cannot|Failed to)\s+[^:]+:\s*(.+)", raw)
+        if err_match:
+            result["error"] = err_match.group(1)
+        elif "does not exist" in raw:
+            result["error"] = "文档不存在"
+        return result
+
+    if "successfully" in raw or "Successfully" in raw or "added" in raw or "deleted" in raw or "Replaced" in raw or "occurrence" in raw:
+        result["success"] = True
+
+    # ── 各工具特有信息提取 ──
+
+    # 创建文档: "Document report.docx created successfully"
+    if action == "create_document":
+        m = _re.search(r"'(.*?)'", raw)
+        if not m:
+            m = _re.search(r"Document\s+(.+?)\s+created", raw)
+        if m:
+            result["filename"] = m.group(1)
+
+    # 复制文档
+    elif action == "copy_document":
+        m = _re.search(r"'(.*?)'", raw)
+        if m:
+            result["filename"] = m.group(1)
+
+    # 合并文档
+    elif action == "merge_documents":
+        m = _re.search(r"(\d+)\s+documents?\s+into", raw)
+        if m:
+            result["count"] = int(m.group(1))
+
+    # 添加标题: "Heading 'Intro' (level 2) added to report.docx"
+    elif action == "add_heading":
+        m = _re.search(r"'([^']*)'.*?level\s+(\d+)", raw)
+        if m:
+            result["text"] = m.group(1)
+            result["level"] = int(m.group(2))
+
+    # 添加段落
+    elif action == "add_paragraph":
+        result["text_preview"] = True
+
+    # 添加表格: "Table (3x4) added to..."
+    elif action == "add_table":
+        m = _re.search(r"\((\d+)x(\d+)\)", raw)
+        if m:
+            result["rows"] = int(m.group(1))
+            result["cols"] = int(m.group(2))
+
+    # 插入图片
+    elif action == "add_picture":
+        m = _re.search(r"Picture\s+(.+?)\s+added", raw)
+        if m:
+            result["image_path"] = m.group(1)
+
+    # 查找替换: "Replaced 3 occurrence(s) of 'foo' with 'bar'."
+    elif action == "search_replace":
+        m = _re.search(r"Replaced\s+(\d+)\s+occurrence", raw)
+        if m:
+            result["count"] = int(m.group(1))
+        m = _re.search(r"of\s+'([^']*)'\s+with\s+'([^']*)'", raw)
+        if m:
+            result["find_text"] = m.group(1)
+            result["replace_text"] = m.group(2)
+        if "No occurrences" in raw:
+            result["count"] = 0
+
+    # 删除段落
+    elif action == "delete_paragraph":
+        m = _re.search(r"index\s+(\d+)", raw)
+        if m:
+            result["paragraph_index"] = int(m.group(1))
+
+    # 保护文档
+    elif action in ("protect", "unprotect"):
+        if "password" in raw.lower():
+            m = _re.search(r"'(.*?)'", raw)
+            if m:
+                result["password"] = m.group(1)
+
+    # 脚注相关
+    elif "footnote" in action or "endnote" in action:
+        m = _re.search(r"(\d+)\s+(footnote|endnote)s?", raw, _re.IGNORECASE)
+        if m:
+            result["footnote_count"] = int(m.group(1))
+
+    # 转换 PDF
+    elif action == "convert_to_pdf":
+        m = _re.search(r"'(.*?\.pdf)'", raw, _re.IGNORECASE)
+        if m:
+            result["output_filename"] = m.group(1)
+
+    return result
+
+
+@register_prefix("word_")
+def _extract_word(
+    tool_name: str, parsed: dict[str, Any], tool_input: str | None = None,
+) -> dict[str, Any] | None:
+    """提取 Word MCP 工具的结构化数据。
+
+    处理两类输出：
+    1. 纯文本（_raw）— 大多数工具返回成功/失败消息
+    2. JSON（data）— get_document_info / get_document_outline 等
+    """
+    # ── 纯文本输出 ──
+    if "_raw" in parsed:
+        raw = parsed["_raw"]
+        return _parse_word_raw_output(raw, tool_name)
+
+    # ── JSON 输出（get_document_info, get_document_outline 等）──
+    data = _get_data(parsed)
+    if data is None:
+        return None
+
+    short_name = _get_word_short_name(tool_name)
+    action = _WORD_ACTION_MAP.get(short_name, short_name)
+
+    result: dict[str, Any] = {
+        "tool_type": "word",
+        "action": action,
+        "success": True,
+    }
+
+    # get_document_info — 文档属性
+    if action == "get_document_info":
+        for field in ("file_name", "file_path", "file_size", "paragraph_count",
+                       "character_count", "table_count", "section_count",
+                       "heading_count", "page_count", "author", "title",
+                       "created", "modified"):
+            if field in data:
+                result[field] = data[field]
+        # 也检查 metadata 子对象
+        metadata = data.get("metadata", data.get("properties", {}))
+        if isinstance(metadata, dict):
+            for field in ("author", "title", "created", "modified",
+                           "last_modified_by", "revision"):
+                if field not in result and field in metadata:
+                    result[field] = metadata[field]
+
+    # get_document_outline — 文档结构
+    elif action == "get_document_outline":
+        for field in ("file_name", "file_path", "headings", "paragraph_count",
+                       "table_count", "sections"):
+            if field in data:
+                result[field] = data[field]
+        # 扁平化 headings 数量
+        headings = data.get("headings", data.get("structure", []))
+        if isinstance(headings, list):
+            result["heading_count"] = len(headings)
+
+    # list_documents — 文档列表
+    elif action == "list_documents":
+        files = data.get("files", data.get("documents", []))
+        if isinstance(files, list):
+            result["files"] = files
+            result["count"] = len(files)
+        elif "count" in data:
+            result["count"] = data["count"]
+
+    # find_text — 搜索结果
+    elif action == "find_text":
+        results = data.get("results", data.get("matches", []))
+        if isinstance(results, list):
+            result["results"] = results
+            result["count"] = len(results)
+
+    # get_comments* — 评论
+    elif action.startswith("get_comments"):
+        comments = data.get("comments", data.get("results", []))
+        if isinstance(comments, list):
+            result["comments"] = comments
+            result["count"] = len(comments)
+
+    return result

--- a/api/callbacks/websocket_callback.py
+++ b/api/callbacks/websocket_callback.py
@@ -40,6 +40,9 @@ class WebSocketCallback(BaseCallbackHandler):
         try:
             parsed = json.loads(out_str)
         except (json.JSONDecodeError, TypeError):
+            # MCP Word 工具返回纯文本而非 JSON — 包装为 _raw 让提取器能处理
+            if tool_name.startswith("word_"):
+                return _dispatch(tool_name, {"_raw": out_str}, tool_input)
             return None
         return _dispatch(tool_name, parsed, tool_input)
 

--- a/api/context_usage.py
+++ b/api/context_usage.py
@@ -14,6 +14,8 @@ def _get_encoding():
 
 def count_tokens(text: str) -> int:
     """返回文本的 token 数量估计值。"""
+    if not isinstance(text, str) or not text:
+        return 0
     return len(_get_encoding().encode(text))
 
 
@@ -37,6 +39,15 @@ def estimate_context_usage(
     total = count_tokens(system_prompt)
     for msg in messages:
         content = msg.content if hasattr(msg, "content") else str(msg)
+        # content 可能是 list（Anthropic 多内容块格式）或 None
+        if isinstance(content, list):
+            parts = [
+                b.get("text", "") for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            ]
+            content = " ".join(parts)
+        elif not isinstance(content, str):
+            content = str(content) if content is not None else ""
         total += count_tokens(content) + 4  # ~4 tokens 消息格式化开销
 
     usage_percent = round(total / max_tokens * 100, 1) if max_tokens else 0.0

--- a/api/server.py
+++ b/api/server.py
@@ -12,6 +12,7 @@ from api.dependencies import get_llm, get_system_prompt, get_tools
 from api.routes import chat, files, memory, sessions, balance
 from api.session_manager import SessionManager
 from memory.narrative import MEMORY_PATH, LongTermMemoryInterface
+from skills.mcp import init_mcp_tools, close_mcp
 from version import __version__
 
 WEB_DIR = Path(__file__).resolve().parent.parent / "web" / "dist"
@@ -27,9 +28,14 @@ async def lifespan(app: FastAPI):
     app.state.ltm = LongTermMemoryInterface(MEMORY_PATH)
     app.state.ltm.start_listening(app.state.llm)
 
+    # 加载 MCP 工具（Word 文档编辑能力）
+    mcp_tools = await init_mcp_tools()
+    app.state.tools = app.state.tools + mcp_tools
+
     yield
 
     # 关闭：清理资源
+    await close_mcp()
     await app.state.ltm.stop_listening()
 
 

--- a/clients/cli.py
+++ b/clients/cli.py
@@ -13,6 +13,7 @@ from config.settings import get_settings
 from memory.narrative import LongTermMemoryInterface, MEMORY_PATH
 from skills import get_all_skills
 from skills.interaction.skill_ask_user import AskUserSkill
+from skills.mcp import init_mcp_tools, close_mcp
 
 
 class SonettoCLI:
@@ -42,14 +43,17 @@ class SonettoCLI:
 
     async def run(self) -> None:
         """启动 REPL 主循环：读取用户输入 → 注入长期记忆 → 流式输出 → 保存本轮对话。"""
-        print("SonettoHere v2.0.0 — LangGraph ReAct Agent")
+        print("SonettoHere v2.0.0 — LangGraph ReAct Agent + MCP Word Tools")
         print("输入 /help 或 / 查看可用命令\n")
 
         self.ltm.start_listening(self.llm)
         try:
+            mcp_tools = await init_mcp_tools()
+            self.tools = self.tools + mcp_tools
             await self._repl()
         finally:
             await self.ltm.stop_listening()
+            await close_mcp()
 
     async def _repl(self) -> None:
         """REPL 主循环体。"""

--- a/clients/qqbot.py
+++ b/clients/qqbot.py
@@ -13,6 +13,7 @@ from agent.prompts import build_system_prompt
 from config.settings import get_settings
 from memory.narrative import LongTermMemoryInterface, MEMORY_PATH
 from skills import get_all_skills
+from skills.mcp import init_mcp_tools, close_mcp
 
 
 class SonettoQQBot(botpy.Client):
@@ -89,12 +90,15 @@ class SonettoQQBot(botpy.Client):
         await self.ltm.send_history(turn_messages)
 
     async def run(self, *args, **kwargs):
-        """启动 QQ Bot，接管 run 生命周期以管理 LongTermMemoryInterface。"""
+        """启动 QQ Bot，接管 run 生命周期以管理 LongTermMemoryInterface 和 MCP 工具。"""
         self.ltm.start_listening(self.llm)
         try:
+            mcp_tools = await init_mcp_tools()
+            self.tools = self.tools + mcp_tools
             await super().run(*args, **kwargs)
         finally:
             await self.ltm.stop_listening()
+            await close_mcp()
 
 
 def create_client_from_config() -> SonettoQQBot:

--- a/dev_docs/word-mcp-integration.md
+++ b/dev_docs/word-mcp-integration.md
@@ -1,0 +1,278 @@
+# Office-Word-MCP-Server 集成复盘
+
+本文档记录将 Office-Word-MCP-Server 通过 `langchain-mcp-adapters` 集成到 SonettoHere 的完整过程、遇到的问题及解决思路，作为后续 MCP 工具集成的参考范例。
+
+---
+
+## 一、成果
+
+| 指标 | 数值 |
+|------|------|
+| 集成工具数 | 54 个 （含 `word_` 前缀） |
+| 后端代码量 | ~40 行（`skills/mcp.py`） |
+| 包裝脚本 | 1 个（`scripts/mcp_word_server.py`） |
+| 前端气泡 | 1 个统一组件（`WordBubble.vue`） |
+| 涉及客户端 | CLI / QQ Bot / Web API 三端 |
+
+---
+
+## 二、架构
+
+```
+Agent 进程
+  └─ init_mcp_tools()                    skills/mcp.py
+       └─ MultiServerMCPClient            langchain-mcp-adapters
+            └─ subprocess                 sys.executable
+                 └─ scripts/mcp_word_server.py    包装脚本
+                      └─ word_document_server.main.run_server()
+                           └─ FastMCP (stdio transport)
+```
+
+MCP Server 不作为独立服务运行，而是由 `MultiServerMCPClient` 在需要时自动衍生子进程，通过 stdio JSON-RPC 通信。主进程退出时子进程自动终止。
+
+---
+
+## 三、遇到的问题与解决思路
+
+### 3.1 模块入口路径错误
+
+**现象**：`python -m office_word_mcp_server.word_mcp_server` 报 `No module named`。
+
+**原因**：`office_word_mcp_server` 只是一个薄包，`__init__.py` 仅从 `word_document_server.main` re-export 了 `run_server()`，本身不包含可运行的 `__main__` 模块。真正的入口在 `word_document_server.main.run_server()`。
+
+**教训**：对于新引入的 MCP 包，不要依赖文档或直觉判断模块路径。先 `pip show` 确认安装位置，然后检查包内目录结构，找到实际包含 `mcp.run()` 或 `FastMCP(...)` 入口的文件。
+
+```bash
+# 推荐的探查流程
+pip show office-word-mcp-server
+# Location → site-packages/office_word_mcp_server/
+ls $(python -c "import office_word_mcp_server; print(office_word_mcp_server.__file__)")
+# 发现是薄包，进一步查找
+ls $(dirname $(python -c "import office_word_mcp_server; print(office_word_mcp_server.__file__)"))/../word_document_server/
+```
+
+**解决**：不依赖 `-m` 方式，而是创建一个包装脚本直接 `import` + 调用。
+
+### 3.2 Stdout 污染破坏 JSON-RPC
+
+**现象**：MCP stdio 协议通过 stdout 传输 JSON-RPC 消息。但服务启动时各种 `print()` 语句直接写入 stdout，导致客户端收到非 JSON 数据，解析失败。
+
+**错误日志特征**：
+```
+Failed to parse JSONRPC message from server
+ValidationError: Invalid JSON: expected value at line 1 column 1
+input_value='Loading configuration from .env file...\r'
+```
+
+**涉及的全部污染源**：
+1. `print("Loading configuration from .env file...")` — dotenv 加载提示
+2. `print("Transport: stdio")` — 传输方式日志
+3. `print("Starting Word Document MCP Server...")` / `print("Server running on stdio transport")`
+4. FastMCP 3.x 的 rich 横幅
+
+**解决思路**：在导入服务模块前 monkey-patch `builtins.print` 将输出重定向到 stderr。MCP 框架内部使用 `sys.stdout.buffer.write()` 而非 `print()`，不受影响。
+
+```python
+# scripts/mcp_word_server.py 核心逻辑
+import builtins
+_original_print = builtins.print
+def _stderr_print(*args, **kwargs):
+    kwargs.setdefault("file", sys.stderr)
+    _original_print(*args, **kwargs)
+builtins.print = _stderr_print
+
+from word_document_server.main import run_server
+run_server()
+```
+
+**经验**：重定向 `print()` 通常足够，因为大部分库用 `print()` 输出日志。如果遇到直接用 `sys.stdout.write()` 的库，则需考虑更底层的重定向。FastMCP 的 rich 横幅走 stderr，恰好不受影响。
+
+**后续 MCP 集成的标准做法**：每个有 stdout 污染风险的 MCP Server 都应创建一个包装脚本，在 import 前 patch `print`。
+
+### 3.3 子进程 Python 解释器路径
+
+**现象**：`MultiServerMCPClient` 配置 `"command": "python"` 时，子进程可能解析到系统 Python 而非虚拟环境 Python。
+
+**解决**：使用 `sys.executable` 显式指定当前进程的 Python 解释器路径，保证父子进程环境一致。
+
+```python
+"command": sys.executable,   # 始终使用当前 venv 的 Python
+```
+
+### 3.4 MultiServerMCPClient 清理
+
+**现象**：尝试 `await client.__aexit__(...)` 时抛出 `NotImplementedError`。
+
+**原因**：`langchain-mcp-adapters` 的 `MultiServerMCPClient` 未实现异步上下文管理器协议。
+
+**解决**：将 client 和 tools 引用设为 `None`，交由 GC 回收。子进程在主进程退出时自动终止。
+
+```python
+async def close_mcp():
+    global _client, _tools
+    _client = None   # 释放引用，GC 回收时终止子进程
+    _tools = None
+```
+
+### 3.5 工具命名冲突
+
+**现象**：MCP 返回的工具有 `add_paragraph`、`add_heading` 等通用名称，可能与未来新增的 Skill 重名。
+
+**解决**：`MultiServerMCPClient` 提供 `tool_name_prefix=True` 参数，自动以 server name 做前缀（`word_add_paragraph`）。无需手动重命名。
+
+### 3.6 54 个工具的前端注册
+
+**现象**：Word 系列有 54 个工具，若逐个注册到气泡组件映射表会非常臃肿。
+
+**解决**：在 `getBubbleComponent()` 中增加前缀匹配逻辑，所有 `word_*` 工具统一路由到 `WordBubble.vue`。
+
+```typescript
+export function getBubbleComponent(name: string): Component | null {
+  if (registry[name]) return registry[name]
+  if (name.startsWith('word_')) return WordBubble   // 前缀匹配
+  return null
+}
+```
+
+同样在 `toolDisplayName()` 中处理前缀兜底。
+
+### 3.7 前端气泡内容如何丰富 — toolData 通道（承前启后）
+
+当前的 `WordBubble.vue` 在前端解析 `toolCall.input` 的 JSON 字符串提取参数，这种方式信息量有限、且无法感知工具执行结果的结构化数据。项目已有完善的 **toolData 通道**，应优先使用。
+
+#### toolData 全链路
+
+```
+Skill._run() 返回 dict
+  → ToolMessage(content=json.dumps({"data": {...}}))
+    → WebSocketCallback.on_tool_end()
+      → _extract_tool_data(tool_name, output)
+        → tool_extractors._dispatch(tool_name, parsed)
+          → 匹配 extractor 函数 → 返回结构化 dict
+            → WebSocket 发送 {"type": "tool_end", "tool_data": {...}}
+              → 前端 ToolCall.toolData
+                → 气泡组件从 toolCall.toolData 读取字段
+```
+
+#### 关键文件
+
+| 文件 | 作用 |
+|------|------|
+| [tool_extractors.py](../api/callbacks/tool_extractors.py) | 注册 extractor 函数，将工具输出转为前端结构化数据 |
+| [websocket_callback.py:95](../api/callbacks/websocket_callback.py#L95) | `_extract_tool_data()` 调用 dispatch |
+| [WordBubble.vue](../web/src/components/tools/WordBubble.vue) | 前端气泡从 `toolCall.toolData` 取数渲染 |
+
+#### 为 word_* 系列注册 extractor
+
+在 `tool_extractors.py` 中添加前缀匹配的 extractor：
+
+```python
+@register_prefix("word_")
+def _extract_word(
+    tool_name: str, parsed: dict[str, Any], tool_input: str | None = None,
+) -> dict[str, Any] | None:
+    data = _get_data(parsed)
+    if data is None:
+        return None
+    # 去掉 word_ 前缀取动作名
+    action = tool_name.replace("word_", "")
+    result: dict[str, Any] = {"action": action}
+    # 提取 filename
+    for key in ("filename", "source_filename", "output_filename"):
+        if tool_input:
+            try:
+                inp = json.loads(tool_input)
+                if inp.get(key):
+                    result["filename"] = inp[key]
+                    break
+            except json.JSONDecodeError:
+                pass
+    # 从 data 中读取结果信息（各工具返回结构不同，按需提取）
+    if "message" in data:
+        result["message"] = data["message"]
+    if "paragraph_count" in data:
+        result["paragraph_count"] = data["paragraph_count"]
+    if "table_index" in data:
+        result["table_index"] = data["table_index"]
+    return result
+```
+
+#### extractor 的三种数据来源
+
+1. **`parsed`**（即 tool output 的 JSON 解析结果）— 优先来源，包含执行结果的结构化数据
+2. **`tool_input`**（原始入参 JSON 字符串）— 提取文件名等入参信息
+3. **`tool_name`** — 区分具体工具，做不同处理
+
+#### 前端取用
+
+注册 extractor 后，`WebSocketCallback` 会自动将返回值注入 `tool_end` 事件的 `tool_data` 字段。前端 `ToolCall.toolData` 自动携带这些数据，`WordBubble.vue` 中直接读取：
+
+```typescript
+const td = computed(() => props.toolCall.toolData as Record<string, any> ?? {})
+
+// 直接使用
+td.value.action      // "create_document"
+td.value.filename    // "报告.docx"
+td.value.message     // "文档创建成功"
+```
+
+#### 扩展建议
+
+按工具类别细化 extractor 返回值：
+
+| 工具类别 | extractor 应返回的字段 |
+|----------|----------------------|
+| 文档创建/复制 `create_document` `copy_document` | `action`, `filename`, `message` |
+| 内容插入 `add_paragraph` `add_heading` `add_table` | `action`, `filename`, `content_preview`, `table_size` |
+| 格式化 `format_text` `format_table` | `action`, `filename`, `changes_summary` |
+| 表格操作 `merge_table_cells` `set_table_column_width` | `action`, `filename`, `table_index`, `affected_cells` |
+| 脚注 `add_footnote_to_document` | `action`, `filename`, `footnote_count` |
+| 查找替换 `search_and_replace` | `action`, `filename`, `replacements_count` |
+| 文档保护 `protect_document` | `action`, `filename`, `protected` |
+| 转换 `convert_to_pdf` | `action`, `filename`, `output_filename` |
+| 查询类 `get_document_info` `get_document_text` | `action`, `filename`, `summary_stats` |
+
+#### 注意事项
+
+- extractor 返回 `None` 时，前端 `toolData` 为 `undefined`，气泡组件应做好防御
+- 不要在前端解析 `toolCall.output` 字符串来获取结构化数据 — 那是给 LLM 看的，不是给 UI 用的
+- 同一 `register_prefix("word_")` 覆盖全部 54 个工具，按 `action` 分支处理即可，无需每个工具单独注册
+
+---
+
+## 四、MCP 集成清单（供后续参考）
+
+后续接入新的 MCP Server 时，按以下步骤检查：
+
+### 4.1 探查阶段
+- [ ] `pip show <package>` 确认安装位置
+- [ ] 检查实际目录结构，找到包含 `mcp.run()` 的入口模块
+- [ ] 试运行确认启动时会输出哪些内容到 stdout
+
+### 4.2 后端集成
+- [ ] 如服务器有 stdout 污染，创建包装脚本 patch `print`
+- [ ] 使用 `sys.executable` 而非硬编码 `"python"`
+- [ ] 设置 `tool_name_prefix=True` 避免命名冲突
+- [ ] 确定合理的清理方式（通常是释放引用即可）
+- [ ] 三端（CLI / QQ Bot / Web API）同步集成
+- [ ] 在 `tool_extractors.py` 注册 extractor（精确匹配或前缀匹配），让前端能获取结构化数据
+
+### 4.3 前端集成
+- [ ] 创建气泡组件（可复用/通用，或专用展示），优先读取 `toolCall.toolData`
+- [ ] 注册到 registry（精确匹配或前缀匹配）
+- [ ] 添加 display name
+
+### 4.4 验证
+- [ ] `await init_mcp_tools()` 能返回工具列表
+- [ ] 调用任意工具能得到正确结果
+- [ ] 进程退出时 MCP 子进程正确终止
+
+---
+
+## 五、参考
+
+- [langchain-mcp-adapters](https://github.com/langchain-ai/langchain-mcp-adapters) — 官方文档
+- [skills/mcp.py](../skills/mcp.py) — MCP 工具管理器实现
+- [scripts/mcp_word_server.py](../scripts/mcp_word_server.py) — 包装脚本
+- [WordBubble.vue](../web/src/components/tools/WordBubble.vue) — 前端气泡
+- [registry.ts](../web/src/components/tools/registry.ts) — 工具注册表

--- a/scripts/mcp_word_server.py
+++ b/scripts/mcp_word_server.py
@@ -1,0 +1,26 @@
+"""
+Office-Word-MCP-Server 包裝腳本。
+
+原服務器啟動時會向 stdout 輸出日誌（"Loading configuration from .env file..." 等），
+這些輸出會破壞 MCP stdio JSON-RPC 協議。
+此包裝腳本將 print 重定向到 stderr，僅保留 MCP 框架的 stdout 通信。
+"""
+
+import sys
+import builtins
+
+# 將 print 重定向到 stderr，避免污染 stdout 的 MCP 協議通信
+_original_print = builtins.print
+
+
+def _stderr_print(*args, **kwargs):
+    kwargs.setdefault("file", sys.stderr)
+    _original_print(*args, **kwargs)
+
+
+builtins.print = _stderr_print
+
+from word_document_server.main import run_server
+
+if __name__ == "__main__":
+    run_server()

--- a/skills/mcp.py
+++ b/skills/mcp.py
@@ -1,0 +1,40 @@
+"""MCP 工具管理器 — 连接 Office-Word-MCP-Server 并返回 LangChain BaseTool。"""
+
+import sys
+from pathlib import Path
+
+from langchain_core.tools import BaseTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+_client: MultiServerMCPClient | None = None
+_tools: list[BaseTool] | None = None
+
+# 包裝腳本路徑（解決服務器 stdout 污染問題）
+_WRAPPER_PATH = str(Path(__file__).resolve().parent.parent / "scripts" / "mcp_word_server.py")
+
+
+async def init_mcp_tools() -> list[BaseTool]:
+    """初始化 MCP 客户端并返回所有 MCP 工具（已自动添加 word_ 前缀）。"""
+    global _client, _tools
+    if _tools is not None:
+        return _tools
+
+    _client = MultiServerMCPClient(
+        {
+            "word": {
+                "command": sys.executable,
+                "args": [_WRAPPER_PATH],
+                "transport": "stdio",
+            }
+        },
+        tool_name_prefix=True,
+    )
+    _tools = await _client.get_tools()
+    return _tools
+
+
+async def close_mcp():
+    """釋放 MCP 客户端资源。"""
+    global _client, _tools
+    _client = None
+    _tools = None

--- a/web/src/components/tools/WordBubble.vue
+++ b/web/src/components/tools/WordBubble.vue
@@ -1,0 +1,264 @@
+<template>
+  <BubbleChrome :tool-call="toolCall">
+    <!-- 运行中 -->
+    <div v-if="toolCall.status === 'running'" class="bubble-running">
+      <span>正在{{ actionLabel }}...</span>
+    </div>
+
+    <!-- 错误 -->
+    <div v-else-if="toolCall.status === 'error'" class="bubble-error">
+      {{ toolCall.output || '操作失败' }}
+    </div>
+
+    <!-- 完成 -->
+    <template v-else-if="toolCall.status === 'done'">
+      <div class="word-result">
+        <div class="word-icon-row">
+          <svg class="word-icon" viewBox="0 0 24 24" fill="none" width="28" height="28">
+            <rect x="3" y="2" width="18" height="20" rx="2" fill="#2b579a" />
+            <path d="M7 12l2 4 2-4h1.5l-2.5 5h-2l-2.5-5H7zM12 12h5v1.5h-5V12zM12 15h4v1.5h-4V15z" fill="white" />
+          </svg>
+          <span class="word-action-label">{{ actionLabel }}</span>
+        </div>
+        <div class="word-filename" v-if="filename">📄 {{ filename }}</div>
+        <div class="word-params" v-if="paramLines.length">
+          <div class="param-row" v-for="(line, i) in paramLines" :key="i">
+            <span class="param-key">{{ line.key }}:</span>
+            <span class="param-val">{{ line.val }}</span>
+          </div>
+        </div>
+        <div class="word-msg" v-if="shortOutput">{{ shortOutput }}</div>
+        <div class="word-detail" v-else-if="toolCall.output && needDetail">
+          <pre class="detail-code">{{ toolCall.output }}</pre>
+        </div>
+      </div>
+    </template>
+  </BubbleChrome>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ToolCall } from '@/types'
+import BubbleChrome from './_shared/BubbleChrome.vue'
+
+const props = defineProps<{ toolCall: ToolCall }>()
+defineEmits<{ (e: 'action', p: { action: string; data?: unknown }): void }>()
+
+// ── 工具名 → 中文动作映射 ──
+const ACTION_LABELS: Record<string, string> = {
+  create_document: '创建文档',
+  copy_document: '复制文档',
+  get_document_info: '查看文档信息',
+  get_document_text: '提取文档文本',
+  get_document_outline: '查看文档大纲',
+  list_available_documents: '列出文档目录',
+  get_document_xml: '查看文档底层 XML',
+  insert_header_near_text: '插入标题',
+  insert_line_or_paragraph_near_text: '插入段落',
+  insert_numbered_list_near_text: '插入列表',
+  add_paragraph: '添加段落',
+  add_heading: '添加标题',
+  add_picture: '插入图片',
+  add_table: '添加表格',
+  add_page_break: '插入分页符',
+  delete_paragraph: '删除段落',
+  search_and_replace: '查找替换',
+  create_custom_style: '创建自定义样式',
+  format_text: '格式化文本',
+  format_table: '格式化表格',
+  set_table_cell_shading: '设置单元格底色',
+  apply_table_alternating_rows: '设置交替行颜色',
+  highlight_table_header: '高亮表头',
+  merge_table_cells: '合并单元格区域',
+  merge_table_cells_horizontal: '水平合并单元格',
+  merge_table_cells_vertical: '垂直合并单元格',
+  set_table_cell_alignment: '设置单元格对齐',
+  set_table_alignment_all: '设置表格对齐',
+  set_table_column_width: '设置列宽',
+  set_table_column_widths: '批量设置列宽',
+  set_table_width: '设置表格宽度',
+  auto_fit_table_columns: '自动调整列宽',
+  format_table_cell_text: '格式化单元格文本',
+  set_table_cell_padding: '设置单元格边距',
+  protect_document: '添加密码保护',
+  unprotect_document: '解除密码保护',
+  add_footnote_to_document: '添加脚注',
+  add_footnote_after_text: '在文本后添加脚注',
+  add_footnote_before_text: '在文本前添加脚注',
+  add_footnote_enhanced: '添加脚注（增强）',
+  add_endnote_to_document: '添加尾注',
+  customize_footnote_style: '自定义脚注样式',
+  delete_footnote_from_document: '删除脚注',
+  add_footnote_robust: '添加脚注（鲁棒）',
+  delete_footnote_robust: '删除脚注（鲁棒）',
+  validate_document_footnotes: '验证文档脚注',
+  get_paragraph_text_from_document: '获取段落文本',
+  find_text_in_document: '在文档中搜索',
+  convert_to_pdf: '转换为 PDF',
+  replace_paragraph_block_below_header: '替换标题下方段落',
+  replace_block_between_manual_anchors: '替换锚点间内容',
+  get_all_comments: '获取所有评论',
+  get_comments_by_author: '按作者筛选评论',
+  get_comments_for_paragraph: '获取段落评论',
+}
+
+// ── 从 toolCall.name 提取动作名（去掉 word_ 前缀）──
+const shortName = computed(() => {
+  return props.toolCall.name.replace(/^word_/, '')
+})
+
+const actionLabel = computed(() => {
+  return ACTION_LABELS[shortName.value] || shortName.value.replace(/_/g, ' ')
+})
+
+// ── 解析 input JSON 提取关键参数 ──
+const parsedInput = computed<Record<string, string>>(() => {
+  try {
+    return JSON.parse(props.toolCall.input) as Record<string, string>
+  } catch {
+    return {}
+  }
+})
+
+const filename = computed(() => parsedInput.value.filename || parsedInput.value.source_filename || '')
+
+// ── 关键参数白名单（显示次要参数） ──
+const KEY_PARAMS = new Set([
+  'filename', 'source_filename', 'destination_filename', 'output_filename',
+  'directory', 'password',
+])
+
+const paramLines = computed(() => {
+  const lines: { key: string; val: string }[] = []
+  for (const [k, v] of Object.entries(parsedInput.value)) {
+    if (v && !KEY_PARAMS.has(k) && String(v).length < 80) {
+      const label = PARAM_LABELS[k] || k.replace(/_/g, ' ')
+      lines.push({ key: label, val: String(v) })
+    }
+  }
+  return lines.slice(0, 4)
+})
+
+const PARAM_LABELS: Record<string, string> = {
+  text: '内容', paragraph_text: '内容', heading_text: '标题',
+  search_text: '搜索', replace_text: '替换为',
+  level: '级别', rows: '行数', columns: '列数',
+  style_name: '样式', font_name: '字体', font_size: '字号',
+  table_index: '表格', paragraph_index: '段落',
+  image_path: '图片路径',
+}
+
+// ── 结果文本（取 output 摘要） ──
+const shortOutput = computed(() => {
+  if (!props.toolCall.output) return ''
+  const s = props.toolCall.output
+  if (s.length < 120) return s
+  // 尝试从 output 中提取关键信息（如成功消息）
+  const match = s.match(/"[^"]*(?:成功|完成|已|created|added|saved)[^"]*"/i)
+  if (match) return match[0].replace(/"/g, '')
+  if (s.includes('Error') || s.includes('error')) return s.slice(0, 120) + '...'
+  return ''
+})
+
+const needDetail = computed(() => {
+  return !shortOutput.value && !!props.toolCall.output
+})
+</script>
+
+<style scoped>
+.bubble-running {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.bubble-error {
+  font-size: 13px;
+  color: #b91c1c;
+  padding: 4px 0;
+}
+
+/* ── 结果卡片 ── */
+.word-result {
+  padding: 12px 4px;
+}
+
+.word-icon-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.word-icon {
+  flex-shrink: 0;
+}
+
+.word-action-label {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.word-filename {
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  padding: 6px 10px;
+  border-radius: 6px;
+  margin-bottom: 8px;
+  display: inline-block;
+}
+
+.word-params {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  margin-bottom: 6px;
+}
+
+.param-row {
+  display: flex;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.param-key {
+  color: var(--text-secondary);
+}
+
+.param-val {
+  color: var(--text-primary);
+  font-weight: 500;
+  word-break: break-all;
+}
+
+.word-msg {
+  font-size: 13px;
+  color: var(--text-primary);
+  padding: 6px 0;
+  line-height: 1.5;
+}
+
+.word-detail {
+  margin-top: 8px;
+}
+
+.detail-code {
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--bg-primary);
+  padding: 8px 10px;
+  border-radius: 6px;
+  max-height: 160px;
+  overflow-y: auto;
+  margin: 0;
+}
+</style>

--- a/web/src/components/tools/WordBubble.vue
+++ b/web/src/components/tools/WordBubble.vue
@@ -1,37 +1,61 @@
 <template>
   <BubbleChrome :tool-call="toolCall">
-    <!-- 运行中 -->
+    <!-- ── 运行中 ── -->
     <div v-if="toolCall.status === 'running'" class="bubble-running">
-      <span>正在{{ actionLabel }}...</span>
+      <WordIcon class="word-icon-pulse" />
+      <span>{{ actionLabel }}</span>
+      <span class="running-dots"></span>
     </div>
 
-    <!-- 错误 -->
+    <!-- ── 错误 ── -->
     <div v-else-if="toolCall.status === 'error'" class="bubble-error">
-      {{ toolCall.output || '操作失败' }}
+      <WordIcon />
+      <div class="error-content">
+        <div class="error-title">{{ actionLabel }} 失败</div>
+        <div class="error-msg">{{ toolCall.output || '未知错误' }}</div>
+      </div>
     </div>
 
-    <!-- 完成 -->
+    <!-- ── 完成 — 按 action 类别渲染不同卡片 ── -->
     <template v-else-if="toolCall.status === 'done'">
-      <div class="word-result">
-        <div class="word-icon-row">
-          <svg class="word-icon" viewBox="0 0 24 24" fill="none" width="28" height="28">
-            <rect x="3" y="2" width="18" height="20" rx="2" fill="#2b579a" />
-            <path d="M7 12l2 4 2-4h1.5l-2.5 5h-2l-2.5-5H7zM12 12h5v1.5h-5V12zM12 15h4v1.5h-4V15z" fill="white" />
-          </svg>
-          <span class="word-action-label">{{ actionLabel }}</span>
-        </div>
-        <div class="word-filename" v-if="filename">📄 {{ filename }}</div>
-        <div class="word-params" v-if="paramLines.length">
-          <div class="param-row" v-for="(line, i) in paramLines" :key="i">
-            <span class="param-key">{{ line.key }}:</span>
-            <span class="param-val">{{ line.val }}</span>
-          </div>
-        </div>
-        <div class="word-msg" v-if="shortOutput">{{ shortOutput }}</div>
-        <div class="word-detail" v-else-if="toolCall.output && needDetail">
-          <pre class="detail-code">{{ toolCall.output }}</pre>
-        </div>
-      </div>
+      <!-- 创建 / 复制 / 合并文档 -->
+      <CreateCard v-if="isAction('create_document','copy_document','merge_documents')" :data="td" />
+
+      <!-- 文档信息 -->
+      <InfoCard v-else-if="isAction('get_document_info')" :data="td" />
+
+      <!-- 文档大纲 / 文档列表 -->
+      <OutlineCard v-else-if="isAction('get_document_outline','list_documents','get_document_xml','get_document_text')" :data="td" />
+
+      <!-- 添加标题 / 添加段落 / 插入内容 -->
+      <InsertCard v-else-if="isAction('add_heading','add_paragraph','add_picture','add_page_break','insert_heading','insert_paragraph','insert_list','add_toc')" :data="td" />
+
+      <!-- 表格操作 -->
+      <TableCard v-else-if="isAction('add_table') || td.action?.startsWith('table_')" :data="td" />
+
+      <!-- 脚注 / 尾注 -->
+      <FootnoteCard v-else-if="td.action?.includes('footnote') || td.action?.includes('endnote')" :data="td" />
+
+      <!-- 查找替换 / 搜索文本 -->
+      <SearchCard v-else-if="isAction('search_replace','find_text')" :data="td" />
+
+      <!-- 格式化 / 样式 -->
+      <FormatCard v-else-if="isAction('format_text','format_table','create_style')" :data="td" />
+
+      <!-- 保护 / 密码 -->
+      <ProtectCard v-else-if="isAction('protect','unprotect')" :data="td" />
+
+      <!-- 转换 PDF -->
+      <ConvertCard v-else-if="isAction('convert_to_pdf')" :data="td" />
+
+      <!-- 评论 -->
+      <CommentsCard v-else-if="td.action?.startsWith('get_comments')" :data="td" />
+
+      <!-- 删除段落 / 替换区块 -->
+      <EditCard v-else-if="isAction('delete_paragraph','replace_block','replace_anchors','get_paragraph')" :data="td" />
+
+      <!-- 默认回退 -->
+      <DefaultCard v-else :data="td" :raw-output="toolCall.output" />
     </template>
   </BubbleChrome>
 </template>
@@ -40,128 +64,57 @@
 import { computed } from 'vue'
 import type { ToolCall } from '@/types'
 import BubbleChrome from './_shared/BubbleChrome.vue'
+import WordIcon from './_shared/WordIcon.vue'
+
+// ── 各分类卡片组件 ──
+import CreateCard from './_word/CreateCard.vue'
+import InfoCard from './_word/InfoCard.vue'
+import OutlineCard from './_word/OutlineCard.vue'
+import InsertCard from './_word/InsertCard.vue'
+import TableCard from './_word/TableCard.vue'
+import FootnoteCard from './_word/FootnoteCard.vue'
+import SearchCard from './_word/SearchCard.vue'
+import FormatCard from './_word/FormatCard.vue'
+import ProtectCard from './_word/ProtectCard.vue'
+import ConvertCard from './_word/ConvertCard.vue'
+import CommentsCard from './_word/CommentsCard.vue'
+import EditCard from './_word/EditCard.vue'
+import DefaultCard from './_word/DefaultCard.vue'
 
 const props = defineProps<{ toolCall: ToolCall }>()
 defineEmits<{ (e: 'action', p: { action: string; data?: unknown }): void }>()
 
-// ── 工具名 → 中文动作映射 ──
-const ACTION_LABELS: Record<string, string> = {
-  create_document: '创建文档',
-  copy_document: '复制文档',
-  get_document_info: '查看文档信息',
-  get_document_text: '提取文档文本',
-  get_document_outline: '查看文档大纲',
-  list_available_documents: '列出文档目录',
-  get_document_xml: '查看文档底层 XML',
-  insert_header_near_text: '插入标题',
-  insert_line_or_paragraph_near_text: '插入段落',
-  insert_numbered_list_near_text: '插入列表',
-  add_paragraph: '添加段落',
-  add_heading: '添加标题',
-  add_picture: '插入图片',
-  add_table: '添加表格',
-  add_page_break: '插入分页符',
-  delete_paragraph: '删除段落',
-  search_and_replace: '查找替换',
-  create_custom_style: '创建自定义样式',
-  format_text: '格式化文本',
-  format_table: '格式化表格',
-  set_table_cell_shading: '设置单元格底色',
-  apply_table_alternating_rows: '设置交替行颜色',
-  highlight_table_header: '高亮表头',
-  merge_table_cells: '合并单元格区域',
-  merge_table_cells_horizontal: '水平合并单元格',
-  merge_table_cells_vertical: '垂直合并单元格',
-  set_table_cell_alignment: '设置单元格对齐',
-  set_table_alignment_all: '设置表格对齐',
-  set_table_column_width: '设置列宽',
-  set_table_column_widths: '批量设置列宽',
-  set_table_width: '设置表格宽度',
-  auto_fit_table_columns: '自动调整列宽',
-  format_table_cell_text: '格式化单元格文本',
-  set_table_cell_padding: '设置单元格边距',
-  protect_document: '添加密码保护',
-  unprotect_document: '解除密码保护',
-  add_footnote_to_document: '添加脚注',
-  add_footnote_after_text: '在文本后添加脚注',
-  add_footnote_before_text: '在文本前添加脚注',
-  add_footnote_enhanced: '添加脚注（增强）',
-  add_endnote_to_document: '添加尾注',
-  customize_footnote_style: '自定义脚注样式',
-  delete_footnote_from_document: '删除脚注',
-  add_footnote_robust: '添加脚注（鲁棒）',
-  delete_footnote_robust: '删除脚注（鲁棒）',
-  validate_document_footnotes: '验证文档脚注',
-  get_paragraph_text_from_document: '获取段落文本',
-  find_text_in_document: '在文档中搜索',
-  convert_to_pdf: '转换为 PDF',
-  replace_paragraph_block_below_header: '替换标题下方段落',
-  replace_block_between_manual_anchors: '替换锚点间内容',
-  get_all_comments: '获取所有评论',
-  get_comments_by_author: '按作者筛选评论',
-  get_comments_for_paragraph: '获取段落评论',
-}
+// ── 工具数据：优先取 toolData，其次从 output 解析 ──
+const td = computed<Record<string, any>>(() => {
+  if (props.toolCall.toolData) {
+    return props.toolCall.toolData as Record<string, any>
+  }
+  // 无 toolData 时在气泡内尝试解析 output（兜底）
+  if (props.toolCall.output) {
+    try {
+      const parsed = JSON.parse(props.toolCall.output)
+      if (parsed?.data) return parsed.data as Record<string, any>
+      return parsed
+    } catch {
+      // 纯文本，回退
+    }
+  }
+  return {}
+})
 
-// ── 从 toolCall.name 提取动作名（去掉 word_ 前缀）──
 const shortName = computed(() => {
   return props.toolCall.name.replace(/^word_/, '')
 })
 
-const actionLabel = computed(() => {
-  return ACTION_LABELS[shortName.value] || shortName.value.replace(/_/g, ' ')
-})
-
-// ── 解析 input JSON 提取关键参数 ──
-const parsedInput = computed<Record<string, string>>(() => {
-  try {
-    return JSON.parse(props.toolCall.input) as Record<string, string>
-  } catch {
-    return {}
-  }
-})
-
-const filename = computed(() => parsedInput.value.filename || parsedInput.value.source_filename || '')
-
-// ── 关键参数白名单（显示次要参数） ──
-const KEY_PARAMS = new Set([
-  'filename', 'source_filename', 'destination_filename', 'output_filename',
-  'directory', 'password',
-])
-
-const paramLines = computed(() => {
-  const lines: { key: string; val: string }[] = []
-  for (const [k, v] of Object.entries(parsedInput.value)) {
-    if (v && !KEY_PARAMS.has(k) && String(v).length < 80) {
-      const label = PARAM_LABELS[k] || k.replace(/_/g, ' ')
-      lines.push({ key: label, val: String(v) })
-    }
-  }
-  return lines.slice(0, 4)
-})
-
-const PARAM_LABELS: Record<string, string> = {
-  text: '内容', paragraph_text: '内容', heading_text: '标题',
-  search_text: '搜索', replace_text: '替换为',
-  level: '级别', rows: '行数', columns: '列数',
-  style_name: '样式', font_name: '字体', font_size: '字号',
-  table_index: '表格', paragraph_index: '段落',
-  image_path: '图片路径',
+function isAction(...actions: string[]): boolean {
+  return actions.includes(td.value.action) || actions.includes(shortName.value)
 }
 
-// ── 结果文本（取 output 摘要） ──
-const shortOutput = computed(() => {
-  if (!props.toolCall.output) return ''
-  const s = props.toolCall.output
-  if (s.length < 120) return s
-  // 尝试从 output 中提取关键信息（如成功消息）
-  const match = s.match(/"[^"]*(?:成功|完成|已|created|added|saved)[^"]*"/i)
-  if (match) return match[0].replace(/"/g, '')
-  if (s.includes('Error') || s.includes('error')) return s.slice(0, 120) + '...'
-  return ''
-})
-
-const needDetail = computed(() => {
-  return !shortOutput.value && !!props.toolCall.output
+const actionLabel = computed(() => {
+  if (td.value.action && td.value.action !== shortName.value) {
+    return td.value.action.replace(/_/g, ' ')
+  }
+  return shortName.value.replace(/_/g, ' ')
 })
 </script>
 
@@ -169,96 +122,55 @@ const needDetail = computed(() => {
 .bubble-running {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 0;
+  gap: 10px;
+  padding: 10px 0;
   font-size: 13px;
   color: var(--text-secondary);
+}
+
+.word-icon-pulse {
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}
+
+.running-dots::after {
+  content: '...';
+  animation: dots 1.2s steps(3, end) infinite;
+}
+
+@keyframes dots {
+  0% { content: ''; }
+  33% { content: '.'; }
+  66% { content: '..'; }
+  100% { content: '...'; }
 }
 
 .bubble-error {
-  font-size: 13px;
-  color: #b91c1c;
-  padding: 4px 0;
-}
-
-/* ── 结果卡片 ── */
-.word-result {
-  padding: 12px 4px;
-}
-
-.word-icon-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
-  margin-bottom: 10px;
+  padding: 10px 0;
 }
 
-.word-icon {
-  flex-shrink: 0;
+.error-content {
+  flex: 1;
 }
 
-.word-action-label {
-  font-size: 15px;
+.error-title {
+  font-size: 14px;
   font-weight: 600;
-  color: var(--text-primary);
+  color: #b91c1c;
+  margin-bottom: 4px;
 }
 
-.word-filename {
-  font-size: 13px;
-  color: var(--text-secondary);
-  background: var(--bg-secondary);
-  padding: 6px 10px;
-  border-radius: 6px;
-  margin-bottom: 8px;
-  display: inline-block;
-}
-
-.word-params {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 12px;
-  margin-bottom: 6px;
-}
-
-.param-row {
-  display: flex;
-  gap: 4px;
+.error-msg {
   font-size: 12px;
-}
-
-.param-key {
-  color: var(--text-secondary);
-}
-
-.param-val {
-  color: var(--text-primary);
-  font-weight: 500;
-  word-break: break-all;
-}
-
-.word-msg {
-  font-size: 13px;
-  color: var(--text-primary);
-  padding: 6px 0;
+  color: #991b1b;
   line-height: 1.5;
-}
-
-.word-detail {
-  margin-top: 8px;
-}
-
-.detail-code {
-  font-family: 'SF Mono', 'Consolas', monospace;
-  font-size: 11px;
-  line-height: 1.5;
-  color: var(--text-primary);
-  white-space: pre-wrap;
   word-break: break-word;
-  background: var(--bg-primary);
-  padding: 8px 10px;
-  border-radius: 6px;
-  max-height: 160px;
-  overflow-y: auto;
-  margin: 0;
 }
 </style>

--- a/web/src/components/tools/_shared/WordIcon.vue
+++ b/web/src/components/tools/_shared/WordIcon.vue
@@ -1,0 +1,12 @@
+<template>
+  <svg class="word-icon" viewBox="0 0 24 24" fill="none" width="24" height="24">
+    <rect x="3" y="2" width="18" height="20" rx="2" fill="#2b579a" />
+    <path d="M7 12l2 4 2-4h1.5l-2.5 5h-2l-2.5-5H7zM12 12h5v1.5h-5V12zM12 15h4v1.5h-4V15z" fill="white" />
+  </svg>
+</template>
+
+<style scoped>
+.word-icon {
+  flex-shrink: 0;
+}
+</style>

--- a/web/src/components/tools/_shared/displayNames.ts
+++ b/web/src/components/tools/_shared/displayNames.ts
@@ -58,7 +58,10 @@ const DISPLAY_NAMES: Record<string, string> = {
 }
 
 export function toolDisplayName(name: string): string {
-  return DISPLAY_NAMES[name] ?? name
+  if (DISPLAY_NAMES[name]) return DISPLAY_NAMES[name]
+  // word_* 系列统一显示为"Word 文档"
+  if (name.startsWith('word_')) return 'Word 文档'
+  return name
 }
 
 /** 所有已知工具名称列表（供 Playground 使用） */

--- a/web/src/components/tools/_shared/displayNames.ts
+++ b/web/src/components/tools/_shared/displayNames.ts
@@ -57,10 +57,72 @@ const DISPLAY_NAMES: Record<string, string> = {
   task_tracker: '任务追踪',
 }
 
+// ── Word MCP 工具独立显示名 ──
+
+const WORD_DISPLAY_NAMES: Record<string, string> = {
+  word_create_document: '创建文档',
+  word_copy_document: '复制文档',
+  word_merge_documents: '合并文档',
+  word_get_document_info: '文档信息',
+  word_get_document_text: '提取文本',
+  word_get_document_outline: '文档大纲',
+  word_list_available_documents: '文档列表',
+  word_get_document_xml: '文档 XML',
+  word_insert_header_near_text: '插入标题',
+  word_insert_line_or_paragraph_near_text: '插入段落',
+  word_insert_numbered_list_near_text: '插入列表',
+  word_add_paragraph: '添加段落',
+  word_add_heading: '添加标题',
+  word_add_picture: '插入图片',
+  word_add_table: '添加表格',
+  word_add_page_break: '插入分页符',
+  word_add_table_of_contents: '添加目录',
+  word_delete_paragraph: '删除段落',
+  word_search_and_replace: '查找替换',
+  word_replace_paragraph_block_below_header: '替换区块',
+  word_replace_block_between_manual_anchors: '替换锚点内容',
+  word_create_custom_style: '创建样式',
+  word_format_text: '格式化文本',
+  word_format_table: '格式化表格',
+  word_set_table_cell_shading: '设置单元格底色',
+  word_apply_table_alternating_rows: '交替行颜色',
+  word_highlight_table_header: '高亮表头',
+  word_merge_table_cells: '合并单元格',
+  word_merge_table_cells_horizontal: '水平合并',
+  word_merge_table_cells_vertical: '垂直合并',
+  word_set_table_cell_alignment: '单元格对齐',
+  word_set_table_alignment_all: '表格对齐',
+  word_set_table_column_width: '设置列宽',
+  word_set_table_column_widths: '批量设置列宽',
+  word_set_table_width: '设置表格宽度',
+  word_auto_fit_table_columns: '自动调整列宽',
+  word_format_table_cell_text: '格式化单元格',
+  word_set_table_cell_padding: '设置单元格边距',
+  word_protect_document: '添加密码',
+  word_unprotect_document: '解除密码',
+  word_add_footnote_to_document: '添加脚注',
+  word_add_footnote_after_text: '添加脚注(后)',
+  word_add_footnote_before_text: '添加脚注(前)',
+  word_add_footnote_enhanced: '添加脚注(增强)',
+  word_add_footnote_robust: '添加脚注(鲁棒)',
+  word_add_endnote_to_document: '添加尾注',
+  word_customize_footnote_style: '脚注样式',
+  word_delete_footnote_from_document: '删除脚注',
+  word_delete_footnote_robust: '删除脚注(鲁棒)',
+  word_validate_document_footnotes: '验证脚注',
+  word_get_paragraph_text_from_document: '获取段落',
+  word_find_text_in_document: '搜索文本',
+  word_convert_to_pdf: '转为 PDF',
+  word_get_all_comments: '查看评论',
+  word_get_comments_by_author: '按作者筛选评论',
+  word_get_comments_for_paragraph: '段落评论',
+}
+
 export function toolDisplayName(name: string): string {
   if (DISPLAY_NAMES[name]) return DISPLAY_NAMES[name]
-  // word_* 系列统一显示为"Word 文档"
-  if (name.startsWith('word_')) return 'Word 文档'
+  if (name.startsWith('word_')) {
+    return WORD_DISPLAY_NAMES[name] || name.replace(/^word_/, '').replace(/_/g, ' ')
+  }
   return name
 }
 

--- a/web/src/components/tools/_word/CommentsCard.vue
+++ b/web/src/components/tools/_word/CommentsCard.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="word-card comments-card">
+    <div class="card-header">
+      <span class="cmt-icon">💬</span>
+      <div>
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename">📄 {{ data.filename }}</div>
+      </div>
+    </div>
+
+    <div class="cmt-summary" v-if="data.count !== undefined">
+      <span class="cmt-badge">{{ data.count }}</span>
+      <span class="cmt-label">条评论</span>
+    </div>
+
+    <div class="cmt-list" v-if="data.comments?.length">
+      <div class="cmt-item" v-for="(c, i) in data.comments.slice(0, 10)" :key="i">
+        <div class="cmt-author" v-if="c.author || c.author_name">
+          <span class="cmt-avatar">👤</span>
+          {{ c.author || c.author_name }}
+        </div>
+        <div class="cmt-text">{{ truncate(c.text || c.content || '', 150) }}</div>
+      </div>
+      <div class="cmt-more" v-if="data.comments.length > 10">
+        … 还有 {{ data.comments.length - 10 }} 条评论
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const titleText = computed(() => {
+  const a = props.data.action
+  if (a?.includes('by_author')) return '评论（按作者）'
+  if (a?.includes('for_paragraph')) return '段落评论'
+  return '文档评论'
+})
+
+function truncate(s: string, n: number): string {
+  return s && s.length > n ? s.slice(0, n) + '...' : s || ''
+}
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.cmt-icon { font-size: 20px; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #0891b2;
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.cmt-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+.cmt-badge {
+  background: #ecfeff;
+  color: #0891b2;
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 700;
+}
+.cmt-label { font-size: 13px; color: var(--text-secondary); }
+.cmt-list {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.cmt-item {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+.cmt-item:last-child { border-bottom: none; }
+.cmt-author {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.cmt-avatar { font-size: 12px; }
+.cmt-text {
+  color: var(--text-secondary);
+  line-height: 1.5;
+  word-break: break-word;
+}
+.cmt-more {
+  padding: 6px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-align: center;
+  background: var(--bg-secondary);
+}
+</style>

--- a/web/src/components/tools/_word/ConvertCard.vue
+++ b/web/src/components/tools/_word/ConvertCard.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="word-card convert-card">
+    <div class="card-body">
+      <span class="convert-icon">📕</span>
+      <div>
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename">
+          📄 {{ data.filename }} → <span class="pdf-label">.pdf</span>
+        </div>
+        <div class="card-output" v-if="data.output_filename">
+          📕 {{ data.output_filename }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const titleText = computed(() => {
+  return props.data.success !== false ? '转换成功' : '转换失败'
+})
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-body {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.convert-icon { font-size: 26px; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #dc2626;
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.pdf-label {
+  font-weight: 700;
+  color: #dc2626;
+}
+.card-output {
+  font-size: 12px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  padding: 3px 8px;
+  border-radius: 4px;
+  margin-top: 4px;
+  display: inline-block;
+  font-family: 'SF Mono', 'Consolas', monospace;
+}
+</style>

--- a/web/src/components/tools/_word/CreateCard.vue
+++ b/web/src/components/tools/_word/CreateCard.vue
@@ -1,0 +1,87 @@
+<template>
+  <div class="word-card success-card">
+    <div class="card-body">
+      <div class="status-badge success">✓</div>
+      <div class="card-text">
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename">📄 {{ data.filename }}</div>
+        <div class="card-meta" v-if="data.count">共合并 {{ data.count }} 个文档</div>
+      </div>
+    </div>
+    <div class="card-msg" v-if="data.message">{{ truncate(data.message, 120) }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const titleText = computed(() => {
+  switch (props.data.action) {
+    case 'create_document': return '文档创建成功'
+    case 'copy_document': return '文档复制成功'
+    case 'merge_documents': return '文档合并成功'
+    default: return '操作成功'
+  }
+})
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n) + '...' : s
+}
+</script>
+
+<style scoped>
+.word-card {
+  padding: 12px 4px;
+}
+.success-card .card-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+.status-badge {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.status-badge.success {
+  background: #dcfce7;
+  color: #16a34a;
+}
+.card-text { flex: 1; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #16a34a;
+  margin-bottom: 4px;
+}
+.card-filename {
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  padding: 4px 8px;
+  border-radius: 4px;
+  display: inline-block;
+}
+.card-meta {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+.card-msg {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  background: var(--bg-primary);
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+</style>

--- a/web/src/components/tools/_word/DefaultCard.vue
+++ b/web/src/components/tools/_word/DefaultCard.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="word-card default-card">
+    <!-- 成功批示 -->
+    <div class="succ-line" v-if="data.success !== false">
+      <span class="succ-icon">✓</span>
+      <span>操作完成</span>
+    </div>
+    <div class="err-line" v-else>
+      <span class="err-icon">✗</span>
+      <span>操作失败</span>
+    </div>
+
+    <!-- 文件名 -->
+    <div class="file-name" v-if="data.filename">📄 {{ data.filename }}</div>
+
+    <!-- 消息摘要 -->
+    <div class="msg-text" v-if="data.message">{{ data.message }}</div>
+
+    <!-- 原始输出（折叠） -->
+    <div class="raw-section" v-if="rawOutput">
+      <div class="raw-toggle" @click="showRaw = !showRaw">
+        {{ showRaw ? '收起原始输出' : '查看原始输出' }}
+      </div>
+      <pre class="raw-code" v-if="showRaw">{{ rawOutput }}</pre>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+defineProps<{ data: Record<string, any>; rawOutput: string | null }>()
+
+const showRaw = ref(false)
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.succ-line, .err-line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.succ-line { color: #16a34a; }
+.err-line { color: #b91c1c; }
+.succ-icon, .err-icon {
+  width: 20px; height: 20px;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px;
+}
+.succ-icon { background: #dcfce7; }
+.err-icon { background: #fee2e2; }
+
+.file-name {
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  padding: 3px 8px;
+  border-radius: 4px;
+  display: inline-block;
+  margin-bottom: 6px;
+}
+.msg-text {
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+.raw-section { margin-top: 8px; }
+.raw-toggle {
+  font-size: 11px;
+  color: var(--accent);
+  cursor: pointer;
+  user-select: none;
+  padding: 4px 0;
+}
+.raw-toggle:hover { opacity: 0.8; }
+.raw-code {
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--bg-primary);
+  padding: 8px 10px;
+  border-radius: 6px;
+  max-height: 150px;
+  overflow-y: auto;
+  margin: 4px 0 0;
+}
+</style>

--- a/web/src/components/tools/_word/EditCard.vue
+++ b/web/src/components/tools/_word/EditCard.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="word-card edit-card">
+    <div class="card-header">
+      <span class="edit-icon">✂️</span>
+      <div>
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename">📄 {{ data.filename }}</div>
+      </div>
+    </div>
+    <div class="card-msg">{{ data.message || '编辑完成' }}</div>
+
+    <!-- 段落索引 -->
+    <div class="detail-line" v-if="data.paragraph_index !== undefined">
+      <span class="dl-label">段落索引</span>
+      <span class="dl-val">{{ data.paragraph_index }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const titleText = computed(() => {
+  switch (props.data.action) {
+    case 'delete_paragraph': return '删除段落'
+    case 'replace_block': return '替换区块'
+    case 'replace_anchors': return '替换锚点内容'
+    case 'get_paragraph': return '获取段落'
+    default: return '编辑操作'
+  }
+})
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.edit-icon { font-size: 20px; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.card-msg {
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.5;
+  margin-bottom: 4px;
+}
+.detail-line {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  padding: 2px 0;
+}
+.dl-label { color: var(--text-secondary); }
+.dl-val { color: var(--text-primary); font-weight: 500; }
+</style>

--- a/web/src/components/tools/_word/FootnoteCard.vue
+++ b/web/src/components/tools/_word/FootnoteCard.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="word-card footnote-card">
+    <div class="card-header">
+      <span class="fn-icon">{{ isEndnote ? '📝' : '①' }}</span>
+      <div>
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename">📄 {{ data.filename }}</div>
+      </div>
+    </div>
+
+    <!-- 脚注统计 -->
+    <div class="fn-stats" v-if="data.footnote_count !== undefined">
+      <span class="fn-badge">{{ data.footnote_count }}</span>
+      <span class="fn-label">{{ isEndnote ? '个尾注' : '个脚注' }}</span>
+    </div>
+
+    <!-- 验证结果 -->
+    <div class="fn-valid" v-if="data.action === 'validate_footnotes'">
+      {{ data.message || '脚注验证完成' }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const isEndnote = computed(() => props.data.action?.includes('endnote'))
+
+const titleText = computed(() => {
+  const a = props.data.action
+  if (!a) return '脚注操作'
+  if (a.includes('add_footnote')) return '添加脚注'
+  if (a.includes('delete_footnote')) return '删除脚注'
+  if (a.includes('customize')) return '自定义脚注样式'
+  if (a.includes('validate')) return '验证脚注'
+  if (a.includes('add_endnote')) return '添加尾注'
+  return a.replace(/_/g, ' ')
+})
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.fn-icon {
+  font-size: 20px;
+  line-height: 1;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff7ed;
+  border-radius: 50%;
+}
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #c2410c;
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.fn-stats {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.fn-badge {
+  background: #fff7ed;
+  color: #c2410c;
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 700;
+}
+.fn-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.fn-valid {
+  font-size: 13px;
+  color: var(--text-primary);
+  padding: 6px 0;
+  line-height: 1.5;
+}
+</style>

--- a/web/src/components/tools/_word/FormatCard.vue
+++ b/web/src/components/tools/_word/FormatCard.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="word-card format-card">
+    <div class="card-header">
+      <span class="fmt-icon">🎨</span>
+      <div class="header-text">
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename">📄 {{ data.filename }}</div>
+      </div>
+    </div>
+    <div class="card-msg">{{ data.message || '格式已应用' }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const titleText = computed(() => {
+  switch (props.data.action) {
+    case 'format_text': return '格式化文本'
+    case 'format_table': return '格式化表格'
+    case 'create_style': return '创建样式'
+    default: return '格式操作'
+  }
+})
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.fmt-icon { font-size: 22px; }
+.header-text { flex: 1; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #7c3aed;
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.card-msg {
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+</style>

--- a/web/src/components/tools/_word/InfoCard.vue
+++ b/web/src/components/tools/_word/InfoCard.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="word-card info-card">
+    <div class="card-header">
+      <WordIcon />
+      <div class="header-text">
+        <div class="card-title">文档信息</div>
+        <div class="card-filename" v-if="data.filename || data.file_name">📄 {{ data.filename || data.file_name }}</div>
+      </div>
+    </div>
+    <div class="info-grid">
+      <div class="info-item" v-if="data.author">
+        <span class="info-label">作者</span>
+        <span class="info-value">{{ data.author }}</span>
+      </div>
+      <div class="info-item" v-if="data.title">
+        <span class="info-label">标题</span>
+        <span class="info-value">{{ data.title }}</span>
+      </div>
+      <div class="info-item" v-if="data.paragraph_count !== undefined">
+        <span class="info-label">段落</span>
+        <span class="info-value">{{ data.paragraph_count }}</span>
+      </div>
+      <div class="info-item" v-if="data.table_count !== undefined">
+        <span class="info-label">表格</span>
+        <span class="info-value">{{ data.table_count }}</span>
+      </div>
+      <div class="info-item" v-if="data.character_count !== undefined">
+        <span class="info-label">字符</span>
+        <span class="info-value">{{ formatNumber(data.character_count) }}</span>
+      </div>
+      <div class="info-item" v-if="data.heading_count !== undefined">
+        <span class="info-label">标题</span>
+        <span class="info-value">{{ data.heading_count }}</span>
+      </div>
+      <div class="info-item" v-if="data.section_count !== undefined">
+        <span class="info-label">节</span>
+        <span class="info-value">{{ data.section_count }}</span>
+      </div>
+      <div class="info-item" v-if="data.page_count !== undefined">
+        <span class="info-label">页数</span>
+        <span class="info-value">{{ data.page_count }}</span>
+      </div>
+      <div class="info-item" v-if="data.file_size">
+        <span class="info-label">大小</span>
+        <span class="info-value">{{ formatSize(data.file_size) }}</span>
+      </div>
+      <div class="info-item" v-if="data.created">
+        <span class="info-label">创建</span>
+        <span class="info-value">{{ data.created }}</span>
+      </div>
+      <div class="info-item" v-if="data.modified">
+        <span class="info-label">修改</span>
+        <span class="info-value">{{ data.modified }}</span>
+      </div>
+      <div class="info-item" v-if="data.revision">
+        <span class="info-label">修订</span>
+        <span class="info-value">{{ data.revision }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import WordIcon from '../_shared/WordIcon.vue'
+
+defineProps<{ data: Record<string, any> }>()
+
+function formatNumber(n: number | string): string {
+  const num = typeof n === 'string' ? parseInt(n, 10) : n
+  if (isNaN(num)) return String(n)
+  return num.toLocaleString()
+}
+
+function formatSize(size: number | string): string {
+  const bytes = typeof size === 'string' ? parseInt(size, 10) : size
+  if (isNaN(bytes)) return String(size)
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.header-text { flex: 1; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 1px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--border);
+}
+.info-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 8px;
+  background: var(--bg-primary);
+}
+.info-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.info-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+</style>

--- a/web/src/components/tools/_word/InsertCard.vue
+++ b/web/src/components/tools/_word/InsertCard.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="word-card insert-card">
+    <div class="card-header">
+      <span class="insert-icon">{{ insertIcon }}</span>
+      <div>
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename">📄 {{ data.filename }}</div>
+      </div>
+    </div>
+
+    <!-- 标题信息 -->
+    <div class="detail-line" v-if="data.text">
+      <span class="detail-label">标题</span>
+      <span class="detail-val">「{{ data.text }}」</span>
+    </div>
+    <div class="detail-line" v-if="data.level">
+      <span class="detail-label">级别</span>
+      <span class="detail-val">Heading {{ data.level }}</span>
+    </div>
+
+    <!-- 图片信息 -->
+    <div class="detail-line" v-if="data.image_path">
+      <span class="detail-label">图片</span>
+      <span class="detail-val path">{{ data.image_path }}</span>
+    </div>
+
+    <!-- 目录条目数 -->
+    <div class="detail-line" v-if="data.count !== undefined">
+      <span class="detail-label">目录条目</span>
+      <span class="detail-val">{{ data.count }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const insertIcon = computed(() => {
+  switch (props.data.action) {
+    case 'add_heading': return '🔤'
+    case 'add_picture': return '🖼️'
+    case 'add_page_break': return '📄'
+    case 'add_toc': return '📑'
+    case 'insert_list': return '📋'
+    default: return '✏️'
+  }
+})
+
+const titleText = computed(() => {
+  switch (props.data.action) {
+    case 'add_heading': return '添加标题'
+    case 'add_paragraph': return '添加段落'
+    case 'add_picture': return '插入图片'
+    case 'add_page_break': return '插入分页符'
+    case 'add_toc': return '添加目录'
+    case 'insert_heading': return '插入标题'
+    case 'insert_paragraph': return '插入段落'
+    case 'insert_list': return '插入列表'
+    default: return '插入内容'
+  }
+})
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.insert-icon { font-size: 24px; line-height: 1; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.detail-line {
+  display: flex;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 13px;
+  align-items: baseline;
+}
+.detail-label {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  min-width: 4em;
+}
+.detail-val {
+  color: var(--text-primary);
+  word-break: break-all;
+}
+.detail-val.path {
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 11px;
+  background: var(--bg-primary);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+</style>

--- a/web/src/components/tools/_word/OutlineCard.vue
+++ b/web/src/components/tools/_word/OutlineCard.vue
@@ -1,0 +1,159 @@
+<template>
+  <div class="word-card outline-card">
+    <div class="card-header">
+      <WordIcon />
+      <div class="header-text">
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename || data.file_name">📄 {{ data.filename || data.file_name }}</div>
+      </div>
+    </div>
+
+    <!-- 统计摘要 -->
+    <div class="stats-row" v-if="hasStats">
+      <div class="stat-pill" v-if="data.heading_count !== undefined">
+        <span class="stat-num">{{ data.heading_count }}</span> 个标题
+      </div>
+      <div class="stat-pill" v-if="data.paragraph_count !== undefined">
+        <span class="stat-num">{{ data.paragraph_count }}</span> 个段落
+      </div>
+      <div class="stat-pill" v-if="data.count !== undefined">
+        <span class="stat-num">{{ data.count }}</span> 个文档
+      </div>
+    </div>
+
+    <!-- 文档列表 -->
+    <div class="file-list" v-if="data.files?.length">
+      <div class="file-row" v-for="(f, i) in data.files.slice(0, 15)" :key="i">
+        <span class="file-icon">📄</span>
+        <span class="file-name">{{ typeof f === 'string' ? f : f.name || f.filename || '' }}</span>
+        <span class="file-size" v-if="f.size">{{ formatSize(f.size) }}</span>
+      </div>
+      <div class="file-more" v-if="data.files.length > 15">… 还有 {{ data.files.length - 15 }} 个文档</div>
+    </div>
+
+    <!-- 标题大纲 -->
+    <div class="heading-list" v-if="data.headings?.length">
+      <div class="heading-row" v-for="(h, i) in data.headings.slice(0, 20)" :key="i"
+           :style="{ paddingLeft: ((h.level || 1) - 1) * 16 + 'px' }">
+        <span class="heading-bullet">•</span>
+        <span class="heading-text">{{ h.text || h.title || '' }}</span>
+      </div>
+      <div class="file-more" v-if="data.headings.length > 20">… 还有 {{ data.headings.length - 20 }} 个标题</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import WordIcon from '../_shared/WordIcon.vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const titleText = computed(() => {
+  switch (props.data.action) {
+    case 'get_document_outline': return '文档大纲'
+    case 'list_documents': return '文档列表'
+    case 'get_document_xml': return '文档 XML'
+    case 'get_document_text': return '文档文本'
+    default: return '文档概览'
+  }
+})
+
+const hasStats = computed(() => {
+  return props.data.heading_count !== undefined ||
+         props.data.paragraph_count !== undefined ||
+         props.data.count !== undefined
+})
+
+function formatSize(size: number | string): string {
+  const bytes = typeof size === 'string' ? parseInt(size, 10) : size
+  if (isNaN(bytes)) return String(size)
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.header-text { flex: 1; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+/* Stats */
+.stats-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.stat-pill {
+  background: var(--bg-secondary);
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.stat-num {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* File list */
+.file-list {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.file-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+}
+.file-row:last-child { border-bottom: none; }
+.file-icon { flex-shrink: 0; }
+.file-name { flex: 1; color: var(--text-primary); word-break: break-all; }
+.file-size { color: var(--text-secondary); flex-shrink: 0; }
+.file-more {
+  padding: 8px 10px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-align: center;
+  background: var(--bg-secondary);
+}
+
+/* Headings */
+.heading-list {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.heading-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+}
+.heading-row:last-child { border-bottom: none; }
+.heading-bullet { color: var(--accent); flex-shrink: 0; }
+.heading-text { color: var(--text-primary); }
+</style>

--- a/web/src/components/tools/_word/ProtectCard.vue
+++ b/web/src/components/tools/_word/ProtectCard.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="word-card protect-card">
+    <div class="card-body">
+      <span class="lock-icon">{{ isLocking ? '🔒' : '🔓' }}</span>
+      <div>
+        <div class="card-title">{{ isLocking ? '已添加密码保护' : '已解除密码保护' }}</div>
+        <div class="card-filename" v-if="data.filename">📄 {{ data.filename }}</div>
+        <div class="card-pw" v-if="data.password">密码已设置</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const isLocking = computed(() => props.data.action === 'protect')
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-body {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.lock-icon { font-size: 26px; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+}
+.protect-card .card-title { color: #b45309; }
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.card-pw {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+</style>

--- a/web/src/components/tools/_word/SearchCard.vue
+++ b/web/src/components/tools/_word/SearchCard.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="word-card search-card">
+    <div class="card-header">
+      <span class="search-icon">🔍</span>
+      <div>
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename">📄 {{ data.filename }}</div>
+      </div>
+    </div>
+
+    <!-- 替换统计 -->
+    <div class="search-count" v-if="data.count !== undefined">
+      <span :class="['count-badge', data.count === 0 ? 'zero' : 'found']">
+        {{ data.count }}
+      </span>
+      <span class="count-label">
+        {{ data.action === 'search_replace' ? '处替换' : '处匹配' }}
+      </span>
+    </div>
+
+    <!-- 替换详情 -->
+    <div class="search-detail" v-if="data.find_text">
+      <div class="detail-line">
+        <span class="dl-label">查找</span>
+        <span class="dl-val find">「{{ data.find_text }}」</span>
+      </div>
+      <div class="detail-line" v-if="data.replace_text">
+        <span class="dl-label">替换为</span>
+        <span class="dl-val replace">「{{ data.replace_text }}」</span>
+      </div>
+    </div>
+
+    <!-- 搜索结果 -->
+    <div class="results-list" v-if="data.results?.length">
+      <div class="result-row" v-for="(r, i) in data.results.slice(0, 8)" :key="i">
+        <span class="result-idx">#{{ i + 1 }}</span>
+        <span class="result-text">{{ truncate(r.text || r.content || r.snippet || '', 80) }}</span>
+      </div>
+      <div class="result-more" v-if="data.results.length > 8">
+        … 还有 {{ data.results.length - 8 }} 条结果
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const titleText = computed(() => {
+  return props.data.action === 'find_text' ? '搜索文本' : '查找替换'
+})
+
+function truncate(s: string, n: number): string {
+  return s && s.length > n ? s.slice(0, n) + '...' : s || ''
+}
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.search-icon { font-size: 20px; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.search-count {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.count-badge {
+  padding: 2px 12px;
+  border-radius: 10px;
+  font-size: 16px;
+  font-weight: 700;
+}
+.count-badge.found { background: #dbeafe; color: #2563eb; }
+.count-badge.zero { background: var(--bg-secondary); color: var(--text-secondary); }
+.count-label { font-size: 13px; color: var(--text-secondary); }
+.search-detail {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-bottom: 8px;
+}
+.detail-line {
+  display: flex;
+  gap: 8px;
+  font-size: 13px;
+  padding: 2px 0;
+  align-items: baseline;
+}
+.dl-label { color: var(--text-secondary); min-width: 4em; }
+.dl-val { word-break: break-all; }
+.dl-val.find { color: #dc2626; }
+.dl-val.replace { color: #16a34a; }
+.results-list {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.result-row {
+  display: flex;
+  gap: 8px;
+  padding: 5px 10px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+}
+.result-row:last-child { border-bottom: none; }
+.result-idx { color: var(--text-secondary); flex-shrink: 0; }
+.result-text { color: var(--text-primary); word-break: break-word; }
+.result-more {
+  padding: 6px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-align: center;
+  background: var(--bg-secondary);
+}
+</style>

--- a/web/src/components/tools/_word/TableCard.vue
+++ b/web/src/components/tools/_word/TableCard.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="word-card table-card">
+    <div class="card-header">
+      <span class="table-icon">📊</span>
+      <div>
+        <div class="card-title">{{ titleText }}</div>
+        <div class="card-filename" v-if="data.filename">📄 {{ data.filename }}</div>
+      </div>
+    </div>
+
+    <!-- 添加表格信息 -->
+    <div class="table-dimensions" v-if="data.rows && data.cols">
+      <span class="dim-badge">{{ data.rows }} 行</span>
+      <span class="dim-sep">×</span>
+      <span class="dim-badge">{{ data.cols }} 列</span>
+    </div>
+
+    <!-- 表格参数摘要 -->
+    <div class="params" v-if="paramLines.length">
+      <div class="param-row" v-for="(p, i) in paramLines" :key="i">
+        <span class="param-key">{{ p.key }}</span>
+        <span class="param-val">{{ p.val }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ data: Record<string, any> }>()
+
+const titleText = computed(() => {
+  const a = props.data.action
+  if (a === 'add_table') return '添加表格'
+  return (a?.replace(/^table_/, '')?.replace(/_/g, ' ') || '表格操作').replace(/^\w/, c => c.toUpperCase())
+})
+
+const PARAM_LABELS: Record<string, string> = {
+  column_width: '列宽',
+  width: '宽度',
+  alignment: '对齐',
+  shading: '底色',
+  cell_alignment: '单元格对齐',
+  text_align: '文本对齐',
+  padding: '边距',
+  rows: '行数',
+  cols: '列数',
+}
+
+const paramLines = computed(() => {
+  const lines: { key: string; val: string }[] = []
+  for (const [k, v] of Object.entries(props.data)) {
+    if (['tool_type', 'action', 'success', 'message', 'filename', 'rows', 'cols'].includes(k)) continue
+    if (v !== null && v !== undefined && v !== '' && typeof v !== 'object') {
+      const label = PARAM_LABELS[k] || k.replace(/_/g, ' ')
+      lines.push({ key: label, val: String(v) })
+    }
+  }
+  return lines.slice(0, 6)
+})
+</script>
+
+<style scoped>
+.word-card { padding: 12px 4px; }
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.table-icon { font-size: 22px; line-height: 1; }
+.card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #6d28d9;
+}
+.card-filename {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.table-dimensions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.dim-badge {
+  background: #ede9fe;
+  color: #6d28d9;
+  padding: 4px 12px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.dim-sep {
+  color: var(--text-secondary);
+  font-size: 16px;
+}
+.params {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+}
+.param-row {
+  display: flex;
+  gap: 4px;
+  font-size: 12px;
+}
+.param-key { color: var(--text-secondary); }
+.param-val { color: var(--text-primary); font-weight: 500; }
+</style>

--- a/web/src/components/tools/registry.ts
+++ b/web/src/components/tools/registry.ts
@@ -21,6 +21,7 @@ import UnitTestBubble from './UnitTestBubble.vue'
 import DebuggerBubble from './DebuggerBubble.vue'
 import ScraperBubble from './ScraperBubble.vue'
 import AskUserBubble from './AskUserBubble.vue'
+import WordBubble from './WordBubble.vue'
 
 /** 工具注册表：tool_name → 专属气泡组件 */
 const registry: Record<string, Component> = {
@@ -66,7 +67,10 @@ const registry: Record<string, Component> = {
 }
 
 export function getBubbleComponent(name: string): Component | null {
-  return registry[name] ?? null
+  if (registry[name]) return registry[name]
+  // word_* 系列工具统一路由到 WordBubble
+  if (name.startsWith('word_')) return WordBubble
+  return null
 }
 
 export function getRegisteredTools(): string[] {


### PR DESCRIPTION
## 变更内容

为 50+ 个 MCP Word 文档工具添加前端结构化气泡展示，替换原有的原始 JSON 显示。

### 后端改动

- **api/callbacks/websocket_callback.py** — 修复 _extract_tool_data：MCP Word 工具返回纯文本而非 JSON 时，包装为 _raw 后继续 dispatch，而非直接 return None
- **api/callbacks/tool_extractors.py** — 新增 @register_prefix("word_") 提取器，支持纯文本成功/失败消息解析 + JSON 双通道提取

### 前端改动

- **WordBubble.vue** — 完全重写，按 action 类别路由到 13 种子卡片组件
- **_word/** — 新增 13 个子卡片组件（创建/信息/大纲/插入/表格/脚注/搜索/格式化/保护/转换/评论/编辑/默认）
- **displayNames.ts** — 50+ word 工具独立中文显示名
- **WordIcon.vue** — 新增共享 Word 图标组件

### Commits

1. 27a1a0c feat(skills): 集成 Office-Word-MCP-Server，新增 54 个 Word 文档操作工具
2. 50ef968 feat(web): 添加 Word 文档工具前端气泡组件
3. f8de4f0 fix(api): 修复 context_usage 崩溃
4. 244ae56 docs: Word-MCP 集成复盘
5. 562bfcf feat(word-bubble): MCP Word工具结构化气泡展示