### PR TITLE
chore: 调整子 Agent recursion_limit 为 72

### DIFF
--- a/skills/sub_agent/skill_call_sub_agent.py
+++ b/skills/sub_agent/skill_call_sub_agent.py
@@ -148,7 +148,7 @@ class CallSubAgentSkill(SkillBase):
             model=app_state.llm,
             tools=app_state.tools,
             system_prompt=system_prompt,
-            recursion_limit=30,
+            recursion_limit=72,
             checkpointer=sub.checkpointer,
         )
         inputs = {"messages": [HumanMessage(content=task)]}


### PR DESCRIPTION
## Summary

- 主模型 recursion_limit 原为 120，保持不变
- 子模型从 30 扩容至 72，使其在复杂工具调用场景下减少因达到迭代上限导致的中断