### PR TITLE
fix: 修复 Win11 启动问题 — git clone 指引 / start.bat 回显 / 缺失依赖 / MCP 容错

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 ## Quick Start
 
+### 0. 克隆仓库
+
+```bash
+git clone https://github.com/Miso2233/SonettoHere.git
+cd SonettoHere
+```
+
 ### 1. 安装
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ moviepy>=1.0.3
 zai-sdk
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0
+office-word-mcp-server>=1.1.0

--- a/start.bat
+++ b/start.bat
@@ -23,7 +23,7 @@ if not exist ".venv\Scripts\python.exe" (
 
 if not exist "web\node_modules" (
     echo [ERR] Frontend dependencies not found. Run:
-    echo        cd web ^&^& npm install
+    echo        cd web && npm install
     pause
     exit /b 1
 )

--- a/tools/mcp.py
+++ b/tools/mcp.py
@@ -14,22 +14,29 @@ _WRAPPER_PATH = str(Path(__file__).resolve().parent.parent / "scripts" / "mcp_wo
 
 
 async def init_mcp_tools() -> list[BaseTool]:
-    """初始化 MCP 客户端并返回所有 MCP 工具（已自动添加 word_ 前缀）。"""
+    """初始化 MCP 客户端并返回所有 MCP 工具（已自动添加 word_ 前缀）。
+
+    初始化失败时返回空列表而非抛出异常，避免阻断整个应用启动。
+    """
     global _client, _tools
     if _tools is not None:
         return _tools
 
-    _client = MultiServerMCPClient(
-        {
-            "word": {
-                "command": sys.executable,
-                "args": [_WRAPPER_PATH],
-                "transport": "stdio",
-            }
-        },
-        tool_name_prefix=True,
-    )
-    _tools = await _client.get_tools()
+    try:
+        _client = MultiServerMCPClient(
+            {
+                "word": {
+                    "command": sys.executable,
+                    "args": [_WRAPPER_PATH],
+                    "transport": "stdio",
+                }
+            },
+            tool_name_prefix=True,
+        )
+        _tools = await _client.get_tools()
+    except Exception as e:
+        print(f"[WARN] MCP 工具初始化失败，将跳过 Word 功能: {e}")
+        _tools = []
     return _tools
 
 


### PR DESCRIPTION
## 修复内容

修复 #109 中报告的 4 个问题：

### 问题 0：README 缺少 `git clone` 指引
- Quick Start 首步添加克隆仓库命令

### 问题 1：start.bat 回显转义符问题
- 第 26 行 `^&^&` → `&&`，用户复制后可直接使用

### 问题 2：缺少 office-word-mcp-server 依赖
- `requirements.txt` 末尾添加 `office-word-mcp-server>=1.1.0`

### 问题 3：tools/mcp.py 无容错处理
- `init_mcp_tools()` 添加 `try-except`，初始化失败时返回空列表而非抛出异常
- 即使 office-word-mcp-server 未安装，应用也能正常启动（仅跳过 Word 功能）

**Close** #109