### PR TITLE
feat(ui): 可折叠侧栏 — 双击/单击空白处切换，窄屏自动折叠

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="app-layout">
-    <aside class="sidebar">
+    <aside class="sidebar" :class="{ collapsed: effectiveCollapsed }">
       <div class="sidebar-header">
         <h1 class="logo">SonettoHere</h1>
       </div>
       <nav class="sidebar-nav">
         <router-link to="/" class="nav-item">
-          <Icon name="chat" :size="18" /> 对话&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CHATING
+          <Icon name="chat" :size="18" /> <span class="nav-label">对话&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CHATING</span>
         </router-link>
         <router-link to="/memory" class="nav-item">
-          <Icon name="memory" :size="18" /> 记忆&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MEMORY
+          <Icon name="memory" :size="18" /> <span class="nav-label">记忆&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MEMORY</span>
         </router-link>
         <router-link to="/playground" class="nav-item pg-nav">Playground</router-link>
       </nav>
@@ -17,12 +17,16 @@
         :sessions="sessions"
         :active-id="sessionId"
         :session-statuses="allSessionStatuses"
+        :collapsed="effectiveCollapsed"
         @create="createSession"
         @switch="switchSession"
         @delete="deleteSession"
       />
       <HealthPanel :health="health!" v-if="health" />
     </aside>
+    <button class="collapse-btn" :class="{ collapsed: effectiveCollapsed }" @click="toggleSidebar" :title="effectiveCollapsed ? '展开侧栏' : '折叠侧栏'">
+      <span class="collapse-icon">{{ effectiveCollapsed ? '▶' : '◀' }}</span>
+    </button>
     <main class="main">
       <router-view />
     </main>
@@ -36,7 +40,10 @@ import SessionSidebar from '@/components/SessionSidebar.vue';
 import { allSessionStatuses } from '@/composables/useChat';
 import { health, startPolling, useHealth } from '@/composables/useHealth';
 import { useSession } from '@/composables/useSession';
-import { onMounted } from 'vue';
+import { onMounted } from 'vue'
+import { useSidebar } from '@/composables/useSidebar';
+
+const { effectiveCollapsed, toggleSidebar } = useSidebar()
 
 const { sessionId, sessions, createSession, switchSession, deleteSession } =
   useSession()
@@ -188,6 +195,72 @@ html, body {
   display: flex;
   flex-direction: column;
   min-width: 0;
+}
+
+/* ── Collapsible sidebar ── */
+.sidebar {
+  position: relative;
+  transition: width 0.25s ease, min-width 0.25s ease, padding 0.25s ease;
+}
+.sidebar.collapsed {
+  width: 58px;
+  min-width: 58px;
+  padding: 24px 10px;
+  align-items: center;
+}
+.sidebar.collapsed .sidebar-header {
+  display: none;
+}
+.sidebar.collapsed .sidebar-nav {
+  width: 100%;
+  align-items: center;
+}
+.sidebar.collapsed .nav-item {
+  justify-content: center;
+  padding: 8px;
+  gap: 0;
+  width: 100%;
+}
+.sidebar.collapsed .nav-label {
+  display: none;
+}
+.sidebar.collapsed .pg-nav {
+  display: none;
+}
+.sidebar.collapsed .health-panel {
+  display: none;
+}
+
+.collapse-btn {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 50;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--bg-card);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  left: 206px;
+  transition: left 0.25s ease, background 0.15s, box-shadow 0.15s;
+}
+.collapse-btn:hover {
+  background: var(--bg-secondary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+.collapse-btn.collapsed {
+  left: 44px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+.collapse-icon {
+  font-size: 10px;
+  color: var(--text-secondary);
+  line-height: 1;
 }
 
 /* ── Shared markdown rendered content ── */

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="app-layout">
-    <aside class="sidebar" :class="{ collapsed: effectiveCollapsed }">
+    <aside class="sidebar" :class="{ collapsed: effectiveCollapsed }" @click="onSidebarClick">
       <div class="sidebar-header">
         <h1 class="logo">SonettoHere</h1>
       </div>
@@ -24,9 +24,6 @@
       />
       <HealthPanel :health="health!" v-if="health" />
     </aside>
-    <button class="collapse-btn" :class="{ collapsed: effectiveCollapsed }" @click="toggleSidebar" :title="effectiveCollapsed ? '展开侧栏' : '折叠侧栏'">
-      <span class="collapse-icon">{{ effectiveCollapsed ? '▶' : '◀' }}</span>
-    </button>
     <main class="main">
       <router-view />
     </main>
@@ -44,6 +41,12 @@ import { onMounted } from 'vue'
 import { useSidebar } from '@/composables/useSidebar';
 
 const { effectiveCollapsed, toggleSidebar } = useSidebar()
+
+function onSidebarClick(e: MouseEvent) {
+  if (e.target === e.currentTarget) {
+    toggleSidebar()
+  }
+}
 
 const { sessionId, sessions, createSession, switchSession, deleteSession } =
   useSession()
@@ -262,38 +265,6 @@ html, body {
   overflow: hidden;
   padding: 0;
   margin: 0;
-}
-
-.collapse-btn {
-  position: fixed;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 50;
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--border);
-  border-radius: 50%;
-  background: var(--bg-card);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  left: 206px;
-  transition: left 0.25s ease, background 0.15s, box-shadow 0.15s;
-}
-.collapse-btn:hover {
-  background: var(--bg-secondary);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-.collapse-btn.collapsed {
-  left: 44px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-.collapse-icon {
-  font-size: 10px;
-  color: var(--text-secondary);
-  line-height: 1;
 }
 
 /* ── Shared markdown rendered content ── */

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -138,6 +138,9 @@ html, body {
 .sidebar-header {
   display: flex;
   justify-content: center;
+  transition: max-height 0.25s ease, opacity 0.2s ease 0.05s, transform 0.25s ease 0.05s, padding 0.25s ease, margin 0.25s ease;
+  overflow: hidden;
+  max-height: 100px;
 }
 
 .logo {
@@ -176,6 +179,13 @@ html, body {
   font-weight: 600;
 }
 
+.nav-label {
+  transition: max-width 0.25s ease, opacity 0.2s ease 0.05s, transform 0.25s ease 0.05s, padding 0.25s ease, margin 0.25s ease;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
 .pg-nav {
   margin-top: 16px;
   border-top: 1px solid var(--border);
@@ -197,6 +207,12 @@ html, body {
   min-width: 0;
 }
 
+.sidebar .health-panel {
+  transition: max-height 0.25s ease, opacity 0.2s ease 0.05s, padding 0.25s ease, margin 0.25s ease;
+  overflow: hidden;
+  max-height: 300px;
+}
+
 /* ── Collapsible sidebar ── */
 .sidebar {
   position: relative;
@@ -207,9 +223,15 @@ html, body {
   min-width: 58px;
   padding: 24px 10px;
   align-items: center;
+  overflow: hidden;
 }
 .sidebar.collapsed .sidebar-header {
-  display: none;
+  max-height: 0;
+  opacity: 0;
+  transform: translateX(-30px);
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
 }
 .sidebar.collapsed .sidebar-nav {
   width: 100%;
@@ -220,15 +242,26 @@ html, body {
   padding: 8px;
   gap: 0;
   width: 100%;
+  overflow: hidden;
 }
 .sidebar.collapsed .nav-label {
-  display: none;
+  max-width: 0;
+  opacity: 0;
+  transform: translateX(-24px);
+  overflow: hidden;
+  white-space: nowrap;
+  padding: 0;
+  margin: 0;
 }
 .sidebar.collapsed .pg-nav {
   display: none;
 }
 .sidebar.collapsed .health-panel {
-  display: none;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
 }
 
 .collapse-btn {

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -194,6 +194,13 @@ const cardStyle = computed(() => {
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
+.sidebar-section-header span {
+  transition: max-width 0.25s ease, opacity 0.2s ease 0.05s, transform 0.25s ease 0.05s, padding 0.25s ease, margin 0.25s ease;
+  overflow: hidden;
+  white-space: nowrap;
+  display: inline-block;
+  max-width: 200px;
+}
 .btn-new {
   width: 24px;
   height: 24px;
@@ -244,6 +251,9 @@ const cardStyle = computed(() => {
   flex-direction: column;
   gap: 2px;
   min-width: 0;
+  transition: max-height 0.25s ease, opacity 0.2s ease 0.05s, transform 0.25s ease 0.05s, padding 0.25s ease, margin 0.25s ease;
+  overflow: hidden;
+  max-height: 80px;
 }
 .session-id {
   font-size: 13px;
@@ -276,7 +286,9 @@ const cardStyle = computed(() => {
   font-size: 16px;
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.15s, color 0.15s;
+  transition: max-width 0.25s ease, opacity 0.15s ease 0.05s, transform 0.25s ease 0.05s, color 0.15s, padding 0.25s ease, margin 0.25s ease;
+  overflow: hidden;
+  max-width: 22px;
 }
 .session-item:hover .btn-delete {
   opacity: 1;
@@ -288,6 +300,9 @@ const cardStyle = computed(() => {
   font-size: 12px;
   color: var(--text-secondary);
   padding: 8px;
+  transition: max-height 0.25s ease, opacity 0.2s ease 0.05s, padding 0.25s ease, margin 0.25s ease;
+  overflow: hidden;
+  max-height: 40px;
 }
 
 .session-item-right {
@@ -370,19 +385,43 @@ const cardStyle = computed(() => {
   justify-content: center;
 }
 .session-sidebar.collapsed .sidebar-section-header span {
-  display: none;
+  max-width: 0;
+  opacity: 0;
+  transform: translateX(-24px);
+  overflow: hidden;
+  white-space: nowrap;
+  display: inline-block;
+  padding: 0;
+  margin: 0;
 }
 .session-sidebar.collapsed .session-item {
   justify-content: center;
   padding: 6px;
 }
 .session-sidebar.collapsed .session-item-main {
-  display: none;
+  max-height: 0;
+  max-width: 0;
+  min-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  transform: translateX(-24px);
+  padding: 0;
+  margin: 0;
 }
 .session-sidebar.collapsed .btn-delete {
-  display: none;
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  transform: translateX(-24px);
+  padding: 0;
+  margin: 0;
+  border: none;
 }
 .session-sidebar.collapsed .no-sessions {
-  display: none;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
 }
 </style>

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="session-sidebar">
+  <div class="session-sidebar" :class="{ collapsed }">
     <div class="sidebar-section-header">
       <span>会话列表</span>
       <button class="btn-new" @click="$emit('create')" title="新会话">+</button>
@@ -88,6 +88,7 @@ const props = defineProps<{
   sessions: SessionInfo[]
   activeId: string
   sessionStatuses?: Record<string, { connected: boolean; isStreaming: boolean; isAwaitingUser: boolean }>
+  collapsed?: boolean
 }>()
 
 defineEmits<{
@@ -362,5 +363,26 @@ const cardStyle = computed(() => {
 .card-leave-to {
   opacity: 0;
   transform: translateX(-8px);
+}
+
+/* ── Collapsed icon-only mode ── */
+.session-sidebar.collapsed .sidebar-section-header {
+  justify-content: center;
+}
+.session-sidebar.collapsed .sidebar-section-header span {
+  display: none;
+}
+.session-sidebar.collapsed .session-item {
+  justify-content: center;
+  padding: 6px;
+}
+.session-sidebar.collapsed .session-item-main {
+  display: none;
+}
+.session-sidebar.collapsed .btn-delete {
+  display: none;
+}
+.session-sidebar.collapsed .no-sessions {
+  display: none;
 }
 </style>

--- a/web/src/composables/useSidebar.ts
+++ b/web/src/composables/useSidebar.ts
@@ -1,0 +1,40 @@
+import { ref, computed, watch } from 'vue'
+
+const STORAGE_KEY = 'sonetto_sidebar_collapsed'
+
+// 模块级状态（所有 useSidebar 调用共享同一份）
+const userCollapsed = ref(false)
+const forcedCollapsed = ref(false)
+
+// 从 localStorage 恢复用户偏好
+try {
+  const saved = localStorage.getItem(STORAGE_KEY)
+  if (saved !== null) userCollapsed.value = saved === 'true'
+} catch { /* localStorage 不可用 */ }
+
+// matchMedia 监听窄屏自动折叠
+const mql = window.matchMedia('(max-width: 900px)')
+forcedCollapsed.value = mql.matches
+
+function onMqlChange(e: MediaQueryListEvent) {
+  forcedCollapsed.value = e.matches
+}
+mql.addEventListener('change', onMqlChange)
+
+// 持久化用户偏好
+watch(userCollapsed, (v) => {
+  try { localStorage.setItem(STORAGE_KEY, String(v)) } catch { /* noop */ }
+})
+
+const effectiveCollapsed = computed(() => userCollapsed.value || forcedCollapsed.value)
+
+export function useSidebar() {
+  function toggleSidebar() {
+    userCollapsed.value = !userCollapsed.value
+  }
+  function setUserCollapsed(v: boolean) {
+    userCollapsed.value = v
+  }
+
+  return { effectiveCollapsed, userCollapsed, toggleSidebar, setUserCollapsed }
+}


### PR DESCRIPTION
## Summary
- 侧栏折叠为 58px 图标模式，导航只显图标，会话列表只显状态圆点
- 单击侧栏空白处切换折叠/展开
- 窗口 < 900px 时自动折叠，不覆盖手动偏好
- 手动偏好持久化到 localStorage
- 展开时内容从左向右推入动画

## Test plan
- [ ] 单击侧栏空白处折叠/展开
- [ ] 拖窄窗口自动折叠，拉宽后恢复
- [ ] 刷新页面后偏好保持