### PR TITLE
固定会话（Const Session）本地持久化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ Thumbs.db
 # Claude Code
 .claude/
 
+# 用户固定会话（Const Session）持久化数据
+api/data/const-sessions/
+
 # Project specific
 botpy.log
 *.dll

--- a/api/const_session_store.py
+++ b/api/const_session_store.py
@@ -1,0 +1,127 @@
+"""Const 固定会话 — YAML 持久化存储。
+
+提供将会话状态（元数据 + 对话消息）序列化为 YAML 文件并重新加载的能力。
+"""
+
+import time
+from pathlib import Path
+
+import yaml
+
+# api/const_session_store.py → api/data/const-sessions/
+_CONST_DIR = Path(__file__).resolve().parent / "data" / "const-sessions"
+
+
+def _ensure_dir() -> Path:
+    _CONST_DIR.mkdir(parents=True, exist_ok=True)
+    return _CONST_DIR
+
+
+# ── 消息序列化 ─────────────────────────────────────────────────
+
+
+def serialize_messages(raw_messages: list) -> list[dict]:
+    """将 LangChain BaseMessage 对象列表转为可序列化的纯 dict 列表。"""
+    result = []
+    for msg in raw_messages:
+        entry: dict = {
+            "type": getattr(msg, "type", "unknown"),
+            "content": msg.content if hasattr(msg, "content") else str(msg),
+        }
+        if hasattr(msg, "tool_call_id") and msg.tool_call_id:
+            entry["tool_call_id"] = msg.tool_call_id
+        if hasattr(msg, "name") and msg.name:
+            entry["name"] = msg.name
+        if hasattr(msg, "tool_calls") and msg.tool_calls:
+            entry["tool_calls"] = msg.tool_calls
+        if hasattr(msg, "additional_kwargs") and msg.additional_kwargs:
+            entry["additional_kwargs"] = msg.additional_kwargs
+        result.append(entry)
+    return result
+
+
+def deserialize_messages(data: list[dict]) -> list:
+    """将纯 dict 列表重建为 LangChain BaseMessage 对象。"""
+    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+    reconstructed = []
+    for m in data:
+        msg_type = m.get("type", "human")
+        content = m.get("content", "")
+        match msg_type:
+            case "human":
+                reconstructed.append(HumanMessage(content=content))
+            case "ai":
+                kwargs: dict = {"content": content}
+                if "tool_calls" in m:
+                    kwargs["tool_calls"] = m["tool_calls"]
+                if "additional_kwargs" in m:
+                    kwargs["additional_kwargs"] = m["additional_kwargs"]
+                reconstructed.append(AIMessage(**kwargs))
+            case "tool":
+                reconstructed.append(ToolMessage(
+                    content=content,
+                    tool_call_id=m.get("tool_call_id", ""),
+                    name=m.get("name", ""),
+                ))
+            case _:
+                # fallback: treat as human message
+                reconstructed.append(HumanMessage(content=content))
+    return reconstructed
+
+
+# ── 文件 I/O ──────────────────────────────────────────────────
+
+
+def save_const_session(
+    session_id: str,
+    const_name: str,
+    metadata: dict,
+    messages: list[dict],
+) -> str:
+    """将会话持久化为 YAML 文件。
+
+    Returns:
+        写入的文件路径。
+    """
+    ensure_dir = _ensure_dir()
+    data = {
+        "session_id": session_id,
+        "const_name": const_name,
+        "const_saved_at": time.time(),
+        "metadata": metadata,
+        "messages": messages,
+    }
+    filepath = ensure_dir / f"{session_id}.yaml"
+    with open(filepath, "w", encoding="utf-8") as f:
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+    return str(filepath)
+
+
+def load_const_session(filepath: Path) -> dict | None:
+    """加载单个 const 会话 YAML 文件。"""
+    try:
+        with open(filepath, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception:
+        return None
+
+
+def load_all_const_sessions() -> list[dict]:
+    """扫描 const-sessions/ 目录，加载所有 YAML。"""
+    ensure_dir = _ensure_dir()
+    sessions = []
+    for fpath in sorted(ensure_dir.glob("*.yaml")):
+        data = load_const_session(fpath)
+        if data and data.get("session_id"):
+            sessions.append(data)
+    return sessions
+
+
+def delete_const_session(session_id: str) -> bool:
+    """删除 const 会话文件。"""
+    filepath = _CONST_DIR / f"{session_id}.yaml"
+    if filepath.exists():
+        filepath.unlink()
+        return True
+    return False

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -1,4 +1,12 @@
 news:
+  - id: "const-session"
+    title: "固定会话功能上线"
+    description: "新增会话固定功能。右键会话即可将重要对话持久化保存为固定会话，重启后自动恢复。内置 AI 标题生成，一键为对话生成凝练标题。固定会话在侧边栏独立分区展示，与临时会话清晰区分。"
+    type: "feat"
+    date: "2026-06-14"
+    tags: ["会话", "持久化", "固定"]
+    version: "PREVIEW"
+    pr_number: 102
   - id: "llm-html-sandbox"
     en_title: "LLM HTML Sandbox"
     title: "LLM HTML 沙箱渲染支持"

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -12,6 +12,7 @@ from agent.graph import build_agent
 from agent.prompts import build_system_prompt
 from api import interaction
 from api.callbacks.websocket_callback import WebSocketCallback
+from api.const_session_store import save_const_session, serialize_messages
 from api.context_usage import estimate_context_usage
 from api.session_manager import SessionState
 from config.settings import get_settings
@@ -279,7 +280,24 @@ async def _run_agent_turn(
             {"role": "assistant", "content": final_answer},
         ])
 
-    # 4. [Sub-agent] 如果有待处理的 pending_result，resolve 它
+    # 4. [Const 会话] 自动持久化到磁盘 YAML
+    if final_answer and session.is_const:
+        try:
+            cpt = await session.checkpointer.aget_tuple(
+                {"configurable": {"thread_id": session.session_id}}
+            )
+            raw_messages = cpt.checkpoint.get("channel_values", {}).get("messages", []) if cpt else []
+            metadata = {
+                "created_at": session.created_at,
+                "last_active": session.last_active,
+                "message_count": session.message_count,
+            }
+            serialized = serialize_messages(raw_messages)
+            save_const_session(session.session_id, session.const_name, metadata, serialized)
+        except Exception as e:
+            print(f"[const] 自动保存会话 {session.session_id[:8]} 失败: {e}", file=sys.stderr)
+
+    # 5. [Sub-agent] 如果有待处理的 pending_result，resolve 它
     if session._pending_result is not None and not session._pending_result.done():
         if _run_error:
             print(f"[sub-agent:{session.session_id[:8]}] resolving pending_result with run error", file=sys.stderr)

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -1,11 +1,16 @@
-"""REST API — 会话 CRUD。"""
+"""REST API — 会话 CRUD + Const 固定会话。"""
 
 from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
 
 from api.context_usage import estimate_context_usage
 from config.settings import get_settings
 
 router = APIRouter()
+
+
+class ConstifyRequest(BaseModel):
+    name: str
 
 
 @router.post("/sessions")
@@ -32,6 +37,8 @@ async def get_session(session_id: str, request: Request):
         "message_count": session.message_count,
         "created_at": session.created_at,
         "has_active_agent": session._active_task is not None and not session._active_task.done(),
+        "is_const": session.is_const,
+        "const_name": session.const_name,
     }
 
 
@@ -42,10 +49,10 @@ async def get_messages(session_id: str, request: Request):
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
     try:
-        state = await session.checkpointer.aget_state(
+        cpt = await session.checkpointer.aget_tuple(
             {"configurable": {"thread_id": session.session_id}}
         )
-        msgs = state.values.get("messages", [])
+        msgs = cpt.checkpoint.get("channel_values", {}).get("messages", []) if cpt else []
     except Exception:
         msgs = []
     return {"session_id": session_id, "messages": [{"role": m.type, "content": m.content} for m in msgs]}
@@ -78,10 +85,10 @@ async def get_context_usage(session_id: str, request: Request):
     settings = get_settings()
     system_prompt = request.app.state.system_prompt
     try:
-        state = await session.checkpointer.aget_state(
+        cpt = await session.checkpointer.aget_tuple(
             {"configurable": {"thread_id": session.session_id}}
         )
-        counting_messages = state.values.get("messages", [])
+        counting_messages = cpt.checkpoint.get("channel_values", {}).get("messages", []) if cpt else []
     except Exception:
         counting_messages = []
     usage = estimate_context_usage(
@@ -97,6 +104,73 @@ async def get_context_usage(session_id: str, request: Request):
 @router.delete("/sessions/{session_id}")
 async def delete_session(session_id: str, request: Request):
     sm = request.app.state.session_manager
+    session = sm.get(session_id)
+
+    # 若为 const 会话，先清理磁盘文件
+    if session is not None and session.is_const:
+        from api.const_session_store import delete_const_session
+        delete_const_session(session_id)
+
     if not sm.delete(session_id):
         raise HTTPException(status_code=404, detail="Session not found")
     return {"status": "deleted"}
+
+
+# ── Const 固定会话 ────────────────────────────────────────────
+
+
+@router.post("/sessions/{session_id}/const")
+async def constify_session(session_id: str, body: ConstifyRequest, request: Request):
+    """将当前会话固定为 const 持久化保存。"""
+    sm = request.app.state.session_manager
+    session = sm.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Agent 运行中禁止固定
+    if session._active_task is not None and not session._active_task.done():
+        raise HTTPException(status_code=409, detail="Agent 仍在运行中，无法固定会话")
+
+    # 从 checkpointer 提取消息
+    try:
+        cpt = await session.checkpointer.aget_tuple(
+            {"configurable": {"thread_id": session.session_id}}
+        )
+        raw_messages = cpt.checkpoint.get("channel_values", {}).get("messages", []) if cpt else []
+    except Exception:
+        raw_messages = []
+
+    from api.const_session_store import save_const_session, serialize_messages
+
+    metadata = {
+        "created_at": session.created_at,
+        "last_active": session.last_active,
+        "message_count": session.message_count,
+    }
+    serialized = serialize_messages(raw_messages)
+    save_const_session(session.session_id, body.name, metadata, serialized)
+
+    # 标记为 const
+    session.is_const = True
+    session.const_name = body.name
+
+    return {
+        "session_id": session.session_id,
+        "is_const": True,
+        "const_name": body.name,
+    }
+
+
+@router.delete("/sessions/{session_id}/const")
+async def unconstify_session(session_id: str, request: Request):
+    """取消固定，删除磁盘文件。"""
+    from api.const_session_store import delete_const_session
+    delete_const_session(session_id)
+
+    sm = request.app.state.session_manager
+    session = sm.get(session_id)
+    if session is not None:
+        session.is_const = False
+        session.const_name = ""
+
+    return {"status": "ok"}

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -161,6 +161,64 @@ async def constify_session(session_id: str, body: ConstifyRequest, request: Requ
     }
 
 
+@router.post("/sessions/{session_id}/generate-title")
+async def generate_session_title(session_id: str, request: Request):
+    """根据会话内容使用 LLM 生成简洁标题。"""
+    sm = request.app.state.session_manager
+    session = sm.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # 从 checkpointer 提取消息
+    try:
+        cpt = await session.checkpointer.aget_tuple(
+            {"configurable": {"thread_id": session.session_id}}
+        )
+        messages = cpt.checkpoint.get("channel_values", {}).get("messages", []) if cpt else []
+    except Exception:
+        messages = []
+
+    if not messages:
+        raise HTTPException(status_code=400, detail="没有消息可供生成标题")
+
+    # 构建对话文本（仅 human/ai，截断长内容）
+    conversation_lines = []
+    for m in messages:
+        role = "user" if m.type == "human" else "assistant"
+        content = (m.content[:600] if hasattr(m, "content") else str(m))[:600]
+        conversation_lines.append(f"[{role}]\n{content}")
+    conversation_text = "\n\n".join(conversation_lines)
+
+    system_prompt = """你是一个对话标题生成器。根据用户和助理的对话内容，生成一个简短的标题。
+
+## 规则（必须严格遵守）
+
+1. **忠实概括**：标题必须基于对话的实际内容，不能捏造或偏离用户真实提出的问题或主题。这是最根本的原则。
+2. **核心主题**：准确抓住整个对话中最主要、最核心的主题或意图。如果用户问了多个问题，优先选择覆盖最广或最重要的那个。
+3. **简洁凝练**：标题通常很短，一般为5-10个字，力求用最少的词概括最多信息。剔除冗余词语，保留关键词。
+4. **区分度**：生成的标题应能明显区别于用户历史对话中的其他标题，便于快速定位和识别不同对话。
+5. **通用可读**：不使用具体的"您"、"我"等指代词，也不包含"对话关于…"这样的描述性前缀。标题本身是名词性短语，直接陈述主题（如"Python爬虫入门"）。
+6. **中性客观**：不添加情感色彩或主观评价（如不写成"令人困惑的数学问题"），也不使用指令式语气（如"请总结这个对话"）。
+
+## 输出格式
+
+只输出标题本身，不要有任何额外文字、引号或标点符号。"""
+
+    prompt = f"{system_prompt}\n\n对话内容：\n{conversation_text}\n\n标题："
+
+    try:
+        llm = request.app.state.llm
+        response = await llm.ainvoke(prompt)
+        title = response.content.strip().strip('"').strip("'") if hasattr(response, "content") else str(response).strip()
+        title = title[:50]
+        if not title:
+            title = "未命名会话"
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"标题生成失败: {e}")
+
+    return {"title": title}
+
+
 @router.delete("/sessions/{session_id}/const")
 async def unconstify_session(session_id: str, request: Request):
     """取消固定，删除磁盘文件。"""

--- a/api/server.py
+++ b/api/server.py
@@ -8,6 +8,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
+import time
+
+from api.const_session_store import (
+    deserialize_messages,
+    load_all_const_sessions,
+)
 from api.dependencies import get_llm, get_system_prompt, get_tools
 from api.health import get_health_report
 from api.providers.manager import ProviderManager
@@ -15,12 +21,66 @@ from api.providers.store import ProviderConfigStore
 from api.routes import chat, files, memory, sessions, balance, providers
 from api.routes import skills as skills_router
 from api.routes import news as news_router
-from api.session_manager import SessionManager
+from api.session_manager import SessionManager, SessionState
+from agent.graph import build_agent
 from memory.narrative import MEMORY_PATH, LongTermMemoryInterface
 from skills.mcp import init_mcp_tools, close_mcp
 from version import __version__
 
 WEB_DIR = Path(__file__).resolve().parent.parent / "web" / "dist"
+
+
+async def _load_const_sessions(app: FastAPI):
+    """从 YAML 重建所有 const 固定会话到内存 SessionManager。"""
+    sm = app.state.session_manager
+    const_list = load_all_const_sessions()
+    if not const_list:
+        return
+
+    from langgraph.checkpoint.memory import MemorySaver
+
+    loaded = 0
+    for const_data in const_list:
+        sid = const_data.get("session_id")
+        if not sid or sid in sm._sessions:
+            continue
+
+        metadata = const_data.get("metadata", {})
+        const_name = const_data.get("const_name", "")
+        messages = const_data.get("messages", [])
+
+        # 重建 checkpointer
+        try:
+            reconstructed = deserialize_messages(messages)
+            checkpointer = MemorySaver()
+            if reconstructed:
+                agent = build_agent(
+                    model=app.state.llm,
+                    tools=app.state.tools,
+                    system_prompt=app.state.system_prompt,
+                    checkpointer=checkpointer,
+                )
+                await agent.aupdate_state(
+                    {"configurable": {"thread_id": sid}},
+                    {"messages": reconstructed},
+                )
+        except Exception as e:
+            print(f"[const] 重建会话 {sid} 失败: {e}")
+            continue
+
+        session = SessionState(
+            session_id=sid,
+            created_at=metadata.get("created_at", time.time()),
+            last_active=metadata.get("last_active", time.time()),
+            message_count=metadata.get("message_count", 0),
+            checkpointer=checkpointer,
+            is_const=True,
+            const_name=const_name,
+        )
+        sm._sessions[sid] = session
+        loaded += 1
+
+    print(f"[const] 已加载 {loaded}/{len(const_list)} 个固定会话")
 
 
 @asynccontextmanager
@@ -43,6 +103,9 @@ async def lifespan(app: FastAPI):
     app.state.session_manager = SessionManager()
     app.state.ltm = LongTermMemoryInterface(MEMORY_PATH)
     app.state.ltm.start_listening(app.state.llm)
+
+    # 加载 const 固定会话（从 YAML 重建内存会话）
+    await _load_const_sessions(app)
 
     # 加载 MCP 工具（Word 文档编辑能力）
     app.state.mcp_tools = await init_mcp_tools()

--- a/api/session_manager.py
+++ b/api/session_manager.py
@@ -26,6 +26,10 @@ class SessionState:
     _sub_agent_task: str | None = field(default=None, repr=False)
     _pending_result: asyncio.Future | None = field(default=None, repr=False)
 
+    # ── Const 固定会话字段 ──────────────────────────────────
+    is_const: bool = False
+    const_name: str = ""
+
 
 class SessionManager:
     def __init__(self, ttl_seconds: int = 1800):
@@ -89,6 +93,8 @@ class SessionManager:
                 "last_active": s.last_active,
                 "has_active_agent": has_active,
                 "is_subagent": s.is_subagent,
+                "is_const": s.is_const,
+                "const_name": s.const_name,
             })
         result.sort(key=lambda x: x["last_active"], reverse=True)
         return result

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -27,6 +27,8 @@
         @create="createSession"
         @switch="handleSwitchSession"
         @delete="deleteSession"
+        @constify="handleConstify"
+        @unconstify="handleUnconstify"
       />
       <HealthPanel :health="health!" v-if="health" />
     </aside>
@@ -42,7 +44,7 @@ import Icon from '@/components/Icon.vue';
 import SessionSidebar from '@/components/SessionSidebar.vue';
 import { allSessionStatuses } from '@/composables/useChat';
 import { health, startPolling, useHealth } from '@/composables/useHealth';
-import { useSession } from '@/composables/useSession';
+import { constifySession, unconstifySession, useSession } from '@/composables/useSession';
 import { useSidebar } from '@/composables/useSidebar';
 import { onMounted } from 'vue';
 import { useRouter } from 'vue-router';
@@ -60,6 +62,19 @@ const router = useRouter()
 function handleSwitchSession(id: string) {
   switchSession(id)
   router.push('/')
+}
+
+function handleConstify(id: string) {
+  const name = window.prompt('请输入会话名称：', '')
+  if (name && name.trim()) {
+    constifySession(id, name.trim())
+  }
+}
+
+function handleUnconstify(id: string) {
+  if (window.confirm('确定取消固定此会话？')) {
+    unconstifySession(id)
+  }
 }
 
 const { sessionId, sessions, createSession, switchSession, deleteSession } =

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -64,8 +64,7 @@ function handleSwitchSession(id: string) {
   router.push('/')
 }
 
-function handleConstify(id: string) {
-  const name = window.prompt('请输入会话名称：', '')
+function handleConstify(id: string, name: string) {
   if (name && name.trim()) {
     constifySession(id, name.trim())
   }

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -138,4 +138,7 @@ export const api = {
 
   unconstifySession: (id: string) =>
     request<{ status: string }>(`/sessions/${id}/const`, { method: 'DELETE' }),
+
+  generateSessionTitle: (id: string) =>
+    request<{ title: string }>(`/sessions/${id}/generate-title`, { method: 'POST' }),
 }

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -15,6 +15,7 @@ import type {
   ProviderConfig,
   TestConnectionResponse,
   DiscoverModelsResponse,
+  ConstifyResponse,
 } from '@/types'
 
 const BASE = '/api'
@@ -126,4 +127,15 @@ export const api = {
 
   listTools: () =>
     request<ListToolsResponse>('/tools'),
+
+  // ── Const 固定会话 ──
+
+  constifySession: (id: string, name: string) =>
+    request<ConstifyResponse>(`/sessions/${id}/const`, {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    }),
+
+  unconstifySession: (id: string) =>
+    request<{ status: string }>(`/sessions/${id}/const`, { method: 'DELETE' }),
 }

--- a/web/src/assets/icons/sidebar/pin.svg
+++ b/web/src/assets/icons/sidebar/pin.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+  <path d="M9.5 1.5 14 6l-1.5 1.5L11 6l-2 2v4l-1 1-3-3-3 3-1-1 3-3-3-3 1-1h4l2-2 1.5-1.5z"/>
+</svg>

--- a/web/src/components/Icon.vue
+++ b/web/src/components/Icon.vue
@@ -7,6 +7,7 @@ import { computed } from 'vue'
 import chatRaw from '@/assets/icons/sidebar/chat.svg?raw'
 import memoryRaw from '@/assets/icons/sidebar/memory.svg?raw'
 import modelRaw from '@/assets/icons/sidebar/model.svg?raw'
+import pinRaw from '@/assets/icons/sidebar/pin.svg?raw'
 import citeSpeechRaw from '@/assets/icons/context-menu/cite-speech.svg?raw'
 import copyRaw from '@/assets/icons/context-menu/copy.svg?raw'
 import undoArrowRaw from '@/assets/icons/context-menu/undo-arrow.svg?raw'
@@ -31,6 +32,7 @@ const svgContents: Record<string, string> = {
   chat: chatRaw,
   memory: memoryRaw,
   model: modelRaw,
+  pin: pinRaw,
   'cite-speech': citeSpeechRaw,
   copy: copyRaw,
   'undo-arrow': undoArrowRaw,

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -141,6 +141,39 @@
       @select="handleContextMenuSelect"
       @close="closeContextMenu"
     />
+
+    <!-- ── 固定会话卡片 ── -->
+    <Teleport to="body">
+      <Transition name="constify-pop">
+        <div
+          v-if="constifyTarget"
+          ref="constifyCardRef"
+          class="constify-card"
+          :style="constifyCardStyle"
+          @click.stop
+        >
+          <div class="constify-card-title">固定会话</div>
+          <input
+            ref="constifyInputRef"
+            v-model="constifyName"
+            class="constify-input"
+            type="text"
+            placeholder="输入会话名称..."
+            maxlength="50"
+            @keydown.enter="confirmConstify"
+            @keydown.esc="cancelConstify"
+          />
+          <div class="constify-actions">
+            <button class="constify-btn cancel" @click="cancelConstify">取消</button>
+            <button
+              class="constify-btn confirm"
+              :disabled="!constifyName.trim()"
+              @click="confirmConstify"
+            >确定</button>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
   </div>
 </template>
 
@@ -148,7 +181,7 @@
 import type { SessionInfo } from '@/types';
 import ContextMenu from '@/components/ContextMenu.vue';
 import Icon from '@/components/Icon.vue';
-import { computed, nextTick, ref } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 
 const props = defineProps<{
   sessions: SessionInfo[]
@@ -161,7 +194,7 @@ const emit = defineEmits<{
   create: []
   switch: [id: string]
   delete: [id: string]
-  constify: [id: string]
+  constify: [id: string, name: string]
   unconstify: [id: string]
 }>()
 
@@ -277,6 +310,94 @@ const ctxMenuItems = computed(() => {
   ]
 })
 
+// ── 固定会话卡片 ──────────────────────────────────────────────
+
+const constifyTarget = ref<SessionInfo | null>(null)
+const constifyName = ref('')
+const constifyCardRef = ref<HTMLElement | null>(null)
+const constifyInputRef = ref<HTMLInputElement | null>(null)
+const constifyCardTop = ref(0)
+const constifyCardLeft = ref(0)
+
+/** 鼠标右键触发时的目标元素 rect，用于定位卡片 */
+let constifyAnchorRect: DOMRect | null = null
+
+const constifyCardStyle = computed(() => {
+  if (!constifyTarget.value) return { display: 'none' }
+  return {
+    position: 'fixed' as const,
+    top: `${constifyCardTop.value}px`,
+    left: `${constifyCardLeft.value}px`,
+    zIndex: 1001,
+  }
+})
+
+function adjustConstifyCardPosition() {
+  const cardEl = constifyCardRef.value
+  if (!cardEl || !constifyTarget.value) return
+  const cardWidth = cardEl.offsetWidth
+  const cardHeight = cardEl.offsetHeight
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+  const margin = 8
+
+  if (constifyCardLeft.value + cardWidth > vw - margin) {
+    const leftPos = (constifyAnchorRect?.left ?? constifyCardLeft.value) - cardWidth - margin
+    constifyCardLeft.value = leftPos >= margin ? leftPos : Math.max(margin, vw - cardWidth - margin)
+  }
+  if (constifyCardTop.value + cardHeight > vh - margin) {
+    constifyCardTop.value = Math.max(margin, vh - cardHeight - margin)
+  }
+  // Ensure card stays on the right side of the anchor when there's room
+  if (constifyAnchorRect && constifyCardLeft.value < constifyAnchorRect.right) {
+    constifyCardLeft.value = constifyAnchorRect.right + margin
+  }
+}
+
+function showConstifyCard(session: SessionInfo) {
+  const rect = constifyAnchorRect
+  if (rect) {
+    constifyCardTop.value = rect.top
+    constifyCardLeft.value = rect.right + 8
+  }
+  constifyTarget.value = session
+  constifyName.value = session.const_name || ''
+  closeContextMenu()
+  nextTick(() => {
+    adjustConstifyCardPosition()
+    constifyInputRef.value?.focus()
+    constifyInputRef.value?.select()
+  })
+}
+
+function confirmConstify() {
+  if (!constifyTarget.value || !constifyName.value.trim()) return
+  emit('constify', constifyTarget.value.session_id, constifyName.value.trim())
+  constifyTarget.value = null
+  constifyName.value = ''
+}
+
+function cancelConstify() {
+  constifyTarget.value = null
+  constifyName.value = ''
+}
+
+// ── 悬浮详情卡片 ──────────────────────────────────────────────
+
+/** 注册一个全局点击监听，在 constify 卡片打开时点击外部关闭 */
+watch(constifyTarget, (val) => {
+  if (val) {
+    const handler = (e: MouseEvent) => {
+      const card = constifyCardRef.value
+      if (card && !card.contains(e.target as Node)) {
+        cancelConstify()
+      }
+    }
+    // delay registration so the current click doesn't immediately close
+    nextTick(() => document.addEventListener('click', handler, { once: true }))
+  }
+})
+
 function onSessionContextMenu(event: MouseEvent, session: SessionInfo) {
   // 关闭 hover card
   if (hoverLeaveTimer !== null) {
@@ -284,6 +405,9 @@ function onSessionContextMenu(event: MouseEvent, session: SessionInfo) {
     hoverLeaveTimer = null
   }
   hoveredSession.value = null
+
+  // 保存锚点元素 rect，供 constify 卡片定位
+  constifyAnchorRect = (event.currentTarget as HTMLElement).getBoundingClientRect()
 
   ctxMenuSession.value = session
   ctxMenuPos.value = { x: event.clientX, y: event.clientY }
@@ -294,7 +418,8 @@ function handleContextMenuSelect(action: string) {
   const s = ctxMenuSession.value
   if (!s) return
   if (action === 'constify') {
-    emit('constify', s.session_id)
+    showConstifyCard(s)
+    return  // 不关闭菜单，showConstifyCard 内部会关闭
   } else if (action === 'unconstify') {
     emit('unconstify', s.session_id)
   }
@@ -590,5 +715,104 @@ function closeContextMenu() {
 /* collapsed 时隐藏 const 左侧边框 */
 .session-sidebar.collapsed .session-item.is-const {
   border-left: none;
+}
+
+/* ── 固定会话卡片 ── */
+.constify-card {
+  min-width: 240px;
+  padding: 16px;
+  background: color-mix(in srgb, var(--bg-card) 75%, transparent);
+  backdrop-filter: blur(14px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  border-radius: 10px;
+  box-shadow: 0 6px 28px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  pointer-events: auto;
+}
+
+.constify-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.constify-input {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.constify-input:focus {
+  border-color: var(--accent);
+}
+
+.constify-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.constify-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.constify-btn {
+  padding: 6px 16px;
+  font-size: 13px;
+  font-family: inherit;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.constify-btn.cancel {
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.constify-btn.cancel:hover {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  color: var(--text-primary);
+}
+
+.constify-btn.confirm {
+  background: var(--accent);
+  color: #fff;
+}
+
+.constify-btn.confirm:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.constify-btn.confirm:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* 卡片弹出动画 */
+.constify-pop-enter-active {
+  transition: opacity 0.12s ease-out, transform 0.12s ease-out;
+}
+.constify-pop-leave-active {
+  transition: opacity 0.1s ease-in, transform 0.1s ease-in;
+}
+.constify-pop-enter-from {
+  opacity: 0;
+  transform: translateX(-6px) scale(0.96);
+}
+.constify-pop-leave-to {
+  opacity: 0;
+  transform: translateX(-4px) scale(0.96);
 }
 </style>

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -5,47 +5,102 @@
       <button class="btn-new" @click="$emit('create')" title="新会话">+</button>
     </div>
     <div class="session-list">
-      <div
-        v-for="(s, index) in sessions"
-        :key="s.session_id"
-        class="session-item"
-        :class="{ active: s.session_id === activeId }"
-        @click="$emit('switch', s.session_id)"
-        @mouseenter="onSessionMouseEnter($event, s)"
-        @mouseleave="onSessionMouseLeave"
-      >
-        <div class="session-item-main">
-          <span class="session-id">
-            Session #{{ sessions.length - index }}
-            <span v-if="s.is_subagent" class="sub-badge" title="子 Agent 会话（只读）">sub</span>
-          </span>
-          <span class="session-count">{{ formatRelativeTime(s.last_active ?? s.created_at) }} · {{ s.message_count }} 条消息</span>
-        </div>
-        <div class="session-item-right">
-          <span
-            v-if="(sessionStatuses ?? {})[s.session_id]?.isAwaitingUser"
-            class="status-dot awaiting-user"
-            title="等待用户输入"
-          />
-          <span
-            v-else-if="(sessionStatuses ?? {})[s.session_id]?.isStreaming"
-            class="status-dot streaming"
-            title="Agent 运行中"
-          />
-          <span
-            v-else-if="(sessionStatuses ?? {})[s.session_id]?.connected"
-            class="status-dot connected"
-            title="已连接"
-          />
-          <button
-            class="btn-delete"
-            @click.stop="$emit('delete', s.session_id)"
-            title="删除会话"
-          >
-            &times;
-          </button>
+
+      <!-- ── 已保存（固定会话）── -->
+      <div v-if="constSessions.length > 0" class="const-section">
+        <div class="section-label">已保存</div>
+        <div
+          v-for="(s, ci) in constSessions"
+          :key="s.session_id"
+          class="session-item is-const"
+          :class="{ active: s.session_id === activeId }"
+          @click="$emit('switch', s.session_id)"
+          @contextmenu.prevent="onSessionContextMenu($event, s)"
+          @mouseenter="onSessionMouseEnter($event, s)"
+          @mouseleave="onSessionMouseLeave"
+        >
+          <div class="session-item-main">
+            <span class="session-id">
+              <Icon name="pin" :size="12" style="margin-right: 3px; flex-shrink: 0;" />
+              <span class="const-name-text">{{ s.const_name || '未命名' }}</span>
+              <span v-if="s.is_subagent" class="sub-badge" title="子 Agent 会话（只读）">sub</span>
+            </span>
+            <span class="session-count">{{ formatRelativeTime(s.last_active ?? s.created_at) }} · {{ s.message_count }} 条消息</span>
+          </div>
+          <div class="session-item-right">
+            <span
+              v-if="(sessionStatuses ?? {})[s.session_id]?.isAwaitingUser"
+              class="status-dot awaiting-user"
+              title="等待用户输入"
+            />
+            <span
+              v-else-if="(sessionStatuses ?? {})[s.session_id]?.isStreaming"
+              class="status-dot streaming"
+              title="Agent 运行中"
+            />
+            <span
+              v-else-if="(sessionStatuses ?? {})[s.session_id]?.connected"
+              class="status-dot connected"
+              title="已连接"
+            />
+            <button
+              class="btn-delete"
+              @click.stop="$emit('delete', s.session_id)"
+              title="删除会话"
+            >
+              &times;
+            </button>
+          </div>
         </div>
       </div>
+
+      <!-- ── 临时会话 ── -->
+      <div class="temp-section">
+        <div v-if="constSessions.length > 0" class="section-label">临时会话</div>
+        <div
+          v-for="(s, index) in tempSessions"
+          :key="s.session_id"
+          class="session-item"
+          :class="{ active: s.session_id === activeId }"
+          @click="$emit('switch', s.session_id)"
+          @contextmenu.prevent="onSessionContextMenu($event, s)"
+          @mouseenter="onSessionMouseEnter($event, s)"
+          @mouseleave="onSessionMouseLeave"
+        >
+          <div class="session-item-main">
+            <span class="session-id">
+              Session #{{ getSessionDisplayIndex(s) }}
+              <span v-if="s.is_subagent" class="sub-badge" title="子 Agent 会话（只读）">sub</span>
+            </span>
+            <span class="session-count">{{ formatRelativeTime(s.last_active ?? s.created_at) }} · {{ s.message_count }} 条消息</span>
+          </div>
+          <div class="session-item-right">
+            <span
+              v-if="(sessionStatuses ?? {})[s.session_id]?.isAwaitingUser"
+              class="status-dot awaiting-user"
+              title="等待用户输入"
+            />
+            <span
+              v-else-if="(sessionStatuses ?? {})[s.session_id]?.isStreaming"
+              class="status-dot streaming"
+              title="Agent 运行中"
+            />
+            <span
+              v-else-if="(sessionStatuses ?? {})[s.session_id]?.connected"
+              class="status-dot connected"
+              title="已连接"
+            />
+            <button
+              class="btn-delete"
+              @click.stop="$emit('delete', s.session_id)"
+              title="删除会话"
+            >
+              &times;
+            </button>
+          </div>
+        </div>
+      </div>
+
       <div v-if="sessions.length === 0" class="no-sessions">
         暂无会话
       </div>
@@ -77,11 +132,22 @@
         </div>
       </div>
     </Transition>
+
+    <!-- ── 右键菜单 ── -->
+    <ContextMenu
+      :position="ctxMenuPos"
+      :items="ctxMenuItems"
+      :visible="ctxMenuVisible"
+      @select="handleContextMenuSelect"
+      @close="closeContextMenu"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import type { SessionInfo } from '@/types';
+import ContextMenu from '@/components/ContextMenu.vue';
+import Icon from '@/components/Icon.vue';
 import { computed, nextTick, ref } from 'vue';
 
 const props = defineProps<{
@@ -91,11 +157,29 @@ const props = defineProps<{
   collapsed?: boolean
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   create: []
   switch: [id: string]
   delete: [id: string]
+  constify: [id: string]
+  unconstify: [id: string]
 }>()
+
+// ── 分区计算 ──────────────────────────────────────────────────
+
+function getSessionDisplayIndex(s: SessionInfo): number {
+  return props.sessions.length - props.sessions.findIndex(x => x.session_id === s.session_id)
+}
+
+const constSessions = computed(() =>
+  props.sessions.filter(s => s.is_const)
+)
+
+const tempSessions = computed(() =>
+  props.sessions.filter(s => !s.is_const)
+)
+
+// ── Hover card ────────────────────────────────────────────────
 
 const hoveredSession = ref<SessionInfo | null>(null)
 const hoverCardRef = ref<HTMLElement | null>(null)
@@ -172,6 +256,55 @@ const cardStyle = computed(() => {
     pointerEvents: 'none' as const,
   }
 })
+
+// ── 右键菜单 ──────────────────────────────────────────────────
+
+const ctxMenuVisible = ref(false)
+const ctxMenuPos = ref({ x: 0, y: 0 })
+const ctxMenuSession = ref<SessionInfo | null>(null)
+
+const ctxMenuItems = computed(() => {
+  const s = ctxMenuSession.value
+  if (!s) return []
+  if (s.is_const) {
+    return [
+      { label: '固定会话…', action: 'constify', icon: 'pin' },
+      { label: '取消固定', action: 'unconstify' },
+    ]
+  }
+  return [
+    { label: '固定会话…', action: 'constify', icon: 'pin' },
+  ]
+})
+
+function onSessionContextMenu(event: MouseEvent, session: SessionInfo) {
+  // 关闭 hover card
+  if (hoverLeaveTimer !== null) {
+    clearTimeout(hoverLeaveTimer)
+    hoverLeaveTimer = null
+  }
+  hoveredSession.value = null
+
+  ctxMenuSession.value = session
+  ctxMenuPos.value = { x: event.clientX, y: event.clientY }
+  ctxMenuVisible.value = true
+}
+
+function handleContextMenuSelect(action: string) {
+  const s = ctxMenuSession.value
+  if (!s) return
+  if (action === 'constify') {
+    emit('constify', s.session_id)
+  } else if (action === 'unconstify') {
+    emit('unconstify', s.session_id)
+  }
+  closeContextMenu()
+}
+
+function closeContextMenu() {
+  ctxMenuVisible.value = false
+  ctxMenuSession.value = null
+}
 </script>
 
 <style scoped>
@@ -222,6 +355,18 @@ const cardStyle = computed(() => {
   max-height: 400px;
   overflow-y: auto;
 }
+
+/* ── Section label ── */
+.section-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-tertiary, #9ca3af);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 4px 12px 2px;
+}
+
+/* ── Session items ── */
 .session-item {
   display: flex;
   align-items: center;
@@ -242,6 +387,12 @@ const cardStyle = computed(() => {
   background: var(--bg-card);
   box-shadow: var(--shadow);
 }
+
+/* Const 会话外观 */
+.session-item.is-const {
+  border-left: 2px solid var(--accent);
+}
+
 .session-item-main {
   display: flex;
   flex-direction: column;
@@ -255,6 +406,14 @@ const cardStyle = computed(() => {
   font-size: 13px;
   font-weight: 500;
   color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.const-name-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .sub-badge {
   display: inline-block;
@@ -419,5 +578,17 @@ const cardStyle = computed(() => {
   overflow: hidden;
   padding: 0;
   margin: 0;
+}
+/* collapsed 时隐藏分区 label */
+.session-sidebar.collapsed .section-label {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+}
+/* collapsed 时隐藏 const 左侧边框 */
+.session-sidebar.collapsed .session-item.is-const {
+  border-left: none;
 }
 </style>

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -153,16 +153,27 @@
           @click.stop
         >
           <div class="constify-card-title">固定会话</div>
-          <input
-            ref="constifyInputRef"
-            v-model="constifyName"
-            class="constify-input"
-            type="text"
-            placeholder="输入会话名称..."
-            maxlength="50"
-            @keydown.enter="confirmConstify"
-            @keydown.esc="cancelConstify"
-          />
+          <div class="constify-input-row">
+            <input
+              ref="constifyInputRef"
+              v-model="constifyName"
+              class="constify-input"
+              type="text"
+              placeholder="输入会话名称..."
+              maxlength="50"
+              @keydown.enter="confirmConstify"
+              @keydown.esc="cancelConstify"
+            />
+            <button
+              class="constify-gen-btn"
+              :class="{ loading: generating }"
+              title="AI 生成标题"
+              :disabled="generating"
+              @click="generateTitle"
+            >
+              <Icon name="sparkles" :size="16" />
+            </button>
+          </div>
           <div class="constify-actions">
             <button class="constify-btn cancel" @click="cancelConstify">取消</button>
             <button
@@ -181,6 +192,7 @@
 import type { SessionInfo } from '@/types';
 import ContextMenu from '@/components/ContextMenu.vue';
 import Icon from '@/components/Icon.vue';
+import { generateSessionTitle } from '@/composables/useSession';
 import { computed, nextTick, ref, watch } from 'vue';
 
 const props = defineProps<{
@@ -318,6 +330,7 @@ const constifyCardRef = ref<HTMLElement | null>(null)
 const constifyInputRef = ref<HTMLInputElement | null>(null)
 const constifyCardTop = ref(0)
 const constifyCardLeft = ref(0)
+const generating = ref(false)
 
 /** 鼠标右键触发时的目标元素 rect，用于定位卡片 */
 let constifyAnchorRect: DOMRect | null = null
@@ -368,6 +381,24 @@ function showConstifyCard(session: SessionInfo) {
     constifyInputRef.value?.focus()
     constifyInputRef.value?.select()
   })
+}
+
+async function generateTitle() {
+  const session = constifyTarget.value
+  if (!session || generating.value) return
+  generating.value = true
+  try {
+    const title = await generateSessionTitle(session.session_id)
+    constifyName.value = title
+    nextTick(() => {
+      constifyInputRef.value?.focus()
+      constifyInputRef.value?.select()
+    })
+  } catch (e) {
+    console.error('[constify] 标题生成失败:', e)
+  } finally {
+    generating.value = false
+  }
 }
 
 function confirmConstify() {
@@ -739,8 +770,14 @@ function closeContextMenu() {
   color: var(--text-primary);
 }
 
+.constify-input-row {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+
 .constify-input {
-  width: 100%;
+  flex: 1;
   padding: 8px 12px;
   font-size: 13px;
   font-family: inherit;
@@ -758,6 +795,40 @@ function closeContextMenu() {
 
 .constify-input::placeholder {
   color: var(--text-tertiary);
+}
+
+.constify-gen-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+}
+
+.constify-gen-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.constify-gen-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.constify-gen-btn.loading {
+  animation: gen-btn-pulse 0.8s ease-in-out infinite;
+}
+
+@keyframes gen-btn-pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
 }
 
 .constify-actions {

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -213,7 +213,7 @@ const emit = defineEmits<{
 // ── 分区计算 ──────────────────────────────────────────────────
 
 function getSessionDisplayIndex(s: SessionInfo): number {
-  return props.sessions.length - props.sessions.findIndex(x => x.session_id === s.session_id)
+  return tempSessions.value.length - tempSessions.value.findIndex(x => x.session_id === s.session_id)
 }
 
 const constSessions = computed(() =>

--- a/web/src/composables/useSession.ts
+++ b/web/src/composables/useSession.ts
@@ -84,9 +84,21 @@ async function deleteSession(id: string) {
   }
 }
 
+export async function constifySession(id: string, name: string) {
+  console.log(`[useSession] constifySession("${id}", "${name}")`)
+  await api.constifySession(id, name)
+  await refreshSessions()
+}
+
+export async function unconstifySession(id: string) {
+  console.log(`[useSession] unconstifySession("${id}")`)
+  await api.unconstifySession(id)
+  await refreshSessions()
+}
+
 export function useSession() {
   initIfNeeded()
-  return { sessionId, sessions, createSession, switchSession, deleteSession, refreshSessions }
+  return { sessionId, sessions, createSession, switchSession, deleteSession, refreshSessions, constifySession, unconstifySession }
 }
 
 /** 清理后端已不存在的会话的 localStorage 孤儿缓存 */

--- a/web/src/composables/useSession.ts
+++ b/web/src/composables/useSession.ts
@@ -96,6 +96,12 @@ export async function unconstifySession(id: string) {
   await refreshSessions()
 }
 
+export async function generateSessionTitle(id: string): Promise<string> {
+  console.log(`[useSession] generateSessionTitle("${id}")`)
+  const res = await api.generateSessionTitle(id)
+  return res.title
+}
+
 export function useSession() {
   initIfNeeded()
   return { sessionId, sessions, createSession, switchSession, deleteSession, refreshSessions, constifySession, unconstifySession }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -181,11 +181,19 @@ export interface SessionInfo {
   has_active_agent?: boolean
   is_subagent?: boolean
   auto_approve?: boolean
+  is_const?: boolean
+  const_name?: string
 }
 
 export interface CreateSessionResponse {
   session_id: string
   created_at: number
+}
+
+export interface ConstifyResponse {
+  session_id: string
+  is_const: boolean
+  const_name: string
 }
 
 export interface ListSessionsResponse {


### PR DESCRIPTION
## 摘要

实现本地固定会话（Const Session）功能：用户可将重要对话持久化保存到磁盘 YAML，重启后自动恢复。整个实现覆盖后端存储层、API 路由、前端 UI 三个层面。

## 主要变更

### 后端
- `SessionState` 新增 `is_const` / `const_name` 字段
- 新增 `api/const_session_store.py`：YAML 持久化、消息序列化/反序列化
- `POST /api/sessions/{id}/const` — 固定会话
- `DELETE /api/sessions/{id}/const` — 取消固定
- `POST /api/sessions/{id}/generate-title` — AI 标题生成（LLM 按 6 条规则生成 5-10 字标题）
- 服务启动时 `_load_const_sessions()` 自动从 YAML 重建固定会话
- 自动保存：每轮对话完成后自动将固定会话写回 YAML
- `DELETE /api/sessions/{id}` 自动清理关联 YAML 文件

### 前端
- `SessionInfo` 类型新增 `is_const` / `const_name`
- 侧边栏会话列表分为「已保存」和「临时会话」两个独立分区
- 右键菜单「固定会话…」→ 弹出玻璃拟态卡片，内嵌输入框 + AI 生成按钮
- 已固定会话左侧 accent 色边框标识
- 临时会话编号仅计临时会话，跳过固定会话
- `SessionSidebar` 新增 `@constify(id, name)` / `@unconstify(id)` 事件

### 新闻
- 添加更新动态：固定会话功能上线（#102）

## 测试计划
- [x] 右键固定会话 → 输入名称 → 确认 → 侧边栏显示固定会话
- [x] 点击 sparkle 按钮 → 自动生成标题
- [x] 重启后端 → 固定会话自动恢复，消息历史完整
- [x] 固定会话继续对话 → 自动保存新消息
- [x] 取消固定 → 移回临时会话分区
- [x] 删除固定会话 → 同时清理 YAML 文件