### PR TITLE
feat(ui): 将私密模式从 CLI 移植到网页端

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -76,6 +76,7 @@ async def _run_agent_turn(
     ws: WebSocket,
     session: SessionState,
     user_message: str,
+    private_mode: bool = False,
 ):
     """
     在指定的session中编排一轮 Agent 对话。
@@ -147,10 +148,11 @@ async def _run_agent_turn(
     # 3. [后处理] 增加消息计数器，将对话记录入长期记忆
     if final_answer:
         session.message_count += 2
-    await app_state.ltm.send_history([
-        {"role": "user", "content": user_message},
-        {"role": "assistant", "content": final_answer},
-    ])
+    if not private_mode:
+        await app_state.ltm.send_history([
+            {"role": "user", "content": user_message},
+            {"role": "assistant", "content": final_answer},
+        ])
 
     # 4. [Sub-agent] 如果有待处理的 pending_result，resolve 它
     if session._pending_result is not None and not session._pending_result.done():
@@ -207,7 +209,7 @@ async def websocket_chat(ws: WebSocket, session_id: str):
             session._sub_agent_task = None  # 消费掉，防止重连后重复启动
             interaction.current_ws.set(ws)
             agent_task = asyncio.create_task(
-                _run_agent_turn(ws, session, task)
+                _run_agent_turn(ws, session, task, private_mode=False)
             )
             session._active_task = agent_task
             print(f"[ws:{session_id[:8]}] sub-agent task created", file=sys.stderr)
@@ -230,11 +232,13 @@ async def websocket_chat(ws: WebSocket, session_id: str):
                     if not user_message:
                         continue
 
+                    private_mode = msg["payload"].get("private", False)
+
                     # 设置当前连接的上下文变量，供工具函数使用
                     interaction.current_ws.set(ws)
 
                     agent_task = asyncio.create_task(
-                        _run_agent_turn(ws, session, user_message)
+                        _run_agent_turn(ws, session, user_message, private_mode)
                     )
                     session._active_task = agent_task  # 立即写入，消除竞争窗口 会话状态 供外部读取 典型用法为绿色黄色呼吸灯
 

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -85,6 +85,7 @@ interface SessionChannel {
   initialized: boolean
   _awaitingToolName: string | null
   parentSessionId: string | null  // sub-agent 用：完成时切回主会话
+  privateMode: boolean
 }
 
 const channels = reactive(new Map<string, SessionChannel>())
@@ -114,6 +115,7 @@ function getOrCreateChannel(sid: string): SessionChannel {
       initialized: false,
       _awaitingToolName: null,
       parentSessionId: null,
+      privateMode: false,
     })
   }
   return channels.get(sid)!
@@ -314,7 +316,9 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
               ch.turns.push(turnToFinalize)
               ch.currentTurn = null
               ch.isStreaming = false
-              persistTurns(sid)
+              if (!ch.privateMode) {
+                persistTurns(sid)
+              }
             }, 420)
           })
         } else {
@@ -322,7 +326,9 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
           ch.turns.push(ch.currentTurn)
           ch.currentTurn = null
           ch.isStreaming = false
-          persistTurns(sid)
+          if (!ch.privateMode) {
+            persistTurns(sid)
+          }
         }
         void refreshSessions()  // 轮次结束，刷新会话列表以更新 message_count
       } else {
@@ -389,6 +395,12 @@ export function useChat(sessionId: Ref<string>) {
   const error = computed(() => activeChannel.value.error)
   const contextUsage = computed(() => activeChannel.value.contextUsage)
 
+  const privateMode = computed(() => activeChannel.value.privateMode)
+
+  function setPrivateMode(val: boolean) {
+    activeChannel.value.privateMode = val
+  }
+
   // Session 切换：只确保新 Session 的 WS 连接，不断开旧的
   watch(
     sessionId,
@@ -439,7 +451,7 @@ export function useChat(sessionId: Ref<string>) {
     }
     ch.currentTurn = turn
 
-    const payload: ClientMessage = { type: 'chat', payload: { message } }
+    const payload: ClientMessage = { type: 'chat', payload: { message, private: ch.privateMode } }
     ch.ws.send(JSON.stringify(payload))
   }
 
@@ -463,8 +475,11 @@ export function useChat(sessionId: Ref<string>) {
   return {
     connected, isStreaming, turns, currentTurn, error, contextUsage,
     send, cancel, sendUserResponse,
+    privateMode, setPrivateMode,
   }
 }
+
+
 
 function findLastThinking(events: TurnEvent[]): ThinkingBlock | undefined {
   for (let i = events.length - 1; i >= 0; i--) {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -97,7 +97,7 @@ export type ServerEvent =
 
 export interface ChatMessage {
   type: 'chat'
-  payload: { message: string }
+  payload: { message: string; private?: boolean }
 }
 
 export interface CancelMessage {

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -2,6 +2,15 @@
   <div class="chat-view">
     <header class="chat-header">
       <StatusBadge :connected="connected" :health="health" />
+      <button
+        class="private-toggle"
+        :class="{ active: privateMode }"
+        @click="setPrivateMode(!privateMode)"
+        :title="privateMode ? '关闭私密模式' : '开启私密模式'"
+      >
+        <span class="private-indicator"></span>
+        私密
+      </button>
       <ContextUsageBadge :usage="contextUsage" />
     </header>
 
@@ -40,7 +49,7 @@ import ChatWindow from '@/components/ChatWindow.vue'
 import ChatInput from '@/components/ChatInput.vue'
 
 const { sessionId, sessions } = useSession()
-const { connected, isStreaming, turns, currentTurn, error, contextUsage, send, cancel, sendUserResponse } =
+const { connected, isStreaming, turns, currentTurn, error, contextUsage, send, cancel, sendUserResponse, privateMode, setPrivateMode } =
   useChat(sessionId)
 
 const isSubagent = computed(() => {
@@ -86,6 +95,34 @@ function handleToolAction(payload: { action: string; data?: unknown }) {
   padding: 12px 24px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-card);
+}
+.private-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+  user-select: none;
+}
+.private-toggle:hover {
+  border-color: var(--text-secondary);
+}
+.private-toggle.active {
+  border-color: var(--status-warn);
+  background: color-mix(in srgb, var(--status-warn) 10%, transparent);
+  color: var(--status-warn);
+}
+.private-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
 }
 .sub-agent-readonly-bar {
   display: flex;

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -2,15 +2,28 @@
   <div class="chat-view">
     <header class="chat-header">
       <StatusBadge :connected="connected" :health="health" />
-      <button
-        class="private-toggle"
-        :class="{ active: privateMode }"
-        @click="setPrivateMode(!privateMode)"
-        :title="privateMode ? '关闭私密模式' : '开启私密模式'"
-      >
-        <span class="private-indicator"></span>
-        私密
-      </button>
+      <span class="private-trigger hover-trigger">
+        <button
+          class="private-toggle"
+          :class="{ active: privateMode }"
+          @click="setPrivateMode(!privateMode)"
+        >
+          <span class="private-indicator"></span>
+          私密
+        </button>
+        <div class="hover-card card-private">
+          <div class="card-row">
+            <span class="card-label">私密模式</span>
+            <span class="card-value" :class="privateMode ? 'status-on' : 'status-off'">
+              {{ privateMode ? '已开启' : '已关闭' }}
+            </span>
+          </div>
+          <div class="card-divider"></div>
+          <div class="private-desc">
+            开启后，当前对话不会被保存到长期记忆和本地存储，关闭后恢复正常保存。
+          </div>
+        </div>
+      </span>
       <ContextUsageBadge :usage="contextUsage" />
     </header>
 
@@ -123,6 +136,68 @@ function handleToolAction(payload: { action: string; data?: unknown }) {
   height: 8px;
   border-radius: 50%;
   background: currentColor;
+}
+.private-trigger {
+  position: relative;
+}
+.hover-card {
+  visibility: hidden;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: visibility 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 100;
+  min-width: 240px;
+  padding: 8px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 12px;
+  line-height: 1.6;
+}
+.private-trigger:hover .hover-card {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+}
+.private-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  white-space: normal;
+  max-width: 240px;
+}
+.status-on {
+  color: var(--status-warn);
+}
+.status-off {
+  color: var(--text-secondary);
+}
+.card-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+.card-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+}
+.card-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.card-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
 }
 .sub-agent-readonly-bar {
   display: flex;


### PR DESCRIPTION
## Summary

- Chat header 新增「私密」切换按钮，开启后显示黄色高亮
- 私密模式下的对话不保存到后端长期记忆（`ltm.send_history` 跳过）
- 私密模式下的对话不写入前端 localStorage
- 按钮悬停弹窗展示开启/关闭状态及功能描述，风格与 StatusBadge 一致

## Changes

| 文件 | 改动 |
|---|---|
| `web/src/types/index.ts` | `ChatMessage.payload` 新增 `private?: boolean` |
| `web/src/composables/useChat.ts` | SessionChannel 新增 `privateMode`；`send()` 附带标志；`done` 条件性跳过 `persistTurns()` |
| `web/src/views/ChatView.vue` | Header 新增私密模式按钮 + 悬停弹窗 |
| `api/routes/chat.py` | 接收 `private` 标志，条件性跳过 `ltm.send_history()` |