### PR TITLE
feat(api): 取消 Agent 时注入统一格式的取消 ToolMessage 并通知前端

### DIFF
--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -1,13 +1,14 @@
 news:
   - id: "cancel-tool-checkpoint"
     en_title: "Cancel Tool Message Checkpoint"
-    title: "取消时工具状态持久化与前端同步"
-    description: "优化 Agent 取消机制：取消时自动为孤立工具调用注入统一格式的取消 ToolMessage 到 Checkpoint，避免下条消息因状态不一致报错；同时向前端推送 tool_error 事件使工具气泡进入错误状态。Python 代码执行工具改为线程运行，取消时不再等待代码执行完毕，响应更及时。"
+    title: "工具调用时允许截停"
+    description: "Project Time Traveler 第二个功能「Cancel-Tool」上线。覆盖绝大部分工具，允许工具运行时手动截停。LLM将从工具返回结果中知晓用户截停操作。"
     type: "feat"
     date: "2026-06-09"
-    tags: ["Agent", "取消", "稳定", "Python"]
+    tags: ["Skill", "取消", "稳定"]
     version: "PREVIEW"
-    pr_number:
+    pr_number: 94
+
   - id: "code-guardian"
     en_title: "Code Guardian"
     title: "代码执行前审查功能正式发布"

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -1,4 +1,13 @@
 news:
+  - id: "cancel-tool-checkpoint"
+    en_title: "Cancel Tool Message Checkpoint"
+    title: "取消时工具状态持久化与前端同步"
+    description: "优化 Agent 取消机制：取消时自动为孤立工具调用注入统一格式的取消 ToolMessage 到 Checkpoint，避免下条消息因状态不一致报错；同时向前端推送 tool_error 事件使工具气泡进入错误状态。Python 代码执行工具改为线程运行，取消时不再等待代码执行完毕，响应更及时。"
+    type: "feat"
+    date: "2026-06-09"
+    tags: ["Agent", "取消", "稳定", "Python"]
+    version: "PREVIEW"
+    pr_number:
   - id: "code-guardian"
     en_title: "Code Guardian"
     title: "代码执行前审查功能正式发布"

--- a/api/interaction.py
+++ b/api/interaction.py
@@ -9,6 +9,8 @@ import asyncio
 import contextvars
 import uuid
 
+from skills.base import format_error
+
 # 当前连接对应的 WebSocket 实例（在 chat.py 中设置）
 current_ws: contextvars.ContextVar = contextvars.ContextVar("current_ws")
 
@@ -41,3 +43,18 @@ def resolve(interaction_id: str, response) -> bool:
 def cleanup(interaction_id: str):
     """清理（超时或取消时调用）。"""
     _pending.pop(interaction_id, None)
+
+
+def cancel_all(reason: str | None = None):
+    """将所有挂起的交互 Future 以取消原因标记为已完成，并清空 _pending。
+
+    在取消 Agent 任务时由 _run_agent_turn 的 CancelledError 处理器调用。
+    返回值套用统一错误响应格式。
+    """
+    if reason is None:
+        reason = "用户取消了该工具调用"
+    formatted = format_error(reason)
+    for interaction_id, future in list(_pending.items()):
+        if not future.done():
+            future.set_result(formatted)
+        _pending.pop(interaction_id, None)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -6,7 +6,7 @@ import sys
 import traceback
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from agent.graph import build_agent
 from agent.prompts import build_system_prompt
@@ -15,6 +15,7 @@ from api.callbacks.websocket_callback import WebSocketCallback
 from api.context_usage import estimate_context_usage
 from api.session_manager import SessionState
 from config.settings import get_settings
+from skills.base import format_error
 
 router = APIRouter()
 
@@ -86,6 +87,94 @@ async def _calculate_context_usage(session, system_prompt, model_name: str | Non
     )
 
 
+async def _inject_cancel_tool_messages(session, config, ws: WebSocket) -> None:
+    """为 checkpoint 中孤立的 tool_calls 注入统一格式的正常 ToolMessage，
+    并通知前端使对应工具气泡进入错误状态。
+
+    由 CancelledError 处理器调用，确保取消后 checkpoint 状态一致，
+    下一条消息不会触发 "tool_calls without corresponding ToolMessage" 错误。
+
+    注入的 ToolMessage 使用 status="success"（默认），content 套用 format_error()
+    统一错误响应格式，使 LLM 在下一轮能正确识别工具调用已被取消。
+
+    前端 tool_error 事件：如果对应工具气泡尚在 'running' 状态，则标记为 'error'；
+    若工具从未启动过（无对应气泡）则事件被前端静默忽略。
+
+    与 time_traveler.py 的 undo_rounds() 使用同一模式（graph.aupdate_state）。
+    注意必需传入 as_node="tools"，否则 aupdate_state 评估路由时会从 model 节点的
+    model_to_tools 条件边走，检测到人造 ToolMessage 后返回 "model" 但该边目的地
+    不含 "model" 导致 KeyError 使写入失败。
+    """
+    graph = session._graph
+    if graph is None:
+        return
+
+    try:
+        state = await graph.aget_state(config)
+    except Exception:
+        return  # checkpoint 不可读时静默跳过
+
+    messages = state.values.get("messages", [])
+    if not messages:
+        return
+
+    # 从后往前找最后一个 AIMessage
+    last_ai = None
+    for i in range(len(messages) - 1, -1, -1):
+        if isinstance(messages[i], AIMessage):
+            last_ai = messages[i]
+            break
+
+    if last_ai is None:
+        return
+
+    tool_calls = getattr(last_ai, "tool_calls", [])
+    if not tool_calls:
+        return
+
+    # 收集其后所有 ToolMessage 的 tool_call_id 集合
+    try:
+        idx = messages.index(last_ai)
+    except ValueError:
+        return
+    following = messages[idx + 1:]
+
+    tool_msg_ids = {m.tool_call_id for m in following if isinstance(m, ToolMessage)}
+
+    orphaned = [tc for tc in tool_calls if tc["id"] not in tool_msg_ids]
+    if not orphaned:
+        return  # checkpoint 已一致
+
+    # 通知前端：使运行的工具体进入错误状态
+    for tc in orphaned:
+        try:
+            await ws.send_json({
+                "type": "tool_error",
+                "payload": {
+                    "tool_name": tc["name"],
+                    "error": "用户取消了该工具调用",
+                },
+            })
+        except Exception:
+            pass  # WebSocket 已断开时静默忽略
+
+    # 生成取消 ToolMessage 并写入 checkpoint
+    cancel_msgs = []
+    for tc in orphaned:
+        cancel_msgs.append(
+            ToolMessage(
+                content=format_error("用户取消了该工具调用"),
+                name=tc["name"],
+                tool_call_id=tc["id"],
+            )
+        )
+    try:
+        await graph.aupdate_state(config, {"messages": cancel_msgs}, as_node="tools")
+    except Exception as e:
+        print(f"[cancel] aupdate_state failed: {type(e).__name__}: {e}", file=sys.stderr)
+        raise
+
+
 async def _run_agent_turn(
     ws: WebSocket,
     session: SessionState,
@@ -150,6 +239,15 @@ async def _run_agent_turn(
             "payload": {"content": final_answer}
         })
     except asyncio.CancelledError:
+        # 清理 interaction 挂起 Future
+        interaction.cancel_all()
+
+        # 修复 checkpoint：为孤立 tool_calls 注入取消 ToolMessage，并通知前端
+        try:
+            await _inject_cancel_tool_messages(session, config, ws)
+        except Exception as e:
+            print(f"[cancel] checkpoint cleanup error: {e}", file=sys.stderr)
+
         await ws.send_json({                                                # [向前端通信] 2. 通知客户端生成已被取消
             "type": "error",
             "payload": {"code": "CANCELLED", "message": "生成已取消"},

--- a/skills/system/skill_python.py
+++ b/skills/system/skill_python.py
@@ -2,13 +2,25 @@
 
 import asyncio
 import io
-import json
 import sys
 
 from pydantic import BaseModel, Field
 
 from api import interaction
 from skills.base import SkillBase, format_error, format_success
+
+
+def _exec_code(code: str) -> str:
+    """在线程中执行代码并捕获 stdout。返回输出文本。"""
+    old_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    try:
+        exec(code, {"__builtins__": __builtins__})
+        return sys.stdout.getvalue() or "（代码执行完毕，无输出）"
+    except Exception as e:
+        raise RuntimeError(f"代码执行错误: {e}") from e
+    finally:
+        sys.stdout = old_stdout
 
 
 class RunPythonInput(BaseModel):
@@ -40,19 +52,11 @@ class RunPythonSkill(SkillBase):
             return format_error("code 不能为空")
 
         if interaction.auto_approve.get():
-            old_stdout = sys.stdout
-            sys.stdout = io.StringIO()
             try:
-                exec(code, {"__builtins__": __builtins__})
-                output = sys.stdout.getvalue()
-                return format_success({
-                    "output": output if output else "（代码执行完毕，无输出）",
-                    "code": code,
-                })
+                output = await asyncio.to_thread(_exec_code, code)
+                return format_success({"output": output, "code": code})
             except Exception as e:
-                return format_error(f"代码执行错误: {e}")
-            finally:
-                sys.stdout = old_stdout
+                return format_error(str(e))
 
         ws = interaction.current_ws.get()
         interaction_id, future = interaction.register()
@@ -79,20 +83,11 @@ class RunPythonSkill(SkillBase):
                 reason = answer.get("reason", "")
 
             if action == "approve":
-                old_stdout = sys.stdout
-                sys.stdout = io.StringIO()
-
                 try:
-                    exec(code, {"__builtins__": __builtins__})
-                    output = sys.stdout.getvalue()
-                    return format_success({
-                        "output": output if output else "（代码执行完毕，无输出）",
-                        "code": code,
-                    })
+                    output = await asyncio.to_thread(_exec_code, code)
+                    return format_success({"output": output, "code": code})
                 except Exception as e:
-                    return format_error(f"代码执行错误: {e}")
-                finally:
-                    sys.stdout = old_stdout
+                    return format_error(str(e))
             else:
                 if reason:
                     return format_error(f"用户拒绝执行代码。原因：{reason}")


### PR DESCRIPTION
## 背景

用户按停止按钮取消 Agent 时，已发出的 `tool_calls` 没有对应的 `ToolMessage`，
导致两条问题：

1. **下一条消息报错**：LLM 看到 `tool_calls` 无对应 `ToolMessage` 时返回 400
   `"tool_calls without corresponding ToolMessage"`
2. **工具气泡状态未更新**：前端工具气泡停留在 `running` 状态，不会变为错误态
3. **Python 代码执行无法打断**：`exec(code)` 是同步阻塞调用，`CancelledError` 要等它跑完才能送达

## 变更内容

### `api/interaction.py`
- `cancel_all()`：挂起的交互 Future 结果套用 `format_error()` 统一格式

### `api/routes/chat.py` — 新增 `_inject_cancel_tool_messages()`
- 取消时从 checkpoint 找出"孤立"的 `tool_calls`（有调用无结果的）
- 向 checkpoint 注入正常完成的 `ToolMessage`，content 为 `format_error("用户取消了该工具调用")`
- 使用 `as_node="tools"` 避免 `aupdate_state` 路由评估 KeyError
- 向前端推送 `tool_error` 事件使工具气泡进入错误状态

### `skills/system/skill_python.py` — Python 执行可打断
- 提取 `_exec_code()` 辅助函数，用 `asyncio.to_thread` 在线程中执行
- `exec(code)` 不再阻塞事件循环，取消时 `CancelledError` 立即送达

### `api/data/news.yaml`
- 新增更新动态条目

## 修复效果

| 场景 | 修改前 | 修改后 |
|------|--------|--------|
| 取消后发下条消息 | 400 错误 | 正常继续 |
| 工具气泡状态 | 永远 `running` | 变为 `error` |
| Python 取消响应 | 等代码跑完才取消 | 立即取消 |
