### PR TITLE
feat(web,api): Playground 改为更新动态新闻页

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,27 @@
 # SonettoHere
 
+## 更新动态发布流程
+
+每次合并 PR 或发布版本后，Claude Code 应根据以下规则评估是否添加系统更新动态：
+
+1. **评估标准**：仅当 PR 属于以下类型时值得加入新闻
+   - `feat` — 新增用户可见的功能、页面、能力（如湾区计划、万花筒计划）
+   - `enhance` — 对现有功能有重大增强或用户体验提升
+   - `refactor` — 影响用户视觉或交互的重构（如 UI 重设计）
+   - 以下类型通常**不值得**加入：纯 `fix`（非关键修复）、`chore`、`docs`、内部重构
+2. **添加方式**：打开 `api/data/news.yaml`，在 `news` 列表的**最前面**插入一条新条目
+   ```yaml
+   - id: "简短-kebab-标识"
+     title: "更新标题（中文，15字以内）"
+     description: "更新内容描述，1-3句话概括变更内容和用户收益"
+     type: "feat"       # feat | enhance | fix | refactor | docs
+     date: "2026-05-30"  # ISO 日期 YYYY-MM-DD
+     tags: ["标签1", "标签2"]
+     version: "v1.3.0"   # 有版本号时填写，否则留空
+     pr_number: 42       # 有 PR 编号时填写，否则留空
+   ```
+3. **提交流程**：`git add api/data/news.yaml && git commit -m "docs: 添加更新动态 <title>"` → 通过常规 PR 流程合入 main
+
 ## 提交规范
 
 每次创建 git commit 前，必须先阅读 `dev_docs/git-conventions.md`，确保 commit message 和分支命名符合规范。

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -6,7 +6,7 @@ news:
     type: "feat"
     date: "2026-05-25"
     tags: ["前端", "提供商", "UI"]
-    version: null
+    version: "v1.2.0"
     pr_number: null
 
   - id: "sub-agent-ping"
@@ -16,7 +16,7 @@ news:
     type: "fix"
     date: "2026-05-23"
     tags: ["Agent", "修复", "稳定性"]
-    version: null
+    version: "v1.2.0"
     pr_number: null
 
   - id: "memory-moment"

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -90,9 +90,9 @@ news:
     pr_number: 69
 
   - id: "kaleidoscope-initial"
-    en_title: "Tool Bubbles"
-    title: "万花筒计划上线：工具气泡系统"
-    description: "万花筒计划带来完整的 Tool Bubble（工具气泡）系统，为每种工具提供专属的渲染组件。现已支持 Bilibili 下载、Todo 管理、Python 执行、文件操作、地图搜索、天气查询、PDF/Word 阅读、代码分析等 30 余种工具组件，并基于注册机制自动匹配兜底组件。"
+    en_title: "Project Kaleidoscope"
+    title: "森罗计划上线：工具气泡系统"
+    description: "森罗计划带来完整的 Tool Bubble（工具气泡）系统，为每种工具提供专属的渲染组件。现已支持 Bilibili 下载、Todo 管理、Python 执行、文件操作、地图搜索、天气查询、PDF/Word 阅读、代码分析等 30 余种工具组件，并基于注册机制自动匹配兜底组件。谨以此命名向知名 Minecraft 模组 Kaleidoscope 森罗物语系列致敬。"
     type: "feat"
     date: "2026-05-01"
     tags: ["前端", "工具系统", "气泡组件"]

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -7,7 +7,7 @@ news:
     date: "2026-05-25"
     tags: ["前端", "提供商", "UI"]
     version: "v1.2.0"
-    pr_number: null
+    pr_number: 69
 
   - id: "sub-agent-ping"
     en_title: "Agent Health Check"
@@ -17,7 +17,7 @@ news:
     date: "2026-05-23"
     tags: ["Agent", "修复", "稳定性"]
     version: "v1.2.0"
-    pr_number: null
+    pr_number: 74
 
   - id: "memory-moment"
     en_title: "Memory Moments"
@@ -26,8 +26,8 @@ news:
     type: "enhance"
     date: "2026-05-20"
     tags: ["记忆", "Moment", "优化"]
-    version: "v1.2.0"
-    pr_number: null
+    version: "v1.0.0"
+    pr_number: 50
 
   - id: "v1.2.0-release"
     en_title: "v1.2.0 Release"
@@ -37,7 +37,7 @@ news:
     date: "2026-05-18"
     tags: ["发布", "版本"]
     version: "v1.2.0"
-    pr_number: null
+    pr_number: 75
 
   - id: "ui-redesign"
     en_title: "UI Redesign"
@@ -46,8 +46,8 @@ news:
     type: "refactor"
     date: "2026-05-15"
     tags: ["前端", "UI", "设计"]
-    version: "v1.2.0"
-    pr_number: null
+    version: "v1.1.0"
+    pr_number: 56
 
   - id: "mcp-tools"
     en_title: "MCP Bridge"
@@ -56,8 +56,8 @@ news:
     type: "feat"
     date: "2026-05-12"
     tags: ["MCP", "工具桥接", "集成"]
-    version: "v1.2.0"
-    pr_number: null
+    version: "v1.1.0"
+    pr_number: 53
 
   - id: "sub-agent-events"
     en_title: "Sub-agent Lifecycle"
@@ -66,8 +66,8 @@ news:
     type: "enhance"
     date: "2026-05-10"
     tags: ["Agent", "会话管理", "事件系统"]
-    version: "v1.2.0"
-    pr_number: null
+    version: "v1.1.0"
+    pr_number: 60
 
   - id: "anthropic-skills"
     en_title: "Anthropic Skills"
@@ -77,7 +77,7 @@ news:
     date: "2026-05-08"
     tags: ["技能", "Anthropic", "LangChain"]
     version: "v1.2.0"
-    pr_number: null
+    pr_number: 73
 
   - id: "bay-project"
     en_title: "Project Bay"
@@ -87,7 +87,7 @@ news:
     date: "2026-05-05"
     tags: ["后端", "提供商", "架构"]
     version: "v1.2.0"
-    pr_number: null
+    pr_number: 69
 
   - id: "kaleidoscope-initial"
     en_title: "Tool Bubbles"
@@ -96,5 +96,5 @@ news:
     type: "feat"
     date: "2026-05-01"
     tags: ["前端", "工具系统", "气泡组件"]
-    version: "v1.1.0"
-    pr_number: null
+    version: "v1.0.0"
+    pr_number: 21

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -1,0 +1,100 @@
+news:
+  - id: "provider-ui"
+    en_title: "Provider Manager"
+    title: "提供商管理页面上线"
+    description: "提供商管理页面（/providers）现已上线。支持提供商列表的卡片式展示，以及新增、编辑、删除、连接测试和模型列表拉取等操作。告别 .env 手动配置，体验更直观的管理方式。"
+    type: "feat"
+    date: "2026-05-25"
+    tags: ["前端", "提供商", "UI"]
+    version: null
+    pr_number: null
+
+  - id: "sub-agent-ping"
+    en_title: "Agent Health Check"
+    title: "子 Agent ping-pong 状态检测优化"
+    description: "优化了子 Agent 的状态检测机制。通过 ping-pong 测试确认子 Agent 的响应状态，显著增强子会话的可靠性监控，有效减少假死会话的残留问题。"
+    type: "fix"
+    date: "2026-05-23"
+    tags: ["Agent", "修复", "稳定性"]
+    version: null
+    pr_number: null
+
+  - id: "memory-moment"
+    en_title: "Memory Moments"
+    title: "记忆系统优化与 Moment 功能"
+    description: "新增 Moment 功能，用于展示最具代表性的记忆条目。同时优化了 LongTermMemoryInterface 长期记忆接口，支持记忆的创建、更新、合并去重，并增强了叙事（Narrative）生成能力。"
+    type: "enhance"
+    date: "2026-05-20"
+    tags: ["记忆", "Moment", "优化"]
+    version: "v1.2.0"
+    pr_number: null
+
+  - id: "v1.2.0-release"
+    en_title: "v1.2.0 Release"
+    title: "发布 v1.2.0 版本"
+    description: "我们正式发布 v1.2.0 版本。该版本聚合了湾区计划、万花筒计划、Anthropic Skills、MCP 工具桥接、子 Agent 系统、记忆 Moment 以及 UI 重新设计等重大特性，带来更强大的功能与更流畅的体验。"
+    type: "feat"
+    date: "2026-05-18"
+    tags: ["发布", "版本"]
+    version: "v1.2.0"
+    pr_number: null
+
+  - id: "ui-redesign"
+    en_title: "UI Redesign"
+    title: "前端 UI 重新设计：黑白风格"
+    description: "前端 UI 迎来简洁的黑白风格重新设计。包括全新的侧边栏、卡片布局和导航系统。新增可折叠侧边栏（折叠后宽度 58px）、Health Panel 系统状态面板以及打字机（Typewriter）效果的欢迎动画。"
+    type: "refactor"
+    date: "2026-05-15"
+    tags: ["前端", "UI", "设计"]
+    version: "v1.2.0"
+    pr_number: null
+
+  - id: "mcp-tools"
+    en_title: "MCP Bridge"
+    title: "集成 MCP 工具桥接"
+    description: "实现了 MCP（Model Context Protocol）客户端桥接，支持通过 MCP 协议连接外部工具服务。现已提供 Word 文档编辑能力（包括创建、编辑、格式转换、批注等）。MCP 工具在应用启动时通过 init_mcp_tools() 加载，并在关闭时通过 close_mcp() 自动清理。"
+    type: "feat"
+    date: "2026-05-12"
+    tags: ["MCP", "工具桥接", "集成"]
+    version: "v1.2.0"
+    pr_number: null
+
+  - id: "sub-agent-events"
+    en_title: "Sub-agent Lifecycle"
+    title: "子 Agent 事件处理与状态监控"
+    description: "实现了子 Agent（Sub-agent）的完整生命周期管理。支持 call_sub_agent 工具调用、sub_session_created 事件推送，以及子会话的创建与监控。"
+    type: "enhance"
+    date: "2026-05-10"
+    tags: ["Agent", "会话管理", "事件系统"]
+    version: "v1.2.0"
+    pr_number: null
+
+  - id: "anthropic-skills"
+    en_title: "Anthropic Skills"
+    title: "集成 Anthropic Skills 系统"
+    description: "引入了基于 SKILL.md 说明书机制的 Skill 工具库体系。每个 Skill 继承自 SkillBase（继承 LangChain 的 BaseTool），并通过 get_all_skills() 注册到 create_react_agent。首批技能包括前端计数器、目录扫描、网页注入检测等。"
+    type: "feat"
+    date: "2026-05-08"
+    tags: ["技能", "Anthropic", "LangChain"]
+    version: "v1.2.0"
+    pr_number: null
+
+  - id: "bay-project"
+    en_title: "Project Bay"
+    title: "湾区计划：多 LLM 提供商支持"
+    description: "湾区计划（Project Bay）实现了多 LLM 提供商支持方案。采用 Provider Adapter 模式适配不同 API，结合 YAML 与环境变量回退的配置存储方式，支持按会话绑定不同提供商。首次启动时自动从 .env 生成 providers.yaml。"
+    type: "feat"
+    date: "2026-05-05"
+    tags: ["后端", "提供商", "架构"]
+    version: "v1.2.0"
+    pr_number: null
+
+  - id: "kaleidoscope-initial"
+    en_title: "Tool Bubbles"
+    title: "万花筒计划上线：工具气泡系统"
+    description: "万花筒计划带来完整的 Tool Bubble（工具气泡）系统，为每种工具提供专属的渲染组件。现已支持 Bilibili 下载、Todo 管理、Python 执行、文件操作、地图搜索、天气查询、PDF/Word 阅读、代码分析等 30 余种工具组件，并基于注册机制自动匹配兜底组件。"
+    type: "feat"
+    date: "2026-05-01"
+    tags: ["前端", "工具系统", "气泡组件"]
+    version: "v1.1.0"
+    pr_number: null

--- a/api/routes/news.py
+++ b/api/routes/news.py
@@ -20,7 +20,7 @@ class NewsEntry(BaseModel):
     type: str
     date: str
     tags: list[str] = []
-    version: str | None = None
+    version: str
     pr_number: int | None = None
 
 

--- a/api/routes/news.py
+++ b/api/routes/news.py
@@ -1,0 +1,49 @@
+"""REST API — 系统更新动态。"""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from pathlib import Path
+import yaml
+
+router = APIRouter()
+
+NEWS_PATH = Path(__file__).resolve().parent.parent / "data" / "news.yaml"
+
+
+# ── Pydantic 模型 ──
+
+class NewsEntry(BaseModel):
+    id: str
+    en_title: str | None = None
+    title: str
+    description: str
+    type: str
+    date: str
+    tags: list[str] = []
+    version: str | None = None
+    pr_number: int | None = None
+
+
+class ListNewsResponse(BaseModel):
+    news: list[NewsEntry]
+
+
+# ── 读取 ──
+
+def _load_news() -> list[NewsEntry]:
+    if not NEWS_PATH.exists():
+        return []
+    with open(NEWS_PATH, encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    entries = [NewsEntry(**item) for item in raw.get("news", [])]
+    # 按日期降序排列（最新的在前）
+    entries.sort(key=lambda e: e.date, reverse=True)
+    return entries
+
+
+# ── 路由 ──
+
+@router.get("/news", response_model=ListNewsResponse)
+def list_news():
+    """返回所有更新动态，按日期降序排列。"""
+    return ListNewsResponse(news=_load_news())

--- a/api/routes/news.py
+++ b/api/routes/news.py
@@ -21,7 +21,7 @@ class NewsEntry(BaseModel):
     date: str
     tags: list[str] = []
     version: str
-    pr_number: int | None = None
+    pr_number: int
 
 
 class ListNewsResponse(BaseModel):

--- a/api/server.py
+++ b/api/server.py
@@ -13,6 +13,7 @@ from api.health import get_health_report
 from api.providers.manager import ProviderManager
 from api.providers.store import ProviderConfigStore
 from api.routes import chat, files, memory, sessions, balance, providers
+from api.routes import news as news_router
 from api.session_manager import SessionManager
 from memory.narrative import MEMORY_PATH, LongTermMemoryInterface
 from skills.mcp import init_mcp_tools, close_mcp
@@ -79,6 +80,9 @@ def create_app() -> FastAPI:
 
     # Provider CRUD 路由
     app.include_router(providers.router, prefix="/api")
+
+    # 系统更新动态
+    app.include_router(news_router.router, prefix="/api")
 
     # 健康检查
     @app.get("/api/health")

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -17,7 +17,7 @@
         <router-link to="/providers" class="nav-item">
           <Icon name="model" :size="18" /> <span class="nav-label">模型&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MODELS</span>
         </router-link>
-        <router-link to="/playground" class="nav-item pg-nav">Playground</router-link>
+        <router-link to="/playground" class="nav-item pg-nav">动态 NEWS</router-link>
       </nav>
       <SessionSidebar
         :sessions="sessions"

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -8,6 +8,7 @@ import type {
   DeepSeekBalanceResponse,
   HealthResponse,
   ListProvidersResponse,
+  ListNewsResponse,
   ProviderConfig,
   TestConnectionResponse,
   DiscoverModelsResponse,
@@ -103,4 +104,9 @@ export const api = {
     request<TestConnectionResponse>(`/providers/${id}/test`, {
       method: 'POST',
     }),
+
+  // ── News ──
+
+  listNews: () =>
+    request<ListNewsResponse>('/news'),
 }

--- a/web/src/components/NewsCard.vue
+++ b/web/src/components/NewsCard.vue
@@ -1,0 +1,185 @@
+<template>
+  <div class="news-card">
+    <!-- 标题行：类型徽章 + 英文标题 -->
+    <div class="card-header">
+      <div class="card-title-row">
+        <span class="card-type-badge" :class="'type-' + entry.type">{{ typeLabel }}</span>
+        <span class="card-en-title">{{ entry.en_title || entry.title }}</span>
+      </div>
+      <span v-if="entry.version" class="version-badge">{{ entry.version }}</span>
+    </div>
+
+    <!-- 中文副标题 -->
+    <div v-if="entry.en_title" class="card-subtitle">{{ entry.title }}</div>
+
+    <!-- 描述（分段） -->
+    <div class="news-description">
+      <p v-for="(para, i) in paragraphs" :key="i" class="desc-para">{{ para }}</p>
+    </div>
+
+    <!-- 标签列表 -->
+    <div class="card-models-tags">
+      <span v-for="tag in entry.tags" :key="tag" class="model-tag">{{ tag }}</span>
+    </div>
+
+    <!-- 底部：日期 -->
+    <div class="news-footer">
+      <span class="news-date">{{ formattedDate }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { NewsEntry } from '@/types'
+import { computed } from 'vue'
+
+const props = defineProps<{ entry: NewsEntry }>()
+
+const typeLabelMap: Record<string, string> = {
+  feat: 'Feature',
+  enhance: 'Enhancement',
+  fix: 'Fix',
+  refactor: 'Refactor',
+  docs: 'Docs',
+}
+
+const typeLabel = computed(() => typeLabelMap[props.entry.type] ?? props.entry.type)
+
+const paragraphs = computed(() => {
+  const text = props.entry.description
+  // 按句号分割，过滤空串，每句补回句号
+  return text.split('。').filter(s => s.trim()).map(s => s.trim() + '。')
+})
+
+const formattedDate = computed(() => {
+  const d = new Date(props.entry.date)
+  return d.toLocaleDateString('zh-CN', { year: 'numeric', month: 'long', day: 'numeric' })
+})
+</script>
+
+<style scoped>
+.news-card {
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.card-en-title {
+  font-size: 17px;
+  font-weight: 700;
+  color: #1f2937;
+  line-height: 1.3;
+}
+
+.card-subtitle {
+  font-size: 13px;
+  font-weight: 400;
+  color: #9ca3af;
+  line-height: 1.4;
+  margin-top: -2px;
+}
+
+.card-type-badge {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  padding: 2px 8px;
+  border-radius: 100px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.card-type-badge.type-feat {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.card-type-badge.type-enhance {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.card-type-badge.type-fix {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.card-type-badge.type-refactor {
+  background: #f3e8ff;
+  color: #6b21a8;
+}
+
+.card-type-badge.type-docs {
+  background: #f3f4f6;
+  color: #6b7280;
+}
+
+.version-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 6px;
+  background: #1f2937;
+  color: #ffffff;
+  flex-shrink: 0;
+  font-family: 'SF Mono', 'Consolas', monospace;
+}
+
+.news-description {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.desc-para {
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.card-models-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.model-tag {
+  font-size: 11px;
+  padding: 3px 8px;
+  background: #f3f4f6;
+  border-radius: 6px;
+  color: #6b7280;
+  font-family: 'SF Mono', 'Consolas', monospace;
+}
+
+.news-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.news-date {
+  font-size: 12px;
+  color: #9ca3af;
+}
+</style>

--- a/web/src/components/NewsCard.vue
+++ b/web/src/components/NewsCard.vue
@@ -106,29 +106,32 @@ const formattedDate = computed(() => {
   border-radius: 100px;
   flex-shrink: 0;
   white-space: nowrap;
+  background: #f3f4f6;
+  color: #9ca3af;
+  transition: background 0.2s, color 0.2s;
 }
 
-.card-type-badge.type-feat {
+.news-card:hover .card-type-badge.type-feat {
   background: #dcfce7;
   color: #166534;
 }
 
-.card-type-badge.type-enhance {
+.news-card:hover .card-type-badge.type-enhance {
   background: #dbeafe;
   color: #1e40af;
 }
 
-.card-type-badge.type-fix {
+.news-card:hover .card-type-badge.type-fix {
   background: #fef3c7;
   color: #92400e;
 }
 
-.card-type-badge.type-refactor {
+.news-card:hover .card-type-badge.type-refactor {
   background: #f3e8ff;
   color: #6b21a8;
 }
 
-.card-type-badge.type-docs {
+.news-card:hover .card-type-badge.type-docs {
   background: #f3f4f6;
   color: #6b7280;
 }

--- a/web/src/components/NewsCard.vue
+++ b/web/src/components/NewsCard.vue
@@ -22,9 +22,9 @@
       <span v-for="tag in entry.tags" :key="tag" class="model-tag">{{ tag }}</span>
     </div>
 
-    <!-- 底部：日期 -->
+    <!-- 底部：PR -->
     <div class="news-footer">
-      <span class="news-date">{{ formattedDate }}</span>
+      <span class="news-pr">#{{ entry.pr_number }}</span>
     </div>
   </div>
 </template>
@@ -49,11 +49,6 @@ const paragraphs = computed(() => {
   const text = props.entry.description
   // 按句号分割，过滤空串，每句补回句号
   return text.split('。').filter(s => s.trim()).map(s => s.trim() + '。')
-})
-
-const formattedDate = computed(() => {
-  const d = new Date(props.entry.date)
-  return d.toLocaleDateString('zh-CN', { year: 'numeric', month: 'long', day: 'numeric' })
 })
 </script>
 
@@ -181,8 +176,10 @@ const formattedDate = computed(() => {
   gap: 8px;
 }
 
-.news-date {
+.news-pr {
   font-size: 12px;
-  color: #9ca3af;
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-family: 'SF Mono', 'Consolas', monospace;
 }
 </style>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -9,8 +9,8 @@ const router = createRouter({
     { path: '/memory', name: 'memory', component: MemoryView },
     {
       path: '/playground',
-      name: 'playground',
-      component: () => import('@/views/PlaygroundView.vue'),
+      name: 'news',
+      component: () => import('@/views/NewsView.vue'),
     },
     {
       path: '/providers',

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -287,7 +287,7 @@ export interface NewsEntry {
   type: string
   date: string
   tags: string[]
-  version: string | null
+  version: string
   pr_number: number | null
 }
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -288,7 +288,7 @@ export interface NewsEntry {
   date: string
   tags: string[]
   version: string
-  pr_number: number | null
+  pr_number: number
 }
 
 export interface ListNewsResponse {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -276,3 +276,21 @@ export interface TestConnectionResponse {
 export interface DiscoverModelsResponse {
   models: string[]
 }
+
+// === 系统更新动态 ===
+
+export interface NewsEntry {
+  id: string
+  en_title: string | null
+  title: string
+  description: string
+  type: string
+  date: string
+  tags: string[]
+  version: string | null
+  pr_number: number | null
+}
+
+export interface ListNewsResponse {
+  news: NewsEntry[]
+}

--- a/web/src/views/NewsView.vue
+++ b/web/src/views/NewsView.vue
@@ -71,7 +71,7 @@ async function loadNews() {
   loading.value = true
   try {
     const res = await api.listNews()
-    news.value = res.news.sort((a, b) => b.date.localeCompare(a.date))
+    news.value = res.news.sort((a, b) => b.pr_number - a.pr_number)
     requestAnimationFrame(updateTimelineBounds)
   } catch (e: any) {
     console.error('加载更新动态失败', e)

--- a/web/src/views/NewsView.vue
+++ b/web/src/views/NewsView.vue
@@ -6,15 +6,29 @@
       <span class="news-count" v-if="!loading">共 {{ news.length }} 条更新</span>
     </div>
 
-    <!-- 加载状态 -->
-    <div v-if="loading" class="loading">加载中...</div>
+    <div class="news-body">
+      <!-- 卡片列表 -->
+      <div class="news-content">
+        <div v-if="loading" class="loading">加载中...</div>
+        <div v-else-if="news.length === 0" class="empty">暂无更新动态</div>
+        <div v-else class="card-grid" ref="cardGridRef">
+          <NewsCard v-for="entry in news" :key="entry.id" :entry="entry" />
+        </div>
+      </div>
 
-    <!-- 空状态 -->
-    <div v-else-if="news.length === 0" class="empty">暂无更新动态</div>
-
-    <!-- 卡片网格 -->
-    <div v-else class="card-grid">
-      <NewsCard v-for="entry in news" :key="entry.id" :entry="entry" />
+      <!-- 版本演进时间轴 -->
+      <div v-if="versionNodes.length > 0" class="version-timeline" :style="tlBounds">
+        <div class="tl-track"></div>
+        <div
+          v-for="node in versionNodes"
+          :key="node.version"
+          class="tl-node"
+          :style="{ top: node.top + '%' }"
+        >
+          <div class="tl-dot"></div>
+          <span class="tl-label">{{ node.version }}</span>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -23,16 +37,42 @@
 import { api } from '@/api'
 import type { NewsEntry } from '@/types'
 import NewsCard from '@/components/NewsCard.vue'
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 
 const news = ref<NewsEntry[]>([])
 const loading = ref(false)
+const cardGridRef = ref<HTMLElement | null>(null)
+const tlBounds = ref<{ top: string; height: string }>()
+
+let observer: ResizeObserver | null = null
+
+function updateTimelineBounds() {
+  const grid = cardGridRef.value
+  const body = grid?.closest<HTMLElement>('.news-body')
+  if (!body || !grid) return
+
+  const cards = grid.querySelectorAll<HTMLElement>('.news-card')
+  if (cards.length < 2) return
+
+  const bodyRect = body.getBoundingClientRect()
+  const firstRect = cards[0].getBoundingClientRect()
+  const lastRect = cards[cards.length - 1].getBoundingClientRect()
+
+  const top = firstRect.top + firstRect.height / 2 - bodyRect.top
+  const bottom = lastRect.top + lastRect.height / 2 - bodyRect.top
+
+  tlBounds.value = {
+    top: top + 'px',
+    height: (bottom - top) + 'px',
+  }
+}
 
 async function loadNews() {
   loading.value = true
   try {
     const res = await api.listNews()
-    news.value = res.news
+    news.value = res.news.sort((a, b) => b.date.localeCompare(a.date))
+    requestAnimationFrame(updateTimelineBounds)
   } catch (e: any) {
     console.error('加载更新动态失败', e)
   } finally {
@@ -40,21 +80,49 @@ async function loadNews() {
   }
 }
 
-onMounted(loadNews)
+onMounted(() => {
+  loadNews()
+  observer = new ResizeObserver(updateTimelineBounds)
+  observer.observe(document.querySelector('.news-view')!)
+})
+
+onUnmounted(() => {
+  observer?.disconnect()
+})
+
+const versionNodes = computed(() => {
+  const entries = news.value
+  if (entries.length === 0) return []
+
+  const seen = new Set<string>()
+  const nodes: { version: string; top: number }[] = []
+
+  entries.forEach((entry, idx) => {
+    if (!seen.has(entry.version)) {
+      seen.add(entry.version)
+      nodes.push({
+        version: entry.version,
+        top: entries.length > 1 ? (idx / (entries.length - 1)) * 100 : 50,
+      })
+    }
+  })
+
+  return nodes
+})
 </script>
 
 <style scoped>
 .news-view {
   flex: 1;
   overflow-y: auto;
-  padding: 24px;
+  padding: 40px 48px;
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 20px;
+  margin-bottom: 28px;
 }
 
 .header h2 {
@@ -67,6 +135,14 @@ onMounted(loadNews)
   color: var(--text-secondary);
 }
 
+.news-body {
+  position: relative;
+}
+
+.news-content {
+  max-width: 720px;
+}
+
 .loading,
 .empty {
   text-align: center;
@@ -75,8 +151,56 @@ onMounted(loadNews)
 }
 
 .card-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ── 版本时间轴 ── */
+
+.version-timeline {
+  position: absolute;
+  left: calc(50% + 360px);
+  transform: translateX(-50%);
+  width: 80px;
+  pointer-events: none;
+}
+
+.tl-track {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+  transform: translateX(-50%);
+}
+
+.tl-node {
+  position: absolute;
+  left: 50%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transform: translateY(-50%);
+}
+
+.tl-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-primary);
+  flex-shrink: 0;
+  position: relative;
+  left: -4px;
+}
+
+.tl-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-family: 'SF Mono', 'Consolas', monospace;
+  white-space: nowrap;
+  padding-left: 12px;
 }
 </style>

--- a/web/src/views/NewsView.vue
+++ b/web/src/views/NewsView.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="news-view">
+    <!-- 标题栏 -->
+    <div class="header">
+      <h2>更新动态</h2>
+      <span class="news-count" v-if="!loading">共 {{ news.length }} 条更新</span>
+    </div>
+
+    <!-- 加载状态 -->
+    <div v-if="loading" class="loading">加载中...</div>
+
+    <!-- 空状态 -->
+    <div v-else-if="news.length === 0" class="empty">暂无更新动态</div>
+
+    <!-- 卡片网格 -->
+    <div v-else class="card-grid">
+      <NewsCard v-for="entry in news" :key="entry.id" :entry="entry" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { api } from '@/api'
+import type { NewsEntry } from '@/types'
+import NewsCard from '@/components/NewsCard.vue'
+import { onMounted, ref } from 'vue'
+
+const news = ref<NewsEntry[]>([])
+const loading = ref(false)
+
+async function loadNews() {
+  loading.value = true
+  try {
+    const res = await api.listNews()
+    news.value = res.news
+  } catch (e: any) {
+    console.error('加载更新动态失败', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadNews)
+</script>
+
+<style scoped>
+.news-view {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.header h2 {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.news-count {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.loading,
+.empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 40px 0;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+</style>


### PR DESCRIPTION
将开发调试用的 Playground 工具气泡测试页替换为系统更新动态展示页。

- 卡片风格对齐模型页（一列布局 + 留白）
- 英文标题 + 中文副标题层次，描述按句号分段
- 类型标签悬停变彩色
- 右侧版本演进时间轴，端点对齐首尾卡片中线
- 按 PR 编号排序，显示 #PR
- version / pr_number 改为必填字段
- 首批 10 条种子新闻，数据来自主分支合并记录
- CLAUDE.md 中定义 PR 审核工作流