### PR TITLE
fix(agent): 子 Agent final_answer 事件遗漏时从 checkpoint 兜底

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -43,6 +43,20 @@ async def _stream_turn(graph, inputs, config, ws, session, system_prompt, model_
         if event.get("event") == "on_chain_end" and event.get("name") == "tools":
             usage = await _calculate_context_usage(session, system_prompt, model_name=model_name)
             await ws.send_json({"type": "context_usage", "payload": usage})
+
+    # 事件未捕获到 final_answer 时，从 checkpoint 兜底提取
+    if not final_answer:
+        try:
+            cpt = await session.checkpointer.aget_tuple(config)
+            if cpt is not None:
+                messages = cpt.checkpoint.get("channel_values", {}).get("messages", [])
+                if messages:
+                    last = messages[-1]
+                    candidate = last.content if hasattr(last, "content") else str(last)
+                    if candidate:
+                        final_answer = candidate
+        except Exception:
+            pass
     return final_answer
 
 

--- a/skills/sub_agent/skill_call_sub_agent.py
+++ b/skills/sub_agent/skill_call_sub_agent.py
@@ -162,6 +162,20 @@ class CallSubAgentSkill(SkillBase):
                     if messages:
                         last = messages[-1]
                         final_answer = last.content if hasattr(last, "content") else str(last)
+
+            # 事件未捕获到 final_answer 时，从 checkpoint 兜底提取
+            if not final_answer:
+                try:
+                    cpt = await sub.checkpointer.aget_tuple(config)
+                    if cpt is not None:
+                        messages = cpt.checkpoint.get("channel_values", {}).get("messages", [])
+                        if messages:
+                            last = messages[-1]
+                            candidate = last.content if hasattr(last, "content") else str(last)
+                            if candidate:
+                                final_answer = candidate
+                except Exception:
+                    pass
         except Exception as e:
             print(f"[call_sub_agent] _run_background agent failed: {e}", file=sys.stderr)
             traceback.print_exc(file=sys.stderr)


### PR DESCRIPTION
## 问题

子 Agent 正常回答了任务，但主 Agent 工具调用结果却显示：
success: false / error: 子 Agent 执行失败: Sub-agent 未能产生有效回答

## 根因

astream_events 中 on_chain_end(agent) 事件在某些情况下未能捕获携带最终回答的内容，导致 final_answer 为空字符串。

## 修复

在 _stream_turn（chat.py）和 _run_background（skill_call_sub_agent.py）事件循环结束后，如果 final_answer 仍为空，从 checkpointer 持久化状态中兜底提取最后一条消息内容。

## Test plan

- [ ] 子 Agent 正常执行后，主 Agent 能正确收到 success: true 和回答
- [ ] 事件正常捕获时，兜底路径不触发，行为不变