### PR TITLE
fix(ui): 添加会话缓存调试日志和孤儿缓存清理

### DIFF
--- a/dev_docs/session-cache.md
+++ b/dev_docs/session-cache.md
@@ -1,0 +1,236 @@
+# 前端会话缓存（localStorage）机制
+
+## 概述
+
+前端使用 `localStorage` 缓存每条会话的聊天记录（`ChatTurn[]`），使得页面刷新后能恢复历史对话。缓存 key 格式为 `sonetto_turns_<session_id>`，值是对 `ChatTurn[]` 的 `JSON.stringify`。
+
+---
+
+## 数据流总览
+
+```
+服务端 WebSocket
+      │
+      ▼
+handleEventForChannel()
+      │
+      ├─ answer / done 事件
+      │      ▼
+      │   ch.turns.push(turn)
+      │      ▼
+      │   persistTurns(sid)
+      │      ▼
+      │   saveTurnsToStorage(sid, snapshot)    ← 写入 localStorage
+      │
+      ├─ sub_session_created
+      │      ▼
+      │   switchSession(subId)  →  触发 watch
+      │                               ▼
+      │                           persistTurns(oldId)    ← 切换前写入
+      │
+      └─ ...
+
+模块加载时：
+  turnsCache = loadAllTurnsFromStorage()    ← 读取全部 localStorage
+
+页面初始化：
+  initIfNeeded() → sessionId.value = stored
+      ▼
+  watch(sessionId) fires
+      ▼
+  cached = turnsCache.get(newId)           ← 从内存 Map 读取
+  if (cached && ch.turns.length === 0)
+    ch.turns.push(...cached)               ← 恢复到响应式通道
+      ▼
+  cleanupOrphanedCaches()                  ← 清理孤儿缓存
+```
+
+---
+
+## localStorage key
+
+| 常量 | 值 | 来源 |
+|------|-----|------|
+| `TURNS_KEY_PREFIX` | `sonetto_turns_` | [useChat.ts:5](web/src/composables/useChat.ts#L5) |
+| `STORAGE_KEY` | `sonetto_session_id` | [useSession.ts:6](web/src/composables/useSession.ts#L6) |
+
+- 缓存 key: `sonetto_turns_<session_id>`（如 `sonetto_turns_550e8400e29b41d4a716446655440000`）
+- 当前会话 ID key: `sonetto_session_id`（值仅为 UUID 字符串，不包含前缀）
+
+---
+
+## 读时机（Read）
+
+### 模块加载时全量读取
+
+**位置**: [useChat.ts:8-32](web/src/composables/useChat.ts#L8-L32) `loadAllTurnsFromStorage()`
+
+在 `useChat.ts` 模块首次被 import 时调用，遍历 `localStorage` 中所有以 `sonetto_turns_` 开头的键，反序列化后存入模块级 `turnsCache: Map<string, ChatTurn[]>`。
+
+```typescript
+const turnsCache = loadAllTurnsFromStorage()    // 模块级，仅执行一次
+```
+
+### 会话切换 / 初始化时从缓存恢复
+
+**位置**: [useChat.ts:393-422](web/src/composables/useChat.ts#L393-L422) `watch(sessionId, ..., { immediate: true })`
+
+在以下两种场景触发：
+1. **页面初始化** — `initIfNeeded()` 从 `sonetto_session_id` 恢复会话 ID，watch 以 `{ immediate: true }` 触发
+2. **用户切换会话** — 点击侧边栏会话 → `switchSession(id)` → `sessionId.value = id` → watch 触发
+
+恢复逻辑：
+```typescript
+const cached = turnsCache.get(newId)
+const ch = getOrCreateChannel(newId)
+if (cached && ch.turns.length === 0) {
+  ch.turns.push(...cached)   // 将缓存数据推入响应式通道
+}
+```
+
+> **注意**: `turnsCache.get(newId)` 查找失败意味着该会话从未被持久化（或缓存已被删除）。此时通道将保持空数组，页面显示空白。
+
+---
+
+## 写时机（Write）
+
+### 1. 轮次完成时（`done` 事件）
+
+**位置**: [useChat.ts:299-336](web/src/composables/useChat.ts#L299-L336)
+
+WebSocket 接收到 `done` 事件后，将 `ch.currentTurn` 移入 `ch.turns` 并持久化：
+
+- **非 `becameAnswer` 分支**: 立即执行 `persistTurns(sid)`（同步）
+- **`becameAnswer` 分支**: 延迟 ~420ms 后执行 `persistTurns(sid)`（`nextTick` + `setTimeout(420)`）
+
+```typescript
+function persistTurns(sid: string) {
+  const snapshot = [...ch.turns]
+  turnsCache.set(sid, snapshot)           // 更新内存缓存
+  saveTurnsToStorage(sid, snapshot)       // 写入 localStorage
+}
+```
+
+### 2. 会话切换时
+
+**位置**: [useChat.ts:397-399](web/src/composables/useChat.ts#L397-L399)
+
+watch 中切换会话前，先持久化旧会话：
+```typescript
+if (oldId) persistTurns(oldId)
+```
+
+### 3. 子 Agent 切回主会话时
+
+**位置**: [useChat.ts:333-335](web/src/composables/useChat.ts#L333-L335)
+
+子 Agent 完成后 500ms 自动切回主会话，触发步骤 2 的持久化。
+
+### 写入函数
+
+**位置**: [useChat.ts:34-51](web/src/composables/useChat.ts#L34-L51) `saveTurnsToStorage()`
+
+```typescript
+function saveTurnsToStorage(sid: string, data: ChatTurn[]) {
+  const serialized = JSON.stringify(data)
+  localStorage.setItem(TURNS_KEY_PREFIX + sid, serialized)
+}
+```
+
+> **注意**: `JSON.stringify` 异常或 `localStorage` 配额超限会导致写入失败。新版已添加错误日志。
+
+---
+
+## 删时机（Delete）
+
+### 1. 用户删除会话
+
+**位置**: [useSession.ts:70-85](web/src/composables/useSession.ts#L70-L85) `deleteSession()`
+
+```typescript
+async function deleteSession(id: string) {
+  await api.deleteSession(id)
+  disconnectSession(id)
+  removeTurnsFromStorage(id)      // 删除 localStorage 条目
+  // ...
+}
+```
+
+### 2. 孤儿缓存清理
+
+**位置**: [useSession.ts:92-114](web/src/composables/useSession.ts#L92-L114) `cleanupOrphanedCaches()`
+
+在 `initIfNeeded()` 获取后端会话列表后执行。删除所有 `sonetto_turns_*` 中后端已不存在的会话缓存。
+
+### 删除函数
+
+**位置**: [useChat.ts:53-55](web/src/composables/useChat.ts#L53-L55) `removeTurnsFromStorage()`
+
+```typescript
+export function removeTurnsFromStorage(sid: string) {
+  localStorage.removeItem(TURNS_KEY_PREFIX + sid)
+}
+```
+
+---
+
+## 时序图
+
+```
+页面加载
+  │
+  ├─ useChat 模块加载
+  │     └─ turnsCache = loadAllTurnsFromStorage()    ← 读所有 localStorage
+  │
+  ├─ useSession().initIfNeeded()
+  │     ├─ localStorage.getItem('sonetto_session_id') ← 读存储的 sessionId
+  │     ├─ api.getSession(stored)                     ← 验证后端存在
+  │     └─ sessionId.value = stored
+  │
+  ├─ watch(sessionId) fires (immediate)
+  │     ├─ persistTurns(oldId)                        ← 写旧会话缓存
+  │     ├─ ensureConnected(newId)
+  │     ├─ turnsCache.get(newId)                      ← 读内存缓存
+  │     └─ ch.turns.push(...cached)                   ← 恢复通道
+  │
+  └─ cleanupOrphanedCaches()                          ← 删孤儿缓存
+
+对话中
+  │
+  ├─ 用户发送消息
+  │     └─ send() → WebSocket
+  │
+  └─ 服务端推送 done 事件
+        ├─ ch.turns.push(turn)
+        └─ persistTurns(sid)                          ← 写 localStorage
+
+切换会话 / 删除会话
+  │
+  ├─ switchSession(id)
+  │     ├─ watch 触发
+  │     │   ├─ persistTurns(oldId)                    ← 写旧会话缓存
+  │     │   └─ 恢复新会话的缓存                        ← 读缓存
+  │     └─ localStorage.setItem('sonetto_session_id') ← 写 sessionId
+  │
+  └─ deleteSession(id)
+        └─ removeTurnsFromStorage(id)                  ← 删 localStorage 条目
+```
+
+---
+
+## 关键文件
+
+| 文件 | 职责 |
+|------|------|
+| [web/src/composables/useChat.ts](web/src/composables/useChat.ts) | 缓存读写函数、WebSocket 事件处理、watch 恢复逻辑、`turnsCache` 内存缓存 |
+| [web/src/composables/useSession.ts](web/src/composables/useSession.ts) | 会话 CRUD、`initIfNeeded` 初始化、孤儿缓存清理 |
+
+## 关键函数
+
+| 函数 | 位置 | 触发时机 |
+|------|------|----------|
+| `loadAllTurnsFromStorage()` | [useChat.ts:8](web/src/composables/useChat.ts#L8) | 模块加载时 |
+| `saveTurnsToStorage()` | [useChat.ts:34](web/src/composables/useChat.ts#L34) | 轮次完成、会话切换 |
+| `persistTurns()` | [useChat.ts:122](web/src/composables/useChat.ts#L122) | 更新内存缓存 + 调用 `saveTurnsToStorage` |
+| `removeTurnsFromStorage()` | [useChat.ts:53](web/src/composables/useChat.ts#L53) | 删除会话 |
+| `cleanupOrphanedCaches()` | [useSession.ts:92](web/src/composables/useSession.ts#L92) | 页面初始化完成时 |

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -2,30 +2,52 @@ import { reactive, computed, watch, nextTick, type Ref } from 'vue'
 import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, AskUserEvent } from '@/types'
 import { refreshSessions, switchSession } from '@/composables/useSession'
 
-const TURNS_KEY_PREFIX = 'sonetto_turns_'
+export const TURNS_KEY_PREFIX = 'sonetto_turns_'
 
 // 从 localStorage 恢复所有会话的消息缓存（页面刷新后仍保留）
 function loadAllTurnsFromStorage(): Map<string, ChatTurn[]> {
   const map = new Map<string, ChatTurn[]>()
+  const keysFound: string[] = []
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i)
     if (key && key.startsWith(TURNS_KEY_PREFIX)) {
+      keysFound.push(key)
       const sid = key.slice(TURNS_KEY_PREFIX.length)
       try {
-        const data = JSON.parse(localStorage.getItem(key) || '[]')
+        const raw = localStorage.getItem(key) || '[]'
+        const data = JSON.parse(raw)
         if (Array.isArray(data)) {
+          console.log(`[useChat:load] 从 localStorage 加载会话 ${sid}: ${data.length} 条 turn, 序列化长度 ${raw.length}`)
           map.set(sid, data)
+        } else {
+          console.warn(`[useChat:load] 键 ${key} 的数据不是数组，跳过`)
         }
-      } catch { /* 忽略解析错误 */ }
+      } catch (e) {
+        console.error(`[useChat:load] 解析 localStorage 键 ${key} 失败:`, e)
+      }
     }
   }
+  console.log(`[useChat:load] localStorage 中共 ${keysFound.length} 个 ${TURNS_KEY_PREFIX}* 键, 恢复 ${map.size} 个会话的缓存`)
   return map
 }
 
 function saveTurnsToStorage(sid: string, data: ChatTurn[]) {
+  const key = TURNS_KEY_PREFIX + sid
   try {
-    localStorage.setItem(TURNS_KEY_PREFIX + sid, JSON.stringify(data))
-  } catch { /* storage 满时静默失败 */ }
+    const serialized = JSON.stringify(data)
+    const size = new Blob([serialized]).size
+    console.log(`[useChat:save] 保存会话 ${sid} 到 localStorage: ${data.length} 条 turn, 约 ${(size / 1024).toFixed(1)} KB, key=${key}`)
+    localStorage.setItem(key, serialized)
+  } catch (e) {
+    console.error(`[useChat:save] 保存会话 ${sid} 到 localStorage 失败 (key=${key}):`, e)
+    // 尝试估算 localStorage 用量
+    let total = 0
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i)
+      if (k) total += k.length + (localStorage.getItem(k) || '').length
+    }
+    console.warn(`[useChat:save] localStorage 当前总估算用量: ${(total * 2 / 1024).toFixed(1)} KB`)
+  }
 }
 
 export function removeTurnsFromStorage(sid: string) {
@@ -78,6 +100,7 @@ export const allSessionStatuses = computed(() => {
 
 function getOrCreateChannel(sid: string): SessionChannel {
   if (!channels.has(sid)) {
+    console.log(`[useChat:channel] 创建新通道 sid="${sid}"`)
     channels.set(sid, {
       ws: null,
       connected: false,
@@ -98,8 +121,12 @@ function getOrCreateChannel(sid: string): SessionChannel {
 
 function persistTurns(sid: string) {
   const ch = channels.get(sid)
-  if (!ch) return
+  if (!ch) {
+    console.warn(`[useChat:persist] 跳过保存 sid="${sid}": 通道不存在`)
+    return
+  }
   const snapshot = [...ch.turns]
+  console.log(`[useChat:persist] 持久化会话 ${sid}: ${snapshot.length} 条 turn`)
   turnsCache.set(sid, snapshot)
   saveTurnsToStorage(sid, snapshot)
 }
@@ -142,9 +169,16 @@ function connectSession(sid: string) {
 }
 
 export function ensureConnected(sid: string) {
-  if (!sid) return
+  if (!sid) {
+    console.warn(`[useChat:ensureConnected] 跳过空 sid`)
+    return
+  }
   const ch = getOrCreateChannel(sid)
-  if (ch.initialized) return
+  if (ch.initialized) {
+    console.log(`[useChat:ensureConnected] 会话 ${sid} 已初始化, 跳过`)
+    return
+  }
+  console.log(`[useChat:ensureConnected] 初始化会话 ${sid} 的 WebSocket 连接`)
   ch.initialized = true
   connectSession(sid)
 }
@@ -270,10 +304,13 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
       }
       if (ch.currentTurn) {
         const lastThink = findLastThinking(ch.currentTurn.events)
-        if (lastThink?.becameAnswer) {
+        const trackBecame = lastThink?.becameAnswer
+        console.log(`[useChat:done] 会话 ${sid}: becameAnswer=${trackBecame}, events=${ch.currentTurn.events.length}, finalAnswer=${ch.currentTurn.finalAnswer?.slice(0, 50) ?? 'null'}`)
+        if (trackBecame) {
           const turnToFinalize = ch.currentTurn
           void nextTick(() => {
             setTimeout(() => {
+              console.log(`[useChat:done] becameAnswer 分支执行 persist (会话 ${sid})`)
               ch.turns.push(turnToFinalize)
               ch.currentTurn = null
               ch.isStreaming = false
@@ -281,6 +318,7 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
             }, 420)
           })
         } else {
+          console.log(`[useChat:done] 直接分支执行 persist (会话 ${sid})`)
           ch.turns.push(ch.currentTurn)
           ch.currentTurn = null
           ch.isStreaming = false
@@ -288,6 +326,7 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
         }
         void refreshSessions()  // 轮次结束，刷新会话列表以更新 message_count
       } else {
+        console.warn(`[useChat:done] 会话 ${sid} 的 done 事件到达时 currentTurn 为 null`)
         ch.isStreaming = false
       }
       // 子 Agent 完成 → 自动切回主会话
@@ -354,13 +393,29 @@ export function useChat(sessionId: Ref<string>) {
   watch(
     sessionId,
     (newId, oldId) => {
-      if (oldId) persistTurns(oldId)
+      console.log(`[useChat:watch] sessionId 变化: "${oldId}" → "${newId}"`)
+      if (oldId) {
+        console.log(`[useChat:watch] 在切换前持久化旧会话 "${oldId}"`)
+        persistTurns(oldId)
+      }
       ensureConnected(newId)
       // 恢复新会话的消息缓存（页面刷新场景）
       const cached = turnsCache.get(newId)
       const ch = getOrCreateChannel(newId)
-      if (cached && ch.turns.length === 0) {
-        ch.turns.push(...cached)
+      if (cached) {
+        console.log(`[useChat:watch] 找到会话 ${newId} 的缓存: ${cached.length} 条 turn, 通道已有 ${ch.turns.length} 条`)
+        if (ch.turns.length === 0) {
+          console.log(`[useChat:watch] 恢复缓存: 将 ${cached.length} 条 turn 推入通道`)
+          ch.turns.push(...cached)
+          console.log(`[useChat:watch] 恢复后通道 turns.length = ${ch.turns.length}`)
+        } else {
+          console.log(`[useChat:watch] 跳过恢复: 通道已有数据`)
+        }
+      } else {
+        console.log(`[useChat:watch] 未找到会话 ${newId} 的缓存, sessionId="${sessionId.value}"`)
+        // 调试：列出 turnsCache 中所有可用的 key
+        const available = Array.from(turnsCache.keys())
+        console.log(`[useChat:watch] turnsCache 可用键:`, available.length ? available : '(空)')
       }
     },
     { immediate: true }
@@ -368,7 +423,11 @@ export function useChat(sessionId: Ref<string>) {
 
   function send(message: string) {
     const ch = activeChannel.value
-    if (!ch.ws || ch.ws.readyState !== WebSocket.OPEN) return
+    if (!ch.ws || ch.ws.readyState !== WebSocket.OPEN) {
+      console.warn(`[useChat:send] WebSocket 未就绪, readyState=${ch.ws?.readyState}, session=${sessionId.value}`)
+      return
+    }
+    console.log(`[useChat:send] 发送消息 (session=${sessionId.value}): "${message.slice(0, 80)}..."`)
     ch.isStreaming = true
     ch.error = null
 

--- a/web/src/composables/useSession.ts
+++ b/web/src/composables/useSession.ts
@@ -1,6 +1,6 @@
 import { ref } from 'vue'
 import { api } from '@/api'
-import { removeTurnsFromStorage, disconnectSession } from '@/composables/useChat'
+import { removeTurnsFromStorage, disconnectSession, TURNS_KEY_PREFIX } from '@/composables/useChat'
 import type { SessionInfo } from '@/types'
 
 const STORAGE_KEY = 'sonetto_session_id'
@@ -11,28 +11,39 @@ const sessions = ref<SessionInfo[]>([])
 let _initialized = false
 
 async function initIfNeeded() {
-  if (_initialized) return
+  if (_initialized) {
+    console.log('[useSession:init] 已初始化, 跳过')
+    return
+  }
   _initialized = true
 
   const stored = localStorage.getItem(STORAGE_KEY)
+  console.log(`[useSession:init] 从 localStorage 读取 stored="${stored}"`)
   if (stored) {
     try {
       await api.getSession(stored)
       sessionId.value = stored
-    } catch {
+      console.log(`[useSession:init] 恢复已有会话: "${stored}"`)
+    } catch (e) {
+      console.warn(`[useSession:init] 会话 "${stored}" 不存在于后端, 创建新会话:`, e)
       await _createSession()
     }
   } else {
+    console.log('[useSession:init] localStorage 中无会话记录, 创建新会话')
     await _createSession()
   }
   await refreshSessions()
+  cleanupOrphanedCaches()
+  console.log(`[useSession:init] 完成, sessionId="${sessionId.value}", 共 ${sessions.value.length} 个会话`)
 }
 
 export async function refreshSessions() {
   try {
     const res = await api.listSessions()
     sessions.value = res.sessions
-  } catch {
+    console.log(`[useSession:refresh] 获取到 ${res.sessions.length} 个会话`)
+  } catch (e) {
+    console.warn('[useSession:refresh] 获取会话列表失败:', e)
     sessions.value = []
   }
 }
@@ -41,19 +52,23 @@ async function _createSession() {
   const res = await api.createSession()
   sessionId.value = res.session_id
   localStorage.setItem(STORAGE_KEY, res.session_id)
+  console.log(`[useSession:create] 创建新会话: "${res.session_id}"`)
 }
 
 async function createSession() {
+  console.log('[useSession] createSession() 被调用')
   await _createSession()
   await refreshSessions()
 }
 
 export async function switchSession(id: string) {
+  console.log(`[useSession] switchSession("${id}") 被调用`)
   sessionId.value = id
   localStorage.setItem(STORAGE_KEY, id)
 }
 
 async function deleteSession(id: string) {
+  console.log(`[useSession] deleteSession("${id}") 被调用`)
   await api.deleteSession(id)
   disconnectSession(id)
   removeTurnsFromStorage(id)
@@ -72,4 +87,28 @@ async function deleteSession(id: string) {
 export function useSession() {
   initIfNeeded()
   return { sessionId, sessions, createSession, switchSession, deleteSession, refreshSessions }
+}
+
+/** 清理后端已不存在的会话的 localStorage 孤儿缓存 */
+function cleanupOrphanedCaches() {
+  const validIds = new Set(sessions.value.map(s => s.session_id))
+  let removed = 0
+  let totalSize = 0
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key && key.startsWith(TURNS_KEY_PREFIX)) {
+      const sid = key.slice(TURNS_KEY_PREFIX.length)
+      if (!sid || validIds.has(sid)) continue
+      const raw = localStorage.getItem(key)
+      localStorage.removeItem(key)
+      removed++
+      totalSize += (raw ? raw.length : 0) + key.length
+      console.log(`[useSession:cleanup] 删除孤儿缓存 会话=${sid}, key=${key}`)
+    }
+  }
+  if (removed > 0) {
+    console.log(`[useSession:cleanup] 共清理 ${removed} 个孤儿缓存, 释放约 ${(totalSize * 2 / 1024).toFixed(1)} KB`)
+  } else {
+    console.log('[useSession:cleanup] 无孤儿缓存需清理')
+  }
 }


### PR DESCRIPTION
## Summary

- 为 useChat/useSession 添加 localStorage 持久化/恢复全链路的调试日志
- 导出 `TURNS_KEY_PREFIX` 供清理逻辑使用
- 新增 `cleanupOrphanedCaches()` 在页面初始化后自动删除后端已不存在的会话缓存
- 添加 `dev_docs/session-cache.md` 文档描述缓存机制

## Background

用户反馈页面刷新后历史记录消失。通过调试日志发现 localStorage 中有 295 个孤儿缓存条目占满配额，导致当前会话的缓存写入静默失败。

## Test plan

- [ ] 刷新页面，确认控制台输出 `[useChat:load]` 加载日志和 `[useSession:cleanup]` 清理日志
- [ ] 发送消息后确认控制台输出 `[useChat:done]` 和 `[useChat:save]` 日志
- [ ] 确认旧会话（后端已删除）的缓存被自动清理