### PR TITLE
fix: 修复侧栏会话删除时 WS 重连导致会话复活

### DIFF
--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -5,7 +5,7 @@
       <button class="btn-new" @click="$emit('create')" title="新会话">+</button>
     </div>
     <div class="session-list">
-      <button
+      <div
         v-for="(s, index) in sessions"
         :key="s.session_id"
         class="session-item"
@@ -45,7 +45,7 @@
             &times;
           </button>
         </div>
-      </button>
+      </div>
       <div v-if="sessions.length === 0" class="no-sessions">
         暂无会话
       </div>

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -61,8 +61,12 @@ export function disconnectSession(sid: string) {
     clearTimeout(ch.reconnectTimer)
     ch.reconnectTimer = null
   }
-  ch.ws?.close()
-  ch.ws = null
+  // 先清除 onclose，再手动关闭 WS — 防止 onclose 触发意外重连
+  if (ch.ws) {
+    ch.ws.onclose = null
+    ch.ws.close()
+    ch.ws = null
+  }
   ch.connected = false
   ch.initialized = false
   channels.delete(sid)


### PR DESCRIPTION
## 问题

点击侧栏会话列表的 × 按钮删除会话时，会话删不掉甚至越点越多。

## 根因

两层 bug 叠加：

### 前端：WebSocket onclose 无条件重连
`disconnectSession()` 调用 `ch.ws?.close()` 触发 `onclose` 处理器，后者在 3 秒后调度 `connectSession(sid)` 重连。即使 channel 随后被删除，定时器已注册，仍会创建新 channel 并连接后端。

### 前端：嵌套 \<button\> 无效 HTML
`<button class="session-item">` 内包含 `<button class="btn-delete">`，浏览器会隐式闭合外层 button，破坏 DOM 结构和事件冒泡。

## 修复

1. **useChat.ts** — `disconnectSession()` 在 `ws.close()` 前将 `onclose` 置 `null`，阻止意外重连
2. **SessionSidebar.vue** — 外层 `<button>` 改为 `<div>`，消除无效嵌套

## 改动文件

- `web/src/composables/useChat.ts` — +5 / -2
- `web/src/components/SessionSidebar.vue` — +2 / -2