### PR TITLE
feat(api,web): 添加后端四部件健康自检及前端展示

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -1,0 +1,172 @@
+"""后端四部件健康自检 — LLM / 记忆 / 原生工具集 / MCP 工具集。"""
+
+import asyncio
+import time
+from typing import Literal
+
+import httpx
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from config.settings import get_settings
+from memory.memory_manager import MemoryManager
+from memory.narrative import MEMORY_PATH
+
+
+class ComponentHealth(BaseModel):
+    status: Literal["ok", "error"]
+    latency_ms: float | None = None
+    detail: str | None = None
+
+
+class HealthResponse(BaseModel):
+    status: Literal["ok", "degraded"]
+    version: str
+    llm: ComponentHealth
+    memory: ComponentHealth
+    native_tools: ComponentHealth
+    mcp_tools: ComponentHealth
+    timestamp: float
+
+
+# ── LLM 健康缓存（30 秒 TTL，避免高频 API 调用）──────────────
+
+_llm_health_cache: tuple[float, ComponentHealth] | None = None
+_LLM_CACHE_TTL = 30.0
+
+
+_httpx_client: httpx.AsyncClient | None = None
+
+
+def _get_httpx_client() -> httpx.AsyncClient:
+    global _httpx_client
+    if _httpx_client is None:
+        _httpx_client = httpx.AsyncClient(timeout=5.0)
+    return _httpx_client
+
+
+async def check_llm(app: FastAPI) -> ComponentHealth:
+    global _llm_health_cache
+
+    now = time.monotonic()
+    if _llm_health_cache is not None and now - _llm_health_cache[0] < _LLM_CACHE_TTL:
+        return _llm_health_cache[1]
+
+    start = now
+    try:
+        settings = get_settings()
+        client = _get_httpx_client()
+        resp = await client.post(
+            f"{settings.deepseek_base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {settings.deepseek_api_key}"},
+            json={
+                "model": settings.model_name,
+                "messages": [{"role": "user", "content": "ok"}],
+                "max_tokens": 1,
+            },
+        )
+        elapsed = (time.monotonic() - start) * 1000
+
+        if resp.is_success:
+            result = ComponentHealth(status="ok", latency_ms=round(elapsed, 1))
+        else:
+            result = ComponentHealth(
+                status="error",
+                latency_ms=round(elapsed, 1),
+                detail=f"API {resp.status_code}: {resp.text[:200]}",
+            )
+    except asyncio.TimeoutError:
+        elapsed = (time.monotonic() - start) * 1000
+        result = ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail="请求超时（5s）")
+    except httpx.RequestError as e:
+        elapsed = (time.monotonic() - start) * 1000
+        result = ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail=f"网络错误: {e}")
+    except Exception as e:
+        elapsed = (time.monotonic() - start) * 1000
+        result = ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail=str(e))
+
+    _llm_health_cache = (time.monotonic(), result)
+    return result
+
+
+async def check_memory(app: FastAPI) -> ComponentHealth:
+    start = time.monotonic()
+    try:
+        memory_path = MEMORY_PATH
+        if not memory_path.exists():
+            elapsed = (time.monotonic() - start) * 1000
+            return ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail="记忆文件不存在")
+
+        mm = MemoryManager(yaml_file=str(memory_path))
+        items = mm.show()
+
+        ltm = app.state.ltm
+        consumer_running = ltm.is_listening if hasattr(ltm, "is_listening") else False
+
+        parts = [f"{len(items)} 条记忆"]
+        if not consumer_running:
+            parts.append("后台消费者异常")
+        status: Literal["ok", "error"] = "ok" if consumer_running else "error"
+
+        elapsed = (time.monotonic() - start) * 1000
+        return ComponentHealth(status=status, latency_ms=round(elapsed, 1), detail="，".join(parts))
+    except Exception as e:
+        elapsed = (time.monotonic() - start) * 1000
+        return ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail=str(e))
+
+
+async def check_native_tools(app: FastAPI) -> ComponentHealth:
+    start = time.monotonic()
+    try:
+        tools = app.state.native_tools
+        names = sorted(t.name for t in tools)
+        elapsed = (time.monotonic() - start) * 1000
+        return ComponentHealth(
+            status="ok",
+            latency_ms=round(elapsed, 1),
+            detail=f"{len(tools)} 个工具",
+        )
+    except Exception as e:
+        elapsed = (time.monotonic() - start) * 1000
+        return ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail=str(e))
+
+
+async def check_mcp_tools(app: FastAPI) -> ComponentHealth:
+    start = time.monotonic()
+    try:
+        tools = app.state.mcp_tools
+        if not tools:
+            elapsed = (time.monotonic() - start) * 1000
+            return ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail="MCP 工具未加载")
+        elapsed = (time.monotonic() - start) * 1000
+        return ComponentHealth(
+            status="ok",
+            latency_ms=round(elapsed, 1),
+            detail=f"{len(tools)} 个工具",
+        )
+    except Exception as e:
+        elapsed = (time.monotonic() - start) * 1000
+        return ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail=str(e))
+
+
+async def get_health_report(app: FastAPI) -> HealthResponse:
+    from version import __version__
+
+    llm = await check_llm(app)
+    memory = await check_memory(app)
+    native_tools = await check_native_tools(app)
+    mcp_tools = await check_mcp_tools(app)
+
+    overall: Literal["ok", "degraded"] = (
+        "ok" if all(c.status == "ok" for c in [llm, memory, native_tools, mcp_tools]) else "degraded"
+    )
+
+    return HealthResponse(
+        status=overall,
+        version=__version__,
+        llm=llm,
+        memory=memory,
+        native_tools=native_tools,
+        mcp_tools=mcp_tools,
+        timestamp=time.time(),
+    )

--- a/api/server.py
+++ b/api/server.py
@@ -9,6 +9,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
 from api.dependencies import get_llm, get_system_prompt, get_tools
+from api.health import get_health_report
 from api.routes import chat, files, memory, sessions, balance
 from api.session_manager import SessionManager
 from memory.narrative import MEMORY_PATH, LongTermMemoryInterface
@@ -23,14 +24,14 @@ async def lifespan(app: FastAPI):
     # 启动：初始化共享资源
     app.state.llm = get_llm()
     app.state.system_prompt = get_system_prompt()
-    app.state.tools = get_tools()
+    app.state.native_tools = get_tools()
     app.state.session_manager = SessionManager()
     app.state.ltm = LongTermMemoryInterface(MEMORY_PATH)
     app.state.ltm.start_listening(app.state.llm)
 
     # 加载 MCP 工具（Word 文档编辑能力）
-    mcp_tools = await init_mcp_tools()
-    app.state.tools = app.state.tools + mcp_tools
+    app.state.mcp_tools = await init_mcp_tools()
+    app.state.tools = app.state.native_tools + app.state.mcp_tools
 
     yield
 
@@ -66,7 +67,7 @@ def create_app() -> FastAPI:
     # 健康检查
     @app.get("/api/health")
     async def health():
-        return {"status": "ok", "version": __version__}
+        return await get_health_report(app)
 
     # 生产模式：serve 前端静态文件（用 /assets 前缀避免拦截 WebSocket）
     if WEB_DIR.exists():

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -243,6 +243,11 @@ class LongTermMemoryInterface:
         self._queue: asyncio.Queue | None = None
         self._consumer_task: asyncio.Task | None = None
 
+    @property
+    def is_listening(self) -> bool:
+        """后台消费者协程是否正在运行。"""
+        return self._consumer_task is not None and not self._consumer_task.done()
+
     def get_narrative(self) -> str:
         """读取当前记忆叙事，不存在则返回空字符串。"""
         if not self._memory_path.exists():

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -21,6 +21,7 @@
         @switch="switchSession"
         @delete="deleteSession"
       />
+      <HealthPanel :health="health!" v-if="health" />
     </aside>
     <main class="main">
       <router-view />
@@ -29,13 +30,22 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import Icon from '@/components/Icon.vue';
 import SessionSidebar from '@/components/SessionSidebar.vue';
+import HealthPanel from '@/components/HealthPanel.vue';
 import { allSessionStatuses } from '@/composables/useChat';
 import { useSession } from '@/composables/useSession';
+import { useHealth, startPolling, health } from '@/composables/useHealth';
 
 const { sessionId, sessions, createSession, switchSession, deleteSession } =
   useSession()
+
+useHealth()
+
+onMounted(() => {
+  startPolling()
+})
 </script>
 
 <style>

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -6,6 +6,7 @@ import type {
   MomentResponse,
   ContextUsage,
   DeepSeekBalanceResponse,
+  HealthResponse,
 } from '@/types'
 
 const BASE = '/api'
@@ -45,4 +46,7 @@ export const api = {
 
   getDeepSeekBalance: () =>
     request<DeepSeekBalanceResponse>('/deepseek-balance'),
+
+  health: () =>
+    request<HealthResponse>('/health'),
 }

--- a/web/src/components/HealthPanel.vue
+++ b/web/src/components/HealthPanel.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="health-panel" v-if="health">
+    <div class="health-title">系统状态</div>
+    <div class="health-items">
+      <div
+        v-for="item in items"
+        :key="item.name"
+        class="health-item"
+        :title="item.tooltip"
+      >
+        <span class="dot" :class="item.statusClass"></span>
+        <span class="label">{{ item.label }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ComponentHealth, HealthResponse } from '@/types';
+import { computed } from 'vue';
+
+const props = defineProps<{ health: HealthResponse }>()
+
+interface HealthItem {
+  name: string
+  label: string
+  statusClass: string
+  tooltip: string
+}
+
+const items = computed<HealthItem[]>(() => {
+  const h = props.health
+  return [
+    makeItem('LLM', h.llm),
+    makeItem('MEMORY', h.memory),
+    makeItem('SKILLS', h.native_tools),
+    makeItem('MCP', h.mcp_tools),
+  ]
+})
+
+function makeItem(label: string, c: ComponentHealth): HealthItem {
+  const ok = c.status === 'ok'
+  const parts: string[] = []
+  if (c.latency_ms != null) parts.push(`${c.latency_ms.toFixed(0)}ms`)
+  if (c.detail != null) parts.push(c.detail)
+  return {
+    name: label,
+    label,
+    statusClass: ok ? 'ok' : 'error',
+    tooltip: `${label}: ${ok ? '正常' : '异常'}${parts.length ? ' — ' + parts.join(' | ') : ''}`,
+  }
+}
+</script>
+
+<style scoped>
+.health-panel {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.health-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.health-items {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.health-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: help;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dot.ok {
+  background: #22c55e;
+}
+
+.dot.error {
+  background: #ef4444;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+</style>

--- a/web/src/components/StatusBadge.vue
+++ b/web/src/components/StatusBadge.vue
@@ -1,21 +1,77 @@
 <template>
-  <span class="status-badge" :class="connected ? 'connected' : 'disconnected'">
+  <span class="status-badge hover-trigger" :class="connected ? 'connected' : 'disconnected'">
     <span class="dot"></span>
     {{ connected ? '已连接' : '未连接' }}
+    <div v-if="health" class="hover-card card-health">
+      <div class="health-title">系统状态</div>
+      <div
+        v-for="(item, idx) in items"
+        :key="item.name"
+        class="health-section"
+      >
+        <div v-if="idx > 0" class="card-divider"></div>
+        <div class="section-header">
+          <span class="section-name">{{ item.name }}</span>
+          <span class="section-status" :class="item.ok ? 'status-ok' : 'status-err'">
+            {{ item.ok ? '正常' : '异常' }}
+          </span>
+        </div>
+        <div class="section-detail">
+          <span v-if="item.latency != null" class="detail-item">{{ item.latency }}</span>
+          <span v-if="item.info" class="detail-item detail-text">{{ item.info }}</span>
+        </div>
+      </div>
+      <div class="card-divider"></div>
+      <div class="card-row">
+        <span class="card-label">{{ health.version }}</span>
+        <span class="card-value" :class="health.status === 'ok' ? 'status-ok' : 'status-err'">
+          {{ health.status === 'ok' ? '就绪' : '部分异常' }}
+        </span>
+      </div>
+    </div>
   </span>
 </template>
 
 <script setup lang="ts">
-defineProps<{ connected: boolean }>()
+import type { ComponentHealth, HealthResponse } from '@/types';
+import { computed } from 'vue';
+
+const props = defineProps<{
+  connected: boolean
+  health: HealthResponse | null
+}>()
+
+const items = computed(() => {
+  if (!props.health) return []
+  return [
+    makeItem('LLM', props.health.llm),
+    makeItem('MEMORY', props.health.memory),
+    makeItem('SKILLS', props.health.native_tools),
+    makeItem('MCP', props.health.mcp_tools),
+  ]
+})
+
+function makeItem(name: string, c: ComponentHealth) {
+  const parts: string[] = []
+  if (c.detail) parts.push(c.detail)
+  return {
+    name,
+    ok: c.status === 'ok',
+    latency: c.latency_ms != null ? `${c.latency_ms.toFixed(0)} ms` : null,
+    info: parts.join(' | ') || null,
+  }
+}
 </script>
 
 <style scoped>
+/* ── trigger badge ── */
 .status-badge {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   font-size: 12px;
   color: var(--text-secondary);
+  cursor: default;
 }
 .dot {
   width: 8px;
@@ -28,5 +84,110 @@ defineProps<{ connected: boolean }>()
 }
 .disconnected .dot {
   background: #ef4444;
+}
+
+/* ── hover card shell ── */
+.hover-trigger {
+  position: relative;
+}
+.hover-trigger:hover .hover-card {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+}
+.hover-card {
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: visibility 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 100;
+  min-width: 240px;
+  padding: 8px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 12px;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+
+/* ── card rows ── */
+.card-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+.card-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+}
+.card-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+.status-ok {
+  color: #22c55e;
+}
+.status-err {
+  color: #ef4444;
+}
+.card-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+/* ── health-specific ── */
+.health-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+.health-section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.section-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.section-status {
+  font-size: 11px;
+  font-weight: 500;
+}
+.section-detail {
+  display: flex;
+  flex-direction: column;
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+.detail-item {
+  display: inline-flex;
+  gap: 4px;
+}
+.detail-text {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>

--- a/web/src/composables/useHealth.ts
+++ b/web/src/composables/useHealth.ts
@@ -1,0 +1,32 @@
+import { ref, onUnmounted } from 'vue'
+import { api } from '@/api'
+import type { HealthResponse } from '@/types'
+
+export const health = ref<HealthResponse | null>(null)
+let _timer: ReturnType<typeof setInterval> | null = null
+
+export async function refreshHealth() {
+  try {
+    health.value = await api.health()
+  } catch {
+    health.value = null
+  }
+}
+
+export function startPolling(intervalMs = 30000) {
+  stopPolling()
+  refreshHealth()
+  _timer = setInterval(refreshHealth, intervalMs)
+}
+
+export function stopPolling() {
+  if (_timer !== null) {
+    clearInterval(_timer)
+    _timer = null
+  }
+}
+
+export function useHealth() {
+  onUnmounted(stopPolling)
+  return { health, refreshHealth, startPolling, stopPolling }
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -213,3 +213,21 @@ export interface ContextUsage {
   usage_percent: number
   model_name: string
 }
+
+// === 健康检查 ===
+
+export interface ComponentHealth {
+  status: 'ok' | 'error'
+  latency_ms: number | null
+  detail: string | null
+}
+
+export interface HealthResponse {
+  status: 'ok' | 'degraded'
+  version: string
+  llm: ComponentHealth
+  memory: ComponentHealth
+  native_tools: ComponentHealth
+  mcp_tools: ComponentHealth
+  timestamp: number
+}

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="chat-view">
     <header class="chat-header">
-      <StatusBadge :connected="connected" />
+      <StatusBadge :connected="connected" :health="health" />
       <ContextUsageBadge :usage="contextUsage" />
     </header>
 
@@ -29,6 +29,7 @@ import { ref } from 'vue'
 import type { Citation } from '@/types'
 import { useSession } from '@/composables/useSession'
 import { useChat } from '@/composables/useChat'
+import { health } from '@/composables/useHealth'
 import StatusBadge from '@/components/StatusBadge.vue'
 import ContextUsageBadge from '@/components/ContextUsageBadge.vue'
 import ChatWindow from '@/components/ChatWindow.vue'


### PR DESCRIPTION
## 概述

为 LLM、记忆、原生工具集、MCP 工具集四个核心部件提供健康检查接口，并在前端侧边栏底部和聊天头部状态徽章悬停弹窗中展示。

## 变更内容

### 后端
- 新增 `api/health.py`：定义 `ComponentHealth` / `HealthResponse` Pydantic 模型，四个部件的异步检测函数
  - LLM：通过 httpx 直连 DeepSeek API 做轻量调用（max_tokens=1，5s 超时，30s 缓存）
  - 记忆：检查 memory.yaml 可读性与 LTM 消费者状态
  - 原生工具集：统计加载的工具数量
  - MCP 工具集：统计加载的 MCP 工具数量
- `api/server.py`：lifespan 中分开存储 native/MCP 工具集；`/api/health` 端点聚合返回
- `memory/narrative.py`：`LongTermMemoryInterface` 新增 `is_listening` 属性

### 前端
- 新增 `HealthPanel.vue`：侧边栏底部健康状态面板
- 新增 `useHealth.ts`：每 30 秒轮询 `/api/health`
- 修改 `StatusBadge.vue`：hover 弹窗展示四部件详细信息（延迟、数量等）
- 添加 `HealthResponse` / `ComponentHealth` 类型定义

## 验证
- `curl http://localhost:8000/api/health` 返回四部件状态
- 侧边栏底部显示健康面板
- hover 状态徽章弹出健康详情