### PR TITLE
feat(web): LLM 输出 HTML/JS/CSS 沙箱渲染支持

### DIFF
--- a/config/personas/AGENTS.md
+++ b/config/personas/AGENTS.md
@@ -82,3 +82,128 @@
 ## 语气
 
 思考过程中保持人设规定的语气。
+
+## 前端设计原则
+
+### HTML 交互效果的渲染机制
+
+你可以直接输出原始的 HTML/CSS/JS 来创建交互式内容，前端会自动将其放入沙箱 iframe 中渲染。
+
+**关键规则**：HTML **不要包裹在围栏代码块内**（```` ```html ````），否则会被显示为代码文本而非渲染为页面元素。
+
+### 正确 vs 错误示范
+
+```
+✅ 正确：直接输出 HTML（无代码块包裹）
+一个交互式计数器：
+
+<div id="counter">
+  <style>
+    .counter-wrap { text-align: center; padding: 20px; }
+    .counter-num { font-size: 48px; font-weight: 700; color: var(--accent); }
+    .counter-btn { background: var(--accent); color: #fff; border: none; padding: 8px 24px; border-radius: 6px; cursor: pointer; font-size: 16px; }
+    .counter-btn:hover { opacity: 0.8; }
+  </style>
+  <div class="counter-wrap">
+    <div class="counter-num" id="num">0</div>
+    <button class="counter-btn" onclick="document.getElementById('num').textContent=parseInt(document.getElementById('num').textContent)+1">+1</button>
+  </div>
+</div>
+
+❌ 错误：包裹在代码块中，只会显示代码
+```html
+<div>hello</div>
+```
+
+❌ 错误：包裹在代码块中的 script 不会被执行
+```html
+<script>alert('test')</script>
+```
+```
+
+### 触发沙箱的条件
+
+内容中**在代码块之外**出现以下任何一种模式，就会进入 iframe 沙箱渲染：
+
+| 模式 | 示例 |
+|------|------|
+| `<script>` 标签 | `<script>...</script>` |
+| `<style>` 标签 | `<style>.cls { color: red; }</style>` |
+| 外部样式表 | `<link rel="stylesheet" href="...">` |
+| 事件处理器属性 | `onclick="..."`、`onmouseover="..."` 等 |
+| `javascript:` 链接 | `<a href="javascript:...">` |
+| `<iframe>` 嵌入 | `<iframe src="...">` |
+
+**技术说明**：
+- 沙箱使用 `<iframe srcdoc="...">` + `sandbox="allow-scripts allow-modals"` 隔离执行
+- 无 `allow-same-origin` → JS 无法访问父页面 DOM、Cookie、localStorage
+- 无 `allow-popups` → 弹窗被阻止
+- 无 `allow-top-navigation` → 无法导航父页面
+- 内容高度自动适配（ResizeObserver + 定时器兜底）
+
+### 设计令牌（Design Tokens）
+
+沙箱 iframe 会自动继承宿主页面的以下 CSS 自定义属性，可直接在 `<style>` 中使用：
+
+| 令牌 | 默认值 | 用途 |
+|------|--------|------|
+| `--bg-primary` | `#ffffff` | 页面/代码块背景 |
+| `--bg-secondary` | `#f9fafb` | 次要背景（表格头等） |
+| `--bg-card` | `#ffffff` | 卡片表面 |
+| `--text-primary` | `#1f2937` | 主要文字色 |
+| `--text-secondary` | `#6b7280` | 次要文字色 |
+| `--text-tertiary` | `#9ca3af` | 占位文字色 |
+| `--accent` | `#000000` | 强调色（链接、按钮） |
+| `--border` | `#e5e7eb` | 边框和分割线 |
+
+**推荐用法**：编写 HTML 时优先使用这些变量而非硬编码颜色，以保持与界面主题一致：
+```html
+<div style="color: var(--text-primary); background: var(--bg-secondary); border: 1px solid var(--border);">
+  自动适应当前主题
+</div>
+```
+
+### 排版规范
+
+字体栈（沙箱内已预置）：
+```
+-apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC',
+'Hiragino Sans GB', 'Microsoft YaHei', sans-serif
+```
+
+等宽字体系列：
+```
+'SF Mono', 'Consolas', monospace
+```
+
+- 正文：16px，行高 1.6
+- 标题：font-weight 600，行高 1.3
+- 代码块：13px，等宽字体，12px padding，8px border-radius
+- 引用块：3px 实线左边框，次要颜色文字
+
+### 内容布局
+
+- 消息气泡最大宽度为消息容器的 72%（约 553px）
+- 内容不应超出此宽度，长文本注意换行
+- 图片默认 `max-width: 100%` + `border-radius: 8px`
+- 表格会自动占满容器宽度
+- 避免使用 `position: fixed` / `absolute`，会因 iframe 边界被截断
+- 避免使用 `document.write()`（加载后调用会清空文档，已被拦截）
+
+### 整体页面布局（参考）
+
+```
++----------- 应用全屏 -----------+
+| 侧栏 220px  |  主区域 (flex: 1)  |
+| (可折叠至   |   +-- 聊天头部 ----+
+|   58px)     |   | 状态 | 按钮 |   |
+|             |   +----------------+
+| 导航        |   消息区 (max-width: 768px, 居中)
+| 会话列表    |   +----------------+
+| 健康状态    |   |  助手气泡       |
+|             |   |  .markdown-body |
+|             |   |  排版内容        |
+|             |   +----------------+
+|             |   |  输入框          |
++-------------+-------------------+
+```

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="chat-window" ref="windowRef">
     <div class="messages-list">
-      <!-- 已完成的消息轮次 -->
-      <template v-for="(turn, idx) in turns" :key="turn.id">
+      <!-- 所有轮次（已完成 + 正在流式）合并在同一列表中，:key="turn.id" 确保
+           组件实例在 turn 从当前轮过渡到已完成时不销毁重建，避免 iframe 闪烁 -->
+      <template v-for="(turn, mergedIdx) in mergedTurns" :key="turn.id">
         <div
           class="cite-source"
-          :data-user-msg-idx="idx"
-          @contextmenu.prevent="onBubbleContextMenu($event, 'user_message', turn.userMessage, '用户', idx)"
+          :data-user-msg-idx="turnsIndex(mergedIdx)"
+          @contextmenu.prevent="onBubbleContextMenu($event, 'user_message', turn.userMessage, '用户', turnsIndex(mergedIdx))"
         >
           <MessageBubble role="user" :content="turn.userMessage" :refs="turn.refs" />
         </div>
@@ -33,46 +34,14 @@
             <ToolBubbleRouter :tool-call="ev" @action="forwardAction" />
           </div>
         </template>
+        <!-- finalAnswer：仅在已完成（非流式）轮次中展示 -->
         <div
-          v-if="turn.finalAnswer && !hasAnswerBlock(turn)"
+          v-if="turn.finalAnswer && !hasAnswerBlock(turn) && !isStreamingTurn(turn)"
           class="cite-source"
           @contextmenu.prevent="onBubbleContextMenu($event, 'assistant_message', turn.finalAnswer, 'AI')"
         >
           <MessageBubble role="assistant" :content="turn.finalAnswer" />
         </div>
-      </template>
-
-      <!-- 当前正在流式生成的消息 -->
-      <template v-if="currentTurn">
-        <div
-          class="cite-source"
-          @contextmenu.prevent="onBubbleContextMenu($event, 'user_message', currentTurn.userMessage, '用户', -1)"
-        >
-          <MessageBubble role="user" :content="currentTurn.userMessage" :refs="currentTurn.refs" />
-        </div>
-        <template v-for="(ev, i) in currentTurn.events" :key="i">
-          <div
-            v-if="ev.kind === 'thinking'"
-            class="cite-source"
-            @contextmenu.prevent="onBubbleContextMenu($event, 'thinking', ev.tokens, '思考过程')"
-          >
-            <ThinkingBlock :block="ev" />
-          </div>
-          <div
-            v-else
-            class="cite-source"
-            @contextmenu.prevent="
-              onBubbleContextMenu(
-                $event,
-                'tool_result',
-                ev.output || ev.input || '',
-                ev.name,
-              )
-            "
-          >
-            <ToolBubbleRouter :tool-call="ev" @action="forwardAction" />
-          </div>
-        </template>
       </template>
 
       <!-- 错误提示 -->
@@ -159,6 +128,27 @@ function isNearBottom(): boolean {
 
 function hasAnswerBlock(turn: ChatTurn): boolean {
   return turn.events.some(e => e.kind === 'thinking' && e.becameAnswer)
+}
+
+/** 合并已完成轮次和当前流式轮次到单个列表，用 turn.id 作为 key，
+ *  使组件实例在过渡时不被销毁重建 */
+const mergedTurns = computed<ChatTurn[]>(() => {
+  if (!props.currentTurn) return props.turns
+  // currentTurn 可能已被 pushed 到 turns（becameAnswer 分支），去重
+  if (props.turns.some(t => t.id === props.currentTurn!.id)) return props.turns
+  return [...props.turns, props.currentTurn]
+})
+
+/** mergedTurns 中第 mergedIdx 项在 props.turns 中的索引（当前轮返回 -1） */
+function turnsIndex(mergedIdx: number): number {
+  // 前 props.turns.length 项索引与 mergedIdx 一致
+  if (mergedIdx < props.turns.length) return mergedIdx
+  return -1
+}
+
+/** 该轮次是否正在流式生成中 */
+function isStreamingTurn(turn: ChatTurn): boolean {
+  return props.currentTurn?.id === turn.id
 }
 
 function scrollToBottom() {

--- a/web/src/components/HtmlSandbox.vue
+++ b/web/src/components/HtmlSandbox.vue
@@ -2,7 +2,10 @@
   <div class="html-sandbox-container" ref="container">
     <div v-if="!iframeLoaded" class="sandbox-loading">
       <span class="sandbox-spinner"></span>
-      <!-- iframe 加载中 -->
+    </div>
+    <div v-if="sandboxErrors.length > 0" class="sandbox-error-bar">
+      <span class="sandbox-error-icon">⚠</span>
+      <span class="sandbox-error-text">沙箱内 {{ sandboxErrors.length }} 个错误 — 见控制台</span>
     </div>
     <iframe
       ref="iframeRef"
@@ -18,12 +21,13 @@
         position: iframeLoaded ? 'relative' : 'absolute',
       }"
       title="sandboxed-content"
+      @load="onIframeLoad"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 
 const props = withDefaults(defineProps<{
   html: string
@@ -33,6 +37,17 @@ const container = ref<HTMLElement | null>(null)
 const iframeRef = ref<HTMLIFrameElement | null>(null)
 const iframeHeight = ref(200)
 const iframeLoaded = ref(false)
+
+interface SandboxError {
+  type: string
+  message: string
+  stack?: string
+  source?: string
+  line?: number
+  col?: number
+  time: string
+}
+const sandboxErrors = ref<SandboxError[]>([])
 
 /** 从当前文档根元素提取 CSS 自定义属性，传给 iframe 以保持主题一致 */
 function getThemeCssVars(): string[] {
@@ -46,6 +61,19 @@ function getThemeCssVars(): string[] {
     '--shadow', '--radius',
   ]
   return names.map(n => `${n}: ${style.getPropertyValue(n).trim()};`)
+}
+
+function logSandboxError(err: SandboxError) {
+  sandboxErrors.value.push(err)
+
+  const tag = `[Sandbox ${err.type}]`
+  console.group(`%c${tag} ${err.message}`, 'color:#ef4444;font-weight:bold')
+  console.error('  消息:', err.message)
+  if (err.stack) console.error('  堆栈:', err.stack)
+  if (err.source) console.error('  来源:', err.source, `(${err.line}:${err.col})`)
+  console.error('  时间:', err.time)
+  console.error('  内容预览 (前 200 字符):', props.html.slice(0, 200))
+  console.groupEnd()
 }
 
 /** 构建 iframe 内完整 HTML 文档 */
@@ -174,7 +202,6 @@ const iframeContent = computed(() => {
     height: auto;
   }
 
-  /* 内联代码和图片等留边距 */
   .markdown-body > *:first-child { margin-top: 0; }
   .markdown-body > *:last-child  { margin-bottom: 0; }
 </style>
@@ -186,6 +213,88 @@ ${props.html}
 <script>
 (function() {
   'use strict';
+
+  /* ── 全局错误拦截器 ── */
+  var _origOnError = window.onerror;
+  window.onerror = function(msg, source, line, col, err) {
+    parent.postMessage({
+      type: 'sandbox-error',
+      payload: {
+        category: 'runtime',
+        message: msg,
+        source: source,
+        line: line,
+        col: col,
+        stack: err && err.stack ? err.stack : null,
+      }
+    }, '*');
+    if (typeof _origOnError === 'function') {
+      return _origOnError(msg, source, line, col, err);
+    }
+    return false;
+  };
+
+  window.addEventListener('error', function(e) {
+    // 不重复上报 window.onerror 已捕获的错误
+    if (e.error && e.error.stack) {
+      parent.postMessage({
+        type: 'sandbox-error',
+        payload: {
+          category: 'error-event',
+          message: e.message || String(e.error),
+          source: e.filename,
+          line: e.lineno,
+          col: e.colno,
+          stack: e.error && e.error.stack ? e.error.stack : null,
+        }
+      }, '*');
+    }
+    e.preventDefault();
+  });
+
+  window.addEventListener('unhandledrejection', function(e) {
+    var reason = e.reason || {};
+    parent.postMessage({
+      type: 'sandbox-error',
+      payload: {
+        category: 'unhandled-rejection',
+        message: typeof reason === 'string' ? reason : (reason.message || String(reason)),
+        stack: reason && reason.stack ? reason.stack : null,
+      }
+    }, '*');
+    e.preventDefault();
+  });
+
+  /* ── 拦截 document.write（LLM 输出后调用会清空文档） ── */
+  var _origWrite = document.write.bind(document);
+  var _origWriteln = document.writeln.bind(document);
+  document.write = function() {
+    var args = Array.prototype.slice.call(arguments);
+    var text = args.join('');
+    parent.postMessage({
+      type: 'sandbox-error',
+      payload: {
+        category: 'document-write',
+        message: 'document.write() 在文档加载完成后被调用（会清空页面内容）',
+        detail: text.slice(0, 200),
+      }
+    }, '*');
+    // 仍执行原 write 以防页面完全崩溃，但用户会在控制台看到警告
+    return _origWrite.apply(document, args);
+  };
+  document.writeln = function() {
+    var args = Array.prototype.slice.call(arguments);
+    parent.postMessage({
+      type: 'sandbox-error',
+      payload: {
+        category: 'document-write',
+        message: 'document.writeln() 在文档加载完成后被调用（会清空页面内容）',
+      }
+    }, '*');
+    return _origWriteln.apply(document, args);
+  };
+
+  /* ── 高度上报 ── */
   function reportHeight() {
     var h = Math.max(
       document.body.scrollHeight,
@@ -206,7 +315,6 @@ ${props.html}
     ro.observe(document.body);
     ro.observe(document.documentElement);
   }
-  // 兜底：动态内容可能延迟变化
   var delays = [100, 300, 800, 2000];
   delays.forEach(function(d) { setTimeout(reportHeight, d); });
 })();
@@ -215,12 +323,29 @@ ${props.html}
 </html>`
 })
 
-/** 窗口消息监听：处理 iframe 高度上报 */
+/** 窗口消息监听：处理 iframe 高度上报和错误上报 */
 function handleMessage(event: MessageEvent) {
   if (event.data?.type === 'sandbox-resize' && typeof event.data.height === 'number') {
     iframeHeight.value = event.data.height
+    return
+  }
+
+  if (event.data?.type === 'sandbox-error' && event.data?.payload) {
+    const p = event.data.payload
+    const now = new Date().toLocaleTimeString()
+    logSandboxError({
+      type: p.category || 'unknown',
+      message: p.message || '(无消息)',
+      stack: p.stack,
+      source: p.source,
+      line: p.line,
+      col: p.col,
+      time: now,
+    })
   }
 }
+
+let iframeErrorTimer: ReturnType<typeof setTimeout> | null = null
 
 function onIframeLoad() {
   iframeLoaded.value = true
@@ -232,6 +357,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener('message', handleMessage)
+  if (iframeErrorTimer) clearTimeout(iframeErrorTimer)
 })
 </script>
 
@@ -263,5 +389,21 @@ onUnmounted(() => {
 
 @keyframes sandbox-spin {
   to { transform: rotate(360deg); }
+}
+
+.sandbox-error-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  margin-bottom: 4px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  font-size: 12px;
+  color: #b91c1c;
+}
+.sandbox-error-icon {
+  font-size: 14px;
 }
 </style>

--- a/web/src/components/HtmlSandbox.vue
+++ b/web/src/components/HtmlSandbox.vue
@@ -1,0 +1,267 @@
+<template>
+  <div class="html-sandbox-container" ref="container">
+    <div v-if="!iframeLoaded" class="sandbox-loading">
+      <span class="sandbox-spinner"></span>
+      <!-- iframe 加载中 -->
+    </div>
+    <iframe
+      ref="iframeRef"
+      :srcdoc="iframeContent"
+      sandbox="allow-scripts allow-modals"
+      :style="{
+        width: '100%',
+        height: iframeHeight + 'px',
+        border: 'none',
+        display: 'block',
+        overflow: 'hidden',
+        visibility: iframeLoaded ? 'visible' : 'hidden',
+        position: iframeLoaded ? 'relative' : 'absolute',
+      }"
+      title="sandboxed-content"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+
+const props = withDefaults(defineProps<{
+  html: string
+}>(), {})
+
+const container = ref<HTMLElement | null>(null)
+const iframeRef = ref<HTMLIFrameElement | null>(null)
+const iframeHeight = ref(200)
+const iframeLoaded = ref(false)
+
+/** 从当前文档根元素提取 CSS 自定义属性，传给 iframe 以保持主题一致 */
+function getThemeCssVars(): string[] {
+  const style = getComputedStyle(document.documentElement)
+  const names = [
+    '--bg-primary', '--bg-secondary', '--bg-card',
+    '--text-primary', '--text-secondary', '--text-tertiary',
+    '--accent', '--accent-light', '--border',
+    '--user-bubble',
+    '--status-ok', '--status-error', '--status-warn',
+    '--shadow', '--radius',
+  ]
+  return names.map(n => `${n}: ${style.getPropertyValue(n).trim()};`)
+}
+
+/** 构建 iframe 内完整 HTML 文档 */
+const iframeContent = computed(() => {
+  const vars = getThemeCssVars()
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+  :root {
+    ${vars.join('\n    ')}
+  }
+  *,
+  *::before,
+  *::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+  html {
+    height: 100%;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC',
+      'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--text-primary, #1f2937);
+    background: transparent;
+    padding: 0;
+    min-height: 40px;
+    word-break: break-word;
+    overflow-x: hidden;
+  }
+
+  /* ── Markdown 样式 ── */
+  h1, h2, h3, h4, h5, h6 {
+    margin: 16px 0 8px;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+  h1 { font-size: 1.5em; }
+  h2 { font-size: 1.3em; }
+  h3 { font-size: 1.15em; }
+  h4 { font-size: 1em; }
+  h5 { font-size: 0.9em; }
+  h6 { font-size: 0.85em; color: var(--text-secondary); }
+
+  p { margin: 8px 0; }
+  ul, ol { padding-left: 20px; margin: 8px 0; }
+  li { margin: 4px 0; }
+
+  code {
+    background: var(--bg-primary);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    font-family: 'SF Mono', 'Consolas', monospace;
+  }
+  pre {
+    background: var(--bg-primary);
+    padding: 12px;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 8px 0;
+  }
+  pre code {
+    background: none;
+    padding: 0;
+    border-radius: 0;
+    font-size: 13px;
+  }
+
+  blockquote {
+    border-left: 3px solid var(--accent);
+    padding: 4px 12px;
+    margin: 8px 0;
+    color: var(--text-secondary);
+  }
+
+  table {
+    border-collapse: collapse;
+    margin: 8px 0;
+    width: 100%;
+  }
+  th, td {
+    border: 1px solid var(--border);
+    padding: 6px 12px;
+    text-align: left;
+  }
+  th {
+    background: var(--bg-secondary);
+    font-weight: 600;
+  }
+
+  a {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+  a:hover { opacity: 0.8; }
+
+  strong { font-weight: 600; }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 16px 0;
+  }
+
+  img {
+    max-width: 100%;
+    border-radius: 8px;
+    height: auto;
+  }
+
+  input[type="checkbox"] {
+    margin-right: 6px;
+    accent-color: var(--accent);
+  }
+
+  /* 响应式媒体 */
+  video, canvas, svg {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* 内联代码和图片等留边距 */
+  .markdown-body > *:first-child { margin-top: 0; }
+  .markdown-body > *:last-child  { margin-bottom: 0; }
+</style>
+</head>
+<body>
+<div class="markdown-body">
+${props.html}
+</div>
+<script>
+(function() {
+  'use strict';
+  function reportHeight() {
+    var h = Math.max(
+      document.body.scrollHeight,
+      document.body.offsetHeight,
+      document.documentElement.scrollHeight,
+      document.documentElement.offsetHeight
+    );
+    if (h < 40) h = 40;
+    parent.postMessage({ type: 'sandbox-resize', height: h }, '*');
+  }
+  if (document.readyState === 'complete') {
+    reportHeight();
+  } else {
+    window.addEventListener('load', reportHeight);
+  }
+  if (window.ResizeObserver) {
+    var ro = new ResizeObserver(reportHeight);
+    ro.observe(document.body);
+    ro.observe(document.documentElement);
+  }
+  // 兜底：动态内容可能延迟变化
+  var delays = [100, 300, 800, 2000];
+  delays.forEach(function(d) { setTimeout(reportHeight, d); });
+})();
+<\/script>
+</body>
+</html>`
+})
+
+/** 窗口消息监听：处理 iframe 高度上报 */
+function handleMessage(event: MessageEvent) {
+  if (event.data?.type === 'sandbox-resize' && typeof event.data.height === 'number') {
+    iframeHeight.value = event.data.height
+  }
+}
+
+function onIframeLoad() {
+  iframeLoaded.value = true
+}
+
+onMounted(() => {
+  window.addEventListener('message', handleMessage)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('message', handleMessage)
+})
+</script>
+
+<style scoped>
+.html-sandbox-container {
+  position: relative;
+  width: 100%;
+  min-height: 40px;
+}
+
+.sandbox-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.sandbox-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: sandbox-spin 0.8s linear infinite;
+}
+
+@keyframes sandbox-spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/web/src/components/MemoryPanel.vue
+++ b/web/src/components/MemoryPanel.vue
@@ -33,7 +33,9 @@
         <div v-if="loading && !narrative" class="memory-loading">
           加载中……
         </div>
-        <div v-else-if="narrative" class="markdown-body" v-html="rendered"></div>
+        <div v-else-if="narrative">
+          <RenderMarkdown :content="narrative" />
+        </div>
         <div v-else class="memory-empty">
           暂无记忆叙事。开始一段对话后，AI 会自动生成关于你的记忆。
         </div>
@@ -43,12 +45,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
-import { renderMarkdown } from '@/utils/markdown'
+import { ref, onMounted } from 'vue'
 import { api } from '@/api'
 import type { VignetteSection } from '@/types'
 import MomentCard from '@/components/MomentCard.vue'
 import SectionCard from '@/components/SectionCard.vue'
+import RenderMarkdown from '@/components/RenderMarkdown.vue'
 
 /** 可通过开发者工具切换为 false 回退到 Markdown 渲染 */
 const useVignette = ref(true)
@@ -56,10 +58,6 @@ const useVignette = ref(true)
 const narrative = ref('')
 const sections = ref<VignetteSection[]>([])
 const loading = ref(false)
-
-const rendered = computed(() => {
-  return renderMarkdown(narrative.value)
-})
 
 async function refresh() {
   loading.value = true

--- a/web/src/components/MessageBubble.vue
+++ b/web/src/components/MessageBubble.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="message-row" :class="role">
     <div class="bubble" :class="role">
-      <div v-if="content" class="markdown-body" v-html="rendered"></div>
+      <RenderMarkdown v-if="content" :content="content" />
       <div v-if="refs?.length" class="ref-chips">
         <ReferenceChip
           v-for="(r, idx) in refs"
@@ -14,14 +14,11 @@
 </template>
 
 <script setup lang="ts">
-import { renderMarkdown } from '@/utils/markdown';
 import type { ParsedRef } from '@/utils/references';
-import { computed } from 'vue';
 import ReferenceChip from './ReferenceChip.vue';
+import RenderMarkdown from './RenderMarkdown.vue';
 
 const props = defineProps<{ role: 'user' | 'assistant'; content: string; refs?: ParsedRef[] }>()
-
-const rendered = computed(() => renderMarkdown(props.content))
 </script>
 
 <style scoped>

--- a/web/src/components/RenderMarkdown.vue
+++ b/web/src/components/RenderMarkdown.vue
@@ -13,13 +13,17 @@ const props = withDefaults(defineProps<{
   content: string
   /** 强制使用 sandbox 渲染（即使检测不到 script 标签） */
   forceSandbox?: boolean
+  /** 处于流式接收中时禁用沙箱，避免 iframe 因内容频繁变化而不断重载 */
+  streaming?: boolean
 }>(), {
   forceSandbox: false,
+  streaming: false,
 })
 
 const renderedHtml = computed(() => renderMarkdown(props.content))
 
 const useSandbox = computed(() => {
+  if (props.streaming) return false
   if (!props.content) return false
   if (props.forceSandbox) return true
   return contentNeedsIsolation(props.content)

--- a/web/src/components/RenderMarkdown.vue
+++ b/web/src/components/RenderMarkdown.vue
@@ -4,7 +4,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onUnmounted } from 'vue'
 import { renderMarkdown, contentNeedsIsolation } from '@/utils/markdown'
 import HtmlSandbox from './HtmlSandbox.vue'
 
@@ -20,12 +20,30 @@ const props = withDefaults(defineProps<{
   streaming: false,
 })
 
-const renderedHtml = computed(() => renderMarkdown(props.content))
+let renderErrorCount = 0
+
+const renderedHtml = computed(() => {
+  try {
+    const result = renderMarkdown(props.content)
+    return result
+  } catch (e) {
+    renderErrorCount++
+    const msg = e instanceof Error ? e.message : String(e)
+    console.error(`[RenderMarkdown] marked.parse 错误 (第 ${renderErrorCount} 次):`, msg)
+    console.error('  内容预览:', props.content.slice(0, 200))
+    return `<p style="color:var(--status-error)">⚠ Markdown 渲染错误: ${msg}</p>`
+  }
+})
 
 const useSandbox = computed(() => {
   if (props.streaming) return false
   if (!props.content) return false
   if (props.forceSandbox) return true
-  return contentNeedsIsolation(props.content)
+  try {
+    return contentNeedsIsolation(props.content)
+  } catch (e) {
+    console.error('[RenderMarkdown] contentNeedsIsolation 检测异常:', e)
+    return false // 降级：不启用沙箱
+  }
 })
 </script>

--- a/web/src/components/RenderMarkdown.vue
+++ b/web/src/components/RenderMarkdown.vue
@@ -1,0 +1,27 @@
+<template>
+  <HtmlSandbox v-if="useSandbox" :html="renderedHtml" />
+  <div v-else class="markdown-body" v-html="renderedHtml"></div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { renderMarkdown, contentNeedsIsolation } from '@/utils/markdown'
+import HtmlSandbox from './HtmlSandbox.vue'
+
+const props = withDefaults(defineProps<{
+  /** 原始 Markdown 文本 */
+  content: string
+  /** 强制使用 sandbox 渲染（即使检测不到 script 标签） */
+  forceSandbox?: boolean
+}>(), {
+  forceSandbox: false,
+})
+
+const renderedHtml = computed(() => renderMarkdown(props.content))
+
+const useSandbox = computed(() => {
+  if (!props.content) return false
+  if (props.forceSandbox) return true
+  return contentNeedsIsolation(props.content)
+})
+</script>

--- a/web/src/components/ThinkingBlock.vue
+++ b/web/src/components/ThinkingBlock.vue
@@ -8,7 +8,7 @@
     </div>
     <div class="thinking-body" v-if="block.tokens">
       <div class="thinking-content">
-        <RenderMarkdown :content="block.tokens" />
+        <RenderMarkdown :content="block.tokens" :streaming="!block.done" />
       </div>
     </div>
   </div>

--- a/web/src/components/ThinkingBlock.vue
+++ b/web/src/components/ThinkingBlock.vue
@@ -7,19 +7,18 @@
       </span>
     </div>
     <div class="thinking-body" v-if="block.tokens">
-      <div class="thinking-content markdown-body" v-html="renderedTokens"></div>
+      <div class="thinking-content">
+        <RenderMarkdown :content="block.tokens" />
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { ThinkingBlock as ThinkingBlockType } from '@/types'
-import { renderMarkdown } from '@/utils/markdown'
+import RenderMarkdown from './RenderMarkdown.vue'
 
 const props = defineProps<{ block: ThinkingBlockType }>()
-
-const renderedTokens = computed(() => renderMarkdown(props.block.tokens))
 </script>
 
 <style scoped>

--- a/web/src/components/ToolCallCard.vue
+++ b/web/src/components/ToolCallCard.vue
@@ -25,7 +25,7 @@
               </div>
             </div>
           </template>
-          <div v-if="inputDisplay.type === 'markdown'" class="markdown-body" v-html="inputDisplay.html"></div>
+          <RenderMarkdown v-if="inputDisplay.type === 'markdown'" :content="toolCall.input" />
         </div>
 
         <!-- 结果 section -->
@@ -41,7 +41,7 @@
             </div>
           </template>
           <pre v-else-if="outputDisplay.type === 'code'" class="code-block">{{ outputDisplay.raw }}</pre>
-          <div v-if="outputDisplay.type === 'markdown'" class="markdown-body" v-html="outputDisplay.html"></div>
+          <RenderMarkdown v-if="outputDisplay.type === 'markdown'" :content="toolCall.output || ''" />
         </div>
       </div>
     </div>
@@ -51,7 +51,7 @@
 <script setup lang="ts">
 import { ref, watch, nextTick, computed } from 'vue'
 import type { ToolCall } from '@/types'
-import { renderMarkdown } from '@/utils/markdown'
+import RenderMarkdown from './RenderMarkdown.vue'
 
 const props = defineProps<{ toolCall: ToolCall }>()
 
@@ -80,7 +80,6 @@ interface CodeDisplay {
 
 interface MarkdownDisplay {
   type: 'markdown'
-  html: string
 }
 
 type SectionDisplay = KvDisplay | CodeDisplay | MarkdownDisplay
@@ -126,12 +125,12 @@ function detectCodeDisplay(raw: string): CodeDisplay {
 const inputDisplay = computed<SectionDisplay>(() => {
   const kv = parseJsonKv(props.toolCall.input)
   if (kv) return kv
-  return { type: 'markdown', html: renderMarkdown(props.toolCall.input) }
+  return { type: 'markdown' }
 })
 
 const outputDisplay = computed<SectionDisplay>(() => {
   if (!props.toolCall.output) {
-    return { type: 'markdown', html: '' }
+    return { type: 'markdown' }
   }
   const kv = parseJsonKv(props.toolCall.output)
   if (kv) return kv

--- a/web/src/components/tools/ImageBubble.vue
+++ b/web/src/components/tools/ImageBubble.vue
@@ -14,7 +14,7 @@
     <template v-else-if="toolCall.status === 'done'">
       <div v-if="hasData" class="image-result">
         <div class="image-content" v-if="response">
-          <div class="markdown-body" v-html="rendered"></div>
+          <RenderMarkdown :content="response" />
         </div>
       </div>
 
@@ -28,11 +28,10 @@
 import { computed } from 'vue'
 import type { ToolCall } from '@/types'
 import BubbleChrome from './_shared/BubbleChrome.vue'
+import RenderMarkdown from '@/components/RenderMarkdown.vue'
 
 const props = defineProps<{ toolCall: ToolCall }>()
 const emit = defineEmits<{ (e: 'action', p: { action: string; data?: unknown }): void }>()
-
-import { renderMarkdown } from '@/utils/markdown'
 
 const td = computed<Record<string, any>>(() => {
   if (props.toolCall.toolData) return props.toolCall.toolData as Record<string, any>
@@ -47,7 +46,6 @@ const td = computed<Record<string, any>>(() => {
 
 const hasData = computed(() => Object.keys(td.value).length > 0)
 const response = computed(() => td.value.response || '')
-const rendered = computed(() => renderMarkdown(response.value))
 
 const displayOutput = computed(() => {
   if (props.toolCall.output) {

--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -11,3 +11,46 @@ export function renderMarkdown(content: string): string {
   if (!content) return ''
   return marked.parse(content) as string
 }
+
+/**
+ * 检测 Markdown 原文是否包含需要沙箱隔离的原始 HTML/JS/CSS。
+ * 跳过围栏代码块内的内容，避免误判示例代码。
+ *
+ * 触发隔离的条件：
+ * - `<script>` — JS 脚本（v-html 不执行，iframe 才执行）
+ * - `<style>` / `<link rel="stylesheet">` — 全局 CSS（泄漏到气泡外部）
+ * - `onXxx="..."` — 内联事件处理器
+ * - `href="javascript:..."` — 伪协议 URL
+ * - `<iframe>` — 嵌入式框架
+ */
+export function contentNeedsIsolation(markdown: string): boolean {
+  if (!markdown) return false
+  let inCodeBlock = false
+  const lines = markdown.split('\n')
+  for (const line of lines) {
+    const trimmed = line.trimStart()
+    // 切换围栏代码块状态
+    if (trimmed.startsWith('```')) {
+      inCodeBlock = !inCodeBlock
+      continue
+    }
+    if (inCodeBlock) continue
+
+    // 检查原始 <script> 标签
+    if (/<script[\s>/]/i.test(line) || /<\/script>/i.test(line)) return true
+    // 检查原始 <style> 标签（全局 CSS 泄漏）
+    if (/<style[\s>/]/i.test(line) || /<\/style>/i.test(line)) return true
+    // 检查 <link rel="stylesheet">（全局 CSS 泄漏）
+    if (/<link[\s>]/i.test(line) && /rel\s*=\s*["']stylesheet["']/i.test(line)) return true
+    // 检查内联事件处理器 onXxx="..."
+    if (/\son\w+\s*=\s*["']/i.test(line)) return true
+    // 检查 javascript: URL
+    if (/href\s*=\s*["']\s*javascript:/i.test(line)) return true
+    // 检查 <iframe> 嵌入
+    if (/<iframe[\s>/]/i.test(line)) return true
+  }
+  return false
+}
+
+/** @deprecated 使用 contentNeedsIsolation */
+export const contentHasScripts = contentNeedsIsolation


### PR DESCRIPTION
## 概述

LLM 输出的 HTML/CSS 可通过 Vue v-html 渲染，但 **\<script\> 不执行、\<style\> 全局泄漏**。本 PR 引入 iframe 沙箱渲染系统，让 LLM 可以直接输出交互式 HTML/JS/CSS 内容。

## 新增组件

### HtmlSandbox.vue
- `<iframe srcdoc>` + `sandbox="allow-scripts allow-modals"` 隔离执行
- 自动继承宿主页面 14 个 CSS 自定义属性，主题一致
- ResizeObserver + postMessage 自动适配高度
- **错误诊断**：拦截 `document.write`、`window.onerror`、未捕获 rejection，全部上报父窗口控制台

### RenderMarkdown.vue
- 智能分发：检测 `<script>`/`<style>` → 走沙箱，否则零开销内联
- `streaming` prop：流式期间禁用沙箱，避免 token 级 iframe 重载
- marked.parse 异常兜底

### contentNeedsIsolation() 检测器
- 逐行扫描，跳过围栏代码块内内容
- 检测 `<script>`、`<style>`、事件处理器、`javascript:` URL、`<iframe>`

## 修复

1. **document.write 导致内容消失** — LLM 输出的 JS 中常见此模式，加载后调用会清空文档。已拦截并上报控制台警告。
2. **流式 iframe 不断重载** — token 逐个追加导致 srcdoc 逐次变化。流式期间走内联渲染，完成后才启用沙箱。
3. **轮次过渡组件重建** — done 事件触发时 iframe 销毁重建。ChatWindow 合并渲染列表，`turn.id` 做 key 复用组件实例。

## Agent 文档

AGENTS.md 新增「前端设计原则」章节，教导 Agent：
- HTML 效果必须输出在代码块外才能触发渲染
- 设计令牌表（`--bg-primary`、`--accent` 等 8 个核心令牌）
- 排版规范、布局参考、沙箱限制