### PR TITLE
feat(web): 记忆/私密模式切换按钮优化

### DIFF
--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -9,7 +9,7 @@
           @click="setPrivateMode(!privateMode)"
         >
           <span class="private-indicator"></span>
-          私密
+          {{ privateMode ? '私密' : '记忆' }}
         </button>
         <div class="hover-card card-private">
           <div class="card-row">

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -153,6 +153,9 @@ async function handleUndo() {
   background: color-mix(in srgb, var(--status-warn) 10%, transparent);
   color: var(--status-warn);
 }
+.private-toggle:not(.active) .private-indicator {
+  background: var(--accent);
+}
 .private-indicator {
   width: 8px;
   height: 8px;


### PR DESCRIPTION
## 改动内容

- 按钮文字根据模式动态切换：正常模式显示「记忆」，私密模式显示「私密」
- 正常模式下按钮原点颜色改为品牌黑色（#000000），私密模式保持橙色

## 类型

- eat — 用户可见的功能增强