### PR TITLE
style: 更新前端配色方案，集中管理状态色

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -30,13 +30,13 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import HealthPanel from '@/components/HealthPanel.vue';
 import Icon from '@/components/Icon.vue';
 import SessionSidebar from '@/components/SessionSidebar.vue';
-import HealthPanel from '@/components/HealthPanel.vue';
 import { allSessionStatuses } from '@/composables/useChat';
+import { health, startPolling, useHealth } from '@/composables/useHealth';
 import { useSession } from '@/composables/useSession';
-import { useHealth, startPolling, health } from '@/composables/useHealth';
+import { onMounted } from 'vue';
 
 const { sessionId, sessions, createSession, switchSession, deleteSession } =
   useSession()
@@ -63,10 +63,13 @@ onMounted(() => {
   --bg-card: #ffffff;
   --text-primary: #1f2937;
   --text-secondary: #6b7280;
-  --accent: #2563eb;
-  --accent-light: #93b4f5;
+  --accent: #000000;
+  --accent-light: #b9b9b9;
   --border: #e5e7eb;
-  --user-bubble: #eff6ff;
+  --user-bubble: #ffffff;
+  --status-ok: #000000;
+  --status-error: #ef4444;
+  --status-warn: #f59e0b;
   --shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
   --radius: 10px;
 }

--- a/web/src/components/ContextUsageBadge.vue
+++ b/web/src/components/ContextUsageBadge.vue
@@ -154,22 +154,22 @@ async function onBalanceHover() {
   transition: stroke-dashoffset 0.5s ease, stroke 0.5s ease;
 }
 .safe .ring-fill {
-  stroke: #22c55e;
+  stroke: var(--status-ok);
 }
 .safe .label {
-  color: #22c55e;
+  color: var(--status-ok);
 }
 .warn .ring-fill {
-  stroke: #f59e0b;
+  stroke: var(--status-warn);
 }
 .warn .label {
-  color: #f59e0b;
+  color: var(--status-warn);
 }
 .danger .ring-fill {
-  stroke: #ef4444;
+  stroke: var(--status-error);
 }
 .danger .label {
-  color: #ef4444;
+  color: var(--status-error);
 }
 .model-name {
   color: var(--text-secondary);
@@ -231,10 +231,10 @@ async function onBalanceHover() {
   margin: 4px 0;
 }
 .status-ok {
-  color: #22c55e;
+  color: var(--status-ok);
 }
 .status-err {
-  color: #ef4444;
+  color: var(--status-error);
 }
 
 /* 余额弹窗专用 */
@@ -250,6 +250,6 @@ async function onBalanceHover() {
   padding: 2px 0;
 }
 .balance-error {
-  color: #ef4444;
+  color: var(--status-error);
 }
 </style>

--- a/web/src/components/HealthPanel.vue
+++ b/web/src/components/HealthPanel.vue
@@ -89,11 +89,11 @@ function makeItem(label: string, c: ComponentHealth): HealthItem {
 }
 
 .dot.ok {
-  background: #22c55e;
+  background: var(--status-ok);
 }
 
 .dot.error {
-  background: #ef4444;
+  background: var(--status-error);
 }
 
 .label {

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -266,7 +266,7 @@ const cardStyle = computed(() => {
   opacity: 1;
 }
 .btn-delete:hover {
-  color: #ef4444;
+  color: var(--status-error);
 }
 .no-sessions {
   font-size: 12px;
@@ -288,16 +288,16 @@ const cardStyle = computed(() => {
 }
 
 .status-dot.connected {
-  background: #22c55e;
+  background: var(--status-ok);
 }
 
 .status-dot.streaming {
-  background: #22c55e;
+  background: var(--status-ok);
   animation: pulse 1.2s ease-in-out infinite;
 }
 
 .status-dot.awaiting-user {
-  background: #f59e0b;
+  background: var(--status-warn);
   animation: pulse 1.2s ease-in-out infinite;
 }
 

--- a/web/src/components/StatusBadge.vue
+++ b/web/src/components/StatusBadge.vue
@@ -80,10 +80,10 @@ function makeItem(name: string, c: ComponentHealth) {
   background: #ccc;
 }
 .connected .dot {
-  background: #22c55e;
+  background: var(--status-ok);
 }
 .disconnected .dot {
-  background: #ef4444;
+  background: var(--status-error);
 }
 
 /* ── hover card shell ── */
@@ -134,10 +134,10 @@ function makeItem(name: string, c: ComponentHealth) {
   color: var(--text-primary);
 }
 .status-ok {
-  color: #22c55e;
+  color: var(--status-ok);
 }
 .status-err {
-  color: #ef4444;
+  color: var(--status-error);
 }
 .card-divider {
   height: 1px;

--- a/web/src/views/PlaygroundView.vue
+++ b/web/src/views/PlaygroundView.vue
@@ -1348,11 +1348,11 @@ function logAction(payload: { action: string; data?: unknown }) {
 }
 
 .state-dot.done {
-  background: #22c55e;
+  background: var(--status-ok);
 }
 
 .state-dot.error {
-  background: #ef4444;
+  background: var(--status-error);
 }
 
 @keyframes pulse {


### PR DESCRIPTION
## 概述

统一前端颜色管理系统，将状态色提升为 CSS 变量（`--status-ok` / `--status-error` / `--status-warn`），替换各组件中的硬编码值。

## 变更

- `App.vue`：:root 中新增 `--status-ok` / `--status-error` / `--status-warn`，调整 accent 等基础色
- 6 个组件中的 20+ 处硬编码 `#22c55e` / `#ef4444` / `#f59e0b` 替换为 CSS 变量