### PR TITLE
fix(ui): 新增滚动阈值判断，仅在用户靠近底部时自动滚动

### DIFF
--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -131,6 +131,13 @@ function forwardAction(payload: { action: string; data?: unknown }) {
 }
 
 const windowRef = ref<HTMLElement | null>(null)
+const SCROLL_BOTTOM_THRESHOLD = 100
+
+function isNearBottom(): boolean {
+  const el = windowRef.value
+  if (!el) return true
+  return el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_BOTTOM_THRESHOLD
+}
 
 function hasAnswerBlock(turn: ChatTurn): boolean {
   return turn.events.some(e => e.kind === 'thinking' && e.becameAnswer)
@@ -152,14 +159,20 @@ function scrollToTurn(index: number) {
   }
 }
 
-watch(() => props.turns.length, () => scrollToBottom())
+watch(() => props.turns.length, () => {
+  if (isNearBottom()) scrollToBottom()
+})
 watch(
   () => props.currentTurn?.events.length,
-  () => scrollToBottom()
+  () => {
+    if (isNearBottom()) scrollToBottom()
+  }
 )
 watch(
   () => props.currentTurn?.finalAnswer,
-  () => scrollToBottom()
+  () => {
+    if (isNearBottom()) scrollToBottom()
+  }
 )
 
 // === 引用功能 ===


### PR DESCRIPTION
## Summary

- 新增 `SCROLL_BOTTOM_THRESHOLD = 100` 和 `isNearBottom()` 方法
- 三个 watch（turns.length、events.length、finalAnswer）触发 scrollToBottom 前先检查用户是否在底部附近
- 避免用户在阅读历史消息时被强制滚动

## Test plan

- [ ] 正常对话时自动滚动行为不变
- [ ] 手动滚动到历史消息后，新消息不再强制拉回底部
- [ ] 手动滚动到底部附近（<100px）时，自动滚动仍然生效