### PR TITLE
feat(sidebar): 点击侧栏会话时切换到聊天界面

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -31,7 +31,11 @@
       <HealthPanel :health="health!" v-if="health" />
     </aside>
     <main class="main">
-      <router-view />
+      <router-view v-slot="{ Component }">
+        <Transition name="page" mode="out-in">
+          <component :is="Component" :key="$route.path" />
+        </Transition>
+      </router-view>
     </main>
   </div>
 </template>
@@ -291,6 +295,20 @@ html, body {
   overflow: hidden;
   padding: 0;
   margin: 0;
+}
+
+/* ── Page transition ── */
+.page-enter-active,
+.page-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.page-enter-from {
+  opacity: 0;
+  transform: translateY(6px);
+}
+.page-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
 }
 
 /* ── Shared markdown rendered content ── */

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -31,11 +31,7 @@
       <HealthPanel :health="health!" v-if="health" />
     </aside>
     <main class="main">
-      <router-view v-slot="{ Component }">
-        <Transition name="page" mode="out-in">
-          <component :is="Component" :key="$route.path" />
-        </Transition>
-      </router-view>
+      <router-view />
     </main>
   </div>
 </template>
@@ -295,20 +291,6 @@ html, body {
   overflow: hidden;
   padding: 0;
   margin: 0;
-}
-
-/* ── Page transition ── */
-.page-enter-active,
-.page-leave-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-.page-enter-from {
-  opacity: 0;
-  transform: translateY(6px);
-}
-.page-leave-to {
-  opacity: 0;
-  transform: translateY(-6px);
 }
 
 /* ── Shared markdown rendered content ── */

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -9,7 +9,7 @@
       </div>
       <nav class="sidebar-nav">
         <router-link to="/" class="nav-item">
-          <Icon name="chat" :size="18" /> <span class="nav-label">对话&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CHATING</span>
+          <Icon name="chat" :size="18" /> <span class="nav-label">对话&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CHATTING</span>
         </router-link>
         <router-link to="/memory" class="nav-item">
           <Icon name="memory" :size="18" /> <span class="nav-label">记忆&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MEMORY</span>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -25,7 +25,7 @@
         :session-statuses="allSessionStatuses"
         :collapsed="effectiveCollapsed"
         @create="createSession"
-        @switch="switchSession"
+        @switch="handleSwitchSession"
         @delete="deleteSession"
       />
       <HealthPanel :health="health!" v-if="health" />
@@ -45,6 +45,7 @@ import { health, startPolling, useHealth } from '@/composables/useHealth';
 import { useSession } from '@/composables/useSession';
 import { useSidebar } from '@/composables/useSidebar';
 import { onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 
 const { effectiveCollapsed, toggleSidebar } = useSidebar()
 
@@ -52,6 +53,13 @@ function onSidebarClick(e: MouseEvent) {
   if (e.target === e.currentTarget) {
     toggleSidebar()
   }
+}
+
+const router = useRouter()
+
+function handleSwitchSession(id: string) {
+  switchSession(id)
+  router.push('/')
 }
 
 const { sessionId, sessions, createSession, switchSession, deleteSession } =


### PR DESCRIPTION
点击侧栏中的会话时，除了切换活动会话 ID，还会通过 `router.push('/')` 跳回聊天界面，避免用户在 Memory/Providers 等页面点击会话后无反应。