### PR TITLE
fix: const 会话加载时序修复

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -104,12 +104,12 @@ async def lifespan(app: FastAPI):
     app.state.ltm = LongTermMemoryInterface(MEMORY_PATH)
     app.state.ltm.start_listening(app.state.llm)
 
-    # 加载 const 固定会话（从 YAML 重建内存会话）
-    await _load_const_sessions(app)
-
     # 加载 MCP 工具（Word 文档编辑能力）
     app.state.mcp_tools = await init_mcp_tools()
     app.state.tools = app.state.native_tools + app.state.mcp_tools
+
+    # 加载 const 固定会话（需要 tools 已就绪）
+    await _load_const_sessions(app)
 
     yield
 


### PR DESCRIPTION
## 问题

启动时 const 会话重建失败：
```
[const] 重建会话 xxx 失败: 'State' object has no attribute 'tools'
```

## 根因

`lifespan()` 中 const 会话加载在 MCP 工具初始化之前执行，此时 `app.state.tools` 尚未设置。

```python
await _load_const_sessions(app)   # 访问 app.state.tools → AttributeError
app.state.tools = native + mcp    # 设置得太晚
```

## 修复

将 `_load_const_sessions` 移到 `app.state.tools` 赋值之后。

## 影响

仅影响启动时重建已有固定会话，不影响运行中的会话操作。