### PR TITLE
feat: 引入 Anthropic Skills 体系 — 目录、扫描注入、前端计数

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ config/personas/memory.yaml
 
 # Provider credentials (明文 API key)
 providers.yaml
+
+# Anthropic Skills
+anthropic_skills/

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,5 @@ config/personas/memory.yaml
 # Provider credentials (明文 API key)
 providers.yaml
 
-# Anthropic Skills
-anthropic_skills/
+# Anthropic Skills（忽略 skill 子目录，保留目录本身用于 .gitkeep）
+anthropic_skills/*/

--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -1,5 +1,6 @@
 """系统提示词组装。"""
 
+import re
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
@@ -8,6 +9,7 @@ from memory.narrative import get_narrative
 from memory.user_init import ensure_user_md
 
 PERSONAS_DIR = Path(__file__).resolve().parent.parent / "config" / "personas"
+ANTHROPIC_SKILLS_DIR = Path(__file__).resolve().parent.parent / "anthropic_skills"
 
 
 @lru_cache(maxsize=3)
@@ -24,6 +26,49 @@ def _read_if_exists(filename: str) -> str:
     if path.exists():
         return path.read_text(encoding="utf-8").strip()
     return ""
+
+
+def _parse_frontmatter(text: str) -> dict[str, str]:
+    """简易解析 YAML frontmatter，提取 name 和 description。"""
+    m = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        return {}
+    meta: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        if ":" in line:
+            key, _, val = line.partition(":")
+            key = key.strip()
+            val = val.strip().strip('"').strip("'")
+            if key in ("name", "description"):
+                meta[key] = val
+    return meta
+
+
+def _scan_anthropic_skills() -> str:
+    """扫描 anthropic_skills/ 下所有 SKILL.md，返回元数据清单。"""
+    if not ANTHROPIC_SKILLS_DIR.is_dir():
+        return ""
+    entries: list[str] = []
+    for sk_path in sorted(ANTHROPIC_SKILLS_DIR.rglob("SKILL.md")):
+        rel = sk_path.relative_to(ANTHROPIC_SKILLS_DIR).parent
+        meta = _parse_frontmatter(sk_path.read_text(encoding="utf-8"))
+        name = meta.get("name", rel.name)
+        desc = meta.get("description", "")
+        path_str = str(sk_path).replace("\\", "/")
+        if desc:
+            entries.append(f"- [{name}]({path_str}): {desc}")
+        else:
+            entries.append(f"- [{name}]({path_str})")
+    if not entries:
+        return ""
+    lines = [
+        "## 可用 Anthropic Skills",
+        "以下 skill 文件存放在 `anthropic_skills/` 目录中，包含完整的任务指令和流程。",
+        "当你需要执行符合上述描述的任务时，应使用文件读取工具按需读取对应 SKILL.md 的完整内容。",
+        "",
+        *entries,
+    ]
+    return "\n".join(lines)
 
 
 def build_system_prompt() -> str:
@@ -44,6 +89,8 @@ def build_system_prompt() -> str:
         get_narrative(),
         "",
         f"当前时间：{now}",
+        "",
+        _scan_anthropic_skills(),
     ]
     return "\n".join(parts)
 

--- a/api/health.py
+++ b/api/health.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from pathlib import Path
 from typing import Literal
 
 import httpx
@@ -11,6 +12,8 @@ from pydantic import BaseModel
 from config.settings import get_settings
 from memory.memory_manager import MemoryManager
 from memory.narrative import MEMORY_PATH
+
+ANTHROPIC_SKILLS_DIR = Path(__file__).resolve().parent.parent / "anthropic_skills"
 
 
 class ComponentHealth(BaseModel):
@@ -26,6 +29,7 @@ class HealthResponse(BaseModel):
     memory: ComponentHealth
     native_tools: ComponentHealth
     mcp_tools: ComponentHealth
+    anthropic_skills_count: int = 0
     providers: dict[str, ComponentHealth] = {}
     timestamp: float
 
@@ -178,6 +182,11 @@ async def get_health_report(app: FastAPI) -> HealthResponse:
     mcp_tools = await check_mcp_tools(app)
     providers = await check_health_providers(app)
 
+    # 统计 anthropic_skills 下的 skill 数量
+    skills_count = 0
+    if ANTHROPIC_SKILLS_DIR.is_dir():
+        skills_count = len([p for p in ANTHROPIC_SKILLS_DIR.iterdir() if p.is_dir()])
+
     all_checks = [llm, memory, native_tools, mcp_tools] + list(providers.values())
     overall: Literal["ok", "degraded"] = (
         "ok" if all(c.status == "ok" for c in all_checks) else "degraded"
@@ -190,6 +199,7 @@ async def get_health_report(app: FastAPI) -> HealthResponse:
         memory=memory,
         native_tools=native_tools,
         mcp_tools=mcp_tools,
+        anthropic_skills_count=skills_count,
         providers=providers,
         timestamp=time.time(),
     )

--- a/config/personas/AGENTS.md
+++ b/config/personas/AGENTS.md
@@ -16,6 +16,15 @@
 
 如果发现自己连续两轮调用了同一个工具且参数相同，说明已经陷入循环，必须立即停止并告知用户。
 
+## Anthropic Skills
+
+项目根目录的 `anthropic_skills/` 下存放了可复用的 skill 文件（格式参考 Claude Code Skill），每个子目录包含一份 `SKILL.md` 作为主文档。系统提示词中已列出所有可用 skill 的名称、描述和路径。
+
+当你遇到符合 skill 描述的任务时：
+1. 使用文件读取工具读取对应 `SKILL.md` 的完整内容
+2. 如有需要，继续读取 `agents/`、`references/`、`scripts/` 等子目录中的辅助文件
+3. 按 skill 中的指令执行任务
+
 ## 语气
 
 思考过程中保持人设规定的语气。

--- a/web/src/components/StatusBadge.vue
+++ b/web/src/components/StatusBadge.vue
@@ -43,12 +43,21 @@ const props = defineProps<{
 
 const items = computed(() => {
   if (!props.health) return []
-  return [
+  const result = [
     makeItem('LLM', props.health.llm),
     makeItem('MEMORY', props.health.memory),
     makeItem('SKILLS', props.health.native_tools),
     makeItem('MCP', props.health.mcp_tools),
   ]
+  if (props.health.anthropic_skills_count != null) {
+    result.push({
+      name: 'ANTHROPIC_SKILLS',
+      ok: true,
+      latency: '0 ms',
+      info: `${props.health.anthropic_skills_count} 个技能`,
+    })
+  }
+  return result
 })
 
 function makeItem(name: string, c: ComponentHealth) {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -247,6 +247,7 @@ export interface HealthResponse {
   memory: ComponentHealth
   native_tools: ComponentHealth
   mcp_tools: ComponentHealth
+  anthropic_skills_count: number
   timestamp: number
 }
 


### PR DESCRIPTION
## Summary

- 创建 `anthropic_skills/` 目录，用于存放可复用的 skill 文件
- `agent/prompts.py` 新增自动扫描机制，在构建系统提示词时提取所有 SKILL.md 的 name/description 元数据并注入
- `AGENTS.md` 新增 skill 使用指引，指导 agent 按需读取 skill 内容
- 后端健康 API 新增 `anthropic_skills_count` 字段
- 前端 StatusBadge 悬停菜单添加 ANTHROPIC_SKILLS 计数展示

## Test plan

- [ ] 启动前端，悬停"已连接"可见 ANTHROPIC_SKILLS 行及技能个数
- [ ] 向后端 `GET /api/health` 返回的 JSON 包含 `anthropic_skills_count`
- [ ] 在 `anthropic_skills/` 中添加/删除 skill 子目录，计数随之变化