### PR TITLE
feat: 从 marked 切换到 markdown-it 渲染引擎

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,20 +1,22 @@
 {
   "name": "sonettohere-web",
-  "version": "1.1.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonettohere-web",
-      "version": "1.0.0",
+      "version": "1.6.1",
       "dependencies": {
         "katex": "^0.16.47",
-        "marked": "^12.0.0",
-        "marked-katex-extension": "^5.1.8",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "markdown-it-texmath": "^1.0.0",
         "vue": "^3.4.0",
         "vue-router": "^4.3.0"
       },
       "devDependencies": {
+        "@types/markdown-it": "^14.1.2",
         "@vitejs/plugin-vue": "^5.0.0",
         "typescript": "^5.4.0",
         "vite": "^5.2.0",
@@ -821,6 +823,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -1013,6 +1040,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1150,6 +1183,25 @@
         "katex": "cli.js"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1159,27 +1211,62 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/marked": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
-      "engines": {
-        "node": ">= 18"
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
-    "node_modules/marked-katex-extension": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/marked-katex-extension/-/marked-katex-extension-5.1.8.tgz",
-      "integrity": "sha512-TsV9OCHHDjVBf4IH0RSjLs4Eqsjj8HGfmVCKlimrS391EtBBxzXj2gBYdF9tY7f7oXu9tb1kHV86ExJsG3iMhw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "katex": ">=0.16 <0.17",
-        "marked": ">=4 <19"
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
+    },
+    "node_modules/markdown-it-texmath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-texmath/-/markdown-it-texmath-1.0.0.tgz",
+      "integrity": "sha512-4hhkiX8/gus+6e53PLCUmUrsa6ZWGgJW2XCW6O0ASvZUiezIK900ZicinTDtG3kAO2kon7oUA/ReWmpW2FByxg==",
+      "license": "MIT"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -1263,6 +1350,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
@@ -1330,6 +1426,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/web/package.json
+++ b/web/package.json
@@ -10,12 +10,14 @@
   },
   "dependencies": {
     "katex": "^0.16.47",
-    "marked": "^12.0.0",
-    "marked-katex-extension": "^5.1.8",
+    "markdown-it": "^14.1.0",
+    "markdown-it-task-lists": "^2.1.1",
+    "markdown-it-texmath": "^1.0.0",
     "vue": "^3.4.0",
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
+    "@types/markdown-it": "^14.1.2",
     "@vitejs/plugin-vue": "^5.0.0",
     "typescript": "^5.4.0",
     "vite": "^5.2.0",

--- a/web/src/types/markdown-it-plugins.d.ts
+++ b/web/src/types/markdown-it-plugins.d.ts
@@ -1,0 +1,28 @@
+declare module 'markdown-it-texmath' {
+  import type MarkdownIt from 'markdown-it'
+  import type { KatexOptions } from 'katex'
+
+  interface TexmathOptions {
+    engine?: typeof import('katex')
+    delimiters?: Array<'dollars' | 'parentheses' | 'brackets' | 'beg_end'>
+    allow_escape?: boolean
+    katexOptions?: KatexOptions
+    macros?: Record<string, string>
+  }
+
+  const texmath: (md: MarkdownIt, options?: TexmathOptions) => void
+  export default texmath
+}
+
+declare module 'markdown-it-task-lists' {
+  import type MarkdownIt from 'markdown-it'
+
+  interface TaskListsOptions {
+    enabled?: boolean
+    label?: boolean
+    labelAfter?: boolean
+  }
+
+  const taskLists: (md: MarkdownIt, options?: TaskListsOptions) => void
+  export default taskLists
+}

--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -1,15 +1,34 @@
-import { Marked } from 'marked'
-import markedKatex from 'marked-katex-extension'
+import MarkdownIt from 'markdown-it'
+import texmath from 'markdown-it-texmath'
+import taskLists from 'markdown-it-task-lists'
+import katex from 'katex'
 
-const marked = new Marked({
-  breaks: true,
-  gfm: true,
+const md = new MarkdownIt({
+  html: true,    // 透传原始 HTML（LLM 直接输出交互式 HTML 的关键功能）
+  breaks: true,  // \n → <br>，适配聊天场景的换行
+  linkify: true, // 自动识别 URL 为可点击链接
 })
-marked.use(markedKatex())
+
+// GFM 任务列表：- [x] 已完成 / - [ ] 未完成
+md.use(taskLists, { enabled: true })
+
+// 数学公式支持：$...$ / $$...$$ / \(...\) / \[...\]
+md.use(texmath, {
+  engine: katex,
+  delimiters: [
+    'dollars',     // $...$ 和 $$...$$
+    'parentheses', // \(...\)
+    'brackets',    // \[...\]
+  ],
+  allow_escape: true,    // \$ 转义为字面 $ 符号
+  katexOptions: {
+    throwOnError: false, // 公式渲染失败时降级显示原文，不抛异常
+  },
+})
 
 export function renderMarkdown(content: string): string {
   if (!content) return ''
-  return marked.parse(content) as string
+  return md.render(content)
 }
 
 /**


### PR DESCRIPTION
## Summary

将 Markdown 渲染引擎从 `marked` + `marked-katex-extension` 迁移到 `markdown-it` + `markdown-it-texmath`，解决数学公式支持不完善的问题。

### 解决的问题
- **`$` 偶发报错** — `throwOnError: false` 使公式渲染失败时降级显示原文；`\$` 转义支持字面美元符号
- **无法识别 `\(...\)` 和 `\[...\]`** — `markdown-it-texmath` 原生支持这三种定界符：`$`/`$$`、`\(\)`、`\[\]`

### 关键变更
- `web/package.json` — 替换依赖
- `web/src/utils/markdown.ts` — 重写渲染引擎，保留 `contentNeedsIsolation()` 沙箱检测函数不变
- `web/src/types/markdown-it-plugins.d.ts` — 新增类型声明

### 保留的现有功能
- ✅ LLM 直接输出 HTML/CSS/JS 的沙箱渲染（`html: true` 透传原始 HTML）
- ✅ 所有消费组件零改动（接口签名不变）
- ✅ GFM 表格、任务列表支持
- ✅ KaTeX CSS 样式

### Test plan
- [ ] `$...$` 和 `$$...$$` 公式正常渲染
- [ ] `\(...\)` 和 `\[...\]` 公式正常渲染
- [ ] 非数学 `$`（如价格 `$10.99`）不触发报错
- [ ] LLM 直接输出的 HTML 仍进入沙箱 iframe
- [ ] 常规 Markdown 渲染无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)