### PR TITLE
refactor: 移除 .env 模型配置，统一由 providers.yaml + 前端面板管理

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
-# DeepSeek API
-DEEPSEEK_API_KEY=sk-your-key-here
-DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+# LLM 提供商配置（API key、base_url、model）通过 Web UI /providers 管理，
+# 存储在 providers.yaml 中。以下仅保留工具类凭据。
 
 # Todoist
 TODOIST_API_TOKEN=your-todoist-token

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ pip install -r requirements.txt
 cp .env.example .env
 ```
 
-**最少只需填写** `DEEPSEEK_API_KEY` 即可开始对话。
+> **LLM 模型配置**：启动后通过 Web UI 的"模型"页面（`/providers`）添加 API 提供商。
+> 支持任何 OpenAI 兼容 API（DeepSeek、OpenRouter、Qwen 等）。
+> 所有提供商配置存储在 `providers.yaml` 中，可通过前端面板管理。
 
 ### 3. 启动
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,9 +1,6 @@
 """Web API 共享资源 — LLM、系统提示词、工具集的惰性单例。"""
 
-from langchain_openai import ChatOpenAI
-
 from agent.prompts import build_system_prompt
-from config.settings import get_settings
 from tools import get_all_tools
 
 _system_prompt: str | None = None
@@ -13,8 +10,9 @@ _tools: list | None = None
 def get_llm(provider_manager=None):
     """获取 LLM。
 
-    优先使用 ProviderManager 的第一个 enabled provider，
-    若无则退化到 .env 配置（首次启动 / 未配置提供商时的向后兼容）。
+    从 ProviderManager 中取第一个 enabled provider 创建 LLM。
+    若无可用的 provider 则抛出 RuntimeError。
+    LLM 配置统一由 providers.yaml 管理，不再降级到 .env。
     """
     if provider_manager is not None and provider_manager.count > 0:
         for provider in provider_manager.iter_enabled():
@@ -24,16 +22,7 @@ def get_llm(provider_manager=None):
                 streaming=True,
             )
 
-    # env fallback
-    settings = get_settings()
-    return ChatOpenAI(
-        model=settings.model_name or "deepseek-v4-flash",
-        api_key=settings.deepseek_api_key,
-        base_url=settings.deepseek_base_url,
-        temperature=0.7,
-        streaming=True,
-        extra_body={"thinking": {"type": "disabled"}},
-    )
+    raise RuntimeError("No enabled LLM provider configured. Add one via the providers panel (/providers).")
 
 
 def get_system_prompt() -> str:

--- a/api/health.py
+++ b/api/health.py
@@ -5,11 +5,9 @@ import time
 from pathlib import Path
 from typing import Literal
 
-import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from config.settings import get_settings
 from memory.memory_manager import MemoryManager
 from memory.narrative import MEMORY_PATH
 
@@ -34,64 +32,35 @@ class HealthResponse(BaseModel):
     timestamp: float
 
 
-# ── LLM 健康缓存（30 秒 TTL，避免高频 API 调用）──────────────
-
-_llm_health_cache: tuple[float, ComponentHealth] | None = None
-_LLM_CACHE_TTL = 30.0
-
-
-_httpx_client: httpx.AsyncClient | None = None
-
-
-def _get_httpx_client() -> httpx.AsyncClient:
-    global _httpx_client
-    if _httpx_client is None:
-        _httpx_client = httpx.AsyncClient(timeout=5.0)
-    return _httpx_client
+# ── LLM 健康检查（通过 ProviderManager）──────────────
 
 
 async def check_llm(app: FastAPI) -> ComponentHealth:
-    global _llm_health_cache
-
-    now = time.monotonic()
-    if _llm_health_cache is not None and now - _llm_health_cache[0] < _LLM_CACHE_TTL:
-        return _llm_health_cache[1]
-
-    start = now
-    try:
-        settings = get_settings()
-        client = _get_httpx_client()
-        resp = await client.post(
-            f"{settings.deepseek_base_url}/chat/completions",
-            headers={"Authorization": f"Bearer {settings.deepseek_api_key}"},
-            json={
-                "model": settings.model_name,
-                "messages": [{"role": "user", "content": "ok"}],
-                "max_tokens": 1,
-            },
+    """使用 ProviderManager 中第一个 enabled provider 检查 LLM 连通性。"""
+    mgr = getattr(app.state, "provider_manager", None)
+    if mgr is None or mgr.count == 0:
+        return ComponentHealth(
+            status="error",
+            detail="No LLM providers configured. Add one via the providers panel.",
         )
-        elapsed = (time.monotonic() - start) * 1000
 
-        if resp.is_success:
-            result = ComponentHealth(status="ok", latency_ms=round(elapsed, 1))
-        else:
-            result = ComponentHealth(
-                status="error",
+    start = time.monotonic()
+    for provider in mgr.iter_enabled():
+        result = await provider.check_health()
+        if result.status == "ok":
+            elapsed = (time.monotonic() - start) * 1000
+            return ComponentHealth(
+                status="ok",
                 latency_ms=round(elapsed, 1),
-                detail=f"API {resp.status_code}: {resp.text[:200]}",
+                detail=f"Provider: {provider.provider_name}",
             )
-    except asyncio.TimeoutError:
-        elapsed = (time.monotonic() - start) * 1000
-        result = ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail="请求超时（5s）")
-    except httpx.RequestError as e:
-        elapsed = (time.monotonic() - start) * 1000
-        result = ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail=f"网络错误: {e}")
-    except Exception as e:
-        elapsed = (time.monotonic() - start) * 1000
-        result = ComponentHealth(status="error", latency_ms=round(elapsed, 1), detail=str(e))
 
-    _llm_health_cache = (time.monotonic(), result)
-    return result
+    elapsed = (time.monotonic() - start) * 1000
+    return ComponentHealth(
+        status="error",
+        latency_ms=round(elapsed, 1),
+        detail="All providers unreachable",
+    )
 
 
 async def check_memory(app: FastAPI) -> ComponentHealth:

--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -18,6 +18,7 @@ class ProviderConfig:
     base_url: str
     models: list[str] = field(default_factory=list)
     enabled: bool = True
+    context_window: int = 256_000
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/api/providers/store.py
+++ b/api/providers/store.py
@@ -58,21 +58,26 @@ class ProviderConfigStore:
         return not self.path.exists() or not self.load_all()
 
     def migrate_from_env(self) -> ProviderConfig | None:
-        """首次启动时从 .env 读取 DeepSeek 配置写入 YAML。"""
-        from config.settings import get_settings
+        """首次启动时从 .env 读取 DeepSeek 配置写入 YAML（向后兼容）。"""
+        import os
 
-        settings = get_settings()
-        if not settings.deepseek_api_key:
+        api_key = os.getenv("DEEPSEEK_API_KEY", "")
+        if not api_key:
             return None
+
+        base_url = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1")
+        model_name = os.getenv("MODEL_NAME", "deepseek-v4-flash")
+        context_window_str = os.getenv("MODEL_CONTEXT_WINDOW", "256000")
 
         config = ProviderConfig(
             id="deepseek-main",
             provider_type="openai",
             label="DeepSeek",
-            api_key=settings.deepseek_api_key,
-            base_url=settings.deepseek_base_url,
-            models=[settings.model_name],
+            api_key=api_key,
+            base_url=base_url,
+            models=[model_name],
             enabled=True,
+            context_window=int(context_window_str),
         )
         self.save(config)
         return config

--- a/api/routes/balance.py
+++ b/api/routes/balance.py
@@ -1,22 +1,33 @@
-"""DeepSeek 余额查询"""
+"""DeepSeek 余额查询 — 从 ProviderManager 获取凭据"""
 
 import httpx
-from fastapi import APIRouter, HTTPException
-
-from config.settings import get_settings
+from fastapi import APIRouter, HTTPException, Request
 
 router = APIRouter()
 
 DEEPSEEK_BALANCE_URL = "https://api.deepseek.com/user/balance"
 
+
+def _find_deepseek_api_key(request: Request) -> str:
+    """在已配置的 provider 中查找 DeepSeek API key。"""
+    mgr = getattr(request.app.state, "provider_manager", None)
+    if mgr is None:
+        raise HTTPException(status_code=400, detail="Provider manager not initialized")
+
+    for config in mgr.list_configs():
+        lid = (config.id + config.label).lower()
+        if "deepseek" in lid and config.api_key:
+            return config.api_key
+
+    raise HTTPException(status_code=400, detail="DeepSeek provider not configured. Add one via the providers panel.")
+
+
 @router.get("/deepseek-balance")
-async def get_deepseek_balance():
-    settings = get_settings()
-    if not settings.deepseek_api_key:
-        raise HTTPException(status_code=400, detail="DeepSeek API key not set")
+async def get_deepseek_balance(request: Request):
+    api_key = _find_deepseek_api_key(request)
     headers = {
         "Accept": "application/json",
-        "Authorization": f"Bearer {settings.deepseek_api_key}",
+        "Authorization": f"Bearer {api_key}",
     }
     try:
         async with httpx.AsyncClient(timeout=10) as client:
@@ -25,8 +36,8 @@ async def get_deepseek_balance():
     except httpx.TimeoutException:
         raise HTTPException(status_code=504, detail="DeepSeek API timeout")
     except httpx.HTTPStatusError as e:
-        raise HTTPException(status_code=500, detail=f"DeepSeek API error:{e}")
+        raise HTTPException(status_code=500, detail=f"DeepSeek API error: {e}")
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"DeepSeek API error:{e}")
+        raise HTTPException(status_code=500, detail=f"DeepSeek API error: {e}")
     return data
 

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -15,10 +15,18 @@ from api.callbacks.websocket_callback import WebSocketCallback
 from api.const_session_store import save_const_session, serialize_messages
 from api.context_usage import estimate_context_usage
 from api.session_manager import SessionState
-from config.settings import get_settings
 from tools.base import format_error
 
 router = APIRouter()
+
+
+def _get_provider_context(app_state) -> tuple[int, str]:
+    """从 ProviderManager 获取默认 context_window 和 model_name。"""
+    mgr = getattr(app_state, "provider_manager", None)
+    if mgr is not None and mgr.count > 0:
+        for provider in mgr.iter_enabled():
+            return provider.config.context_window, provider.default_model
+    return 256_000, ""
 
 
 def _get_final_answer(event) -> str:
@@ -35,7 +43,7 @@ def _get_final_answer(event) -> str:
     return final_answer
 
 
-async def _stream_turn(graph, inputs, config, ws, session, system_prompt, model_name: str | None = None) -> str:
+async def _stream_turn(graph, inputs, config, ws, session, system_prompt, model_name: str | None = None, max_tokens: int = 256_000) -> str:
     """流式执行 Agent 图，返回最终回答。"""
     final_answer = ""
     async for event in graph.astream_events(inputs, config=config, version="v2"):
@@ -43,7 +51,7 @@ async def _stream_turn(graph, inputs, config, ws, session, system_prompt, model_
             final_answer = _get_final_answer(event)
         # 一轮工具执行完毕，ToolMessage 已写入 checkpoint，推送上下文用量
         if event.get("event") == "on_chain_end" and event.get("name") == "tools":
-            usage = await _calculate_context_usage(session, system_prompt, model_name=model_name)
+            usage = await _calculate_context_usage(session, system_prompt, max_tokens=max_tokens, model_name=model_name or "")
             await ws.send_json({"type": "context_usage", "payload": usage})
 
     # 事件未捕获到 final_answer 时，从 checkpoint 兜底提取
@@ -62,12 +70,17 @@ async def _stream_turn(graph, inputs, config, ws, session, system_prompt, model_
     return final_answer
 
 
-async def _calculate_context_usage(session, system_prompt, model_name: str | None = None) -> dict:
+async def _calculate_context_usage(
+    session,
+    system_prompt,
+    *,
+    max_tokens: int = 256_000,
+    model_name: str = "",
+) -> dict:
     """
     从 checkpointer 拉取消息列表，估算上下文用量。
     返回字典，包括现用量、最大用量、占比、模型名称。
     """
-    settings = get_settings()
     try:
         cpt = await session.checkpointer.aget_tuple(
             {"configurable": {"thread_id": session.session_id}}
@@ -83,8 +96,8 @@ async def _calculate_context_usage(session, system_prompt, model_name: str | Non
     return estimate_context_usage(
         messages=counting_messages,
         system_prompt=system_prompt,
-        max_tokens=settings.model_context_window,
-        model_name=model_name or settings.model_name,
+        max_tokens=max_tokens,
+        model_name=model_name,
     )
 
 
@@ -198,18 +211,30 @@ async def _run_agent_turn(
     session.auto_approve = auto_approve
     ws_callback = WebSocketCallback(ws) # WebUI 回调函数系统
 
+    # 获取默认上下文窗口大小
+    default_max_tokens, _ = _get_provider_context(app_state)
+
     # 动态 LLM 选择（Phase 2：每次消息独立指定提供商/模型）
+    current_max_tokens = default_max_tokens
     if provider_id and model_name and hasattr(app_state, 'provider_manager'):
         try:
             provider = app_state.provider_manager.get(provider_id)
             llm = provider.create_llm(model_name, temperature=0.7, streaming=True)
             current_model_name = model_name
+            current_max_tokens = provider.config.context_window
         except KeyError:
             llm = app_state.llm
             current_model_name = None
     else:
         llm = app_state.llm
         current_model_name = None
+
+    if llm is None:
+        await ws.send_json({
+            "type": "error",
+            "payload": {"code": "NO_LLM", "message": "No LLM provider configured. Add one in Model Settings first."},
+        })
+        return
 
     system_prompt = build_system_prompt()
     agent_sonetto = build_agent(
@@ -231,10 +256,10 @@ async def _run_agent_turn(
     _run_error: str | None = None
     try:
         # turn 开始时推送当前上下文用量（含刚加入的 user message）
-        initial_turn_usage = await _calculate_context_usage(session, system_prompt, model_name=current_model_name)
+        initial_turn_usage = await _calculate_context_usage(session, system_prompt, max_tokens=current_max_tokens, model_name=current_model_name or "")
         await ws.send_json({"type": "context_usage", "payload": initial_turn_usage})
 
-        final_answer = await _stream_turn(agent_sonetto, inputs, config, ws, session, system_prompt, model_name=current_model_name)
+        final_answer = await _stream_turn(agent_sonetto, inputs, config, ws, session, system_prompt, model_name=current_model_name, max_tokens=current_max_tokens)
         await ws.send_json({                                                # [向前端通信] 1. 向客户端推送最终答案
             "type": "answer",
             "payload": {"content": final_answer}
@@ -263,7 +288,7 @@ async def _run_agent_turn(
         })
     finally:
         session._active_task = None
-        context_usage = await _calculate_context_usage(session, system_prompt, model_name=current_model_name)
+        context_usage = await _calculate_context_usage(session, system_prompt, max_tokens=current_max_tokens, model_name=current_model_name or "")
         await ws.send_json({                                                # [向前端通信] 3. 推送 turn 结束 + 上下文用量
             "type": "done",
             "payload": {
@@ -340,7 +365,8 @@ async def websocket_chat(ws: WebSocket, session_id: str):
     session = app_state.session_manager.get_or_create(session_id)
 
     # ── 推送初始上下文用量 ─────────────────────────────────
-    initial_usage = await _calculate_context_usage(session, app_state.system_prompt)
+    default_max_tokens, default_model = _get_provider_context(app_state)
+    initial_usage = await _calculate_context_usage(session, app_state.system_prompt, max_tokens=default_max_tokens, model_name=default_model)
     await ws.send_json({"type": "context_usage", "payload": initial_usage})
 
     # ── 断线重连时恢复 sub-agent ──────────────────────────

--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -18,6 +18,7 @@ class ProviderCreateBody(BaseModel):
     base_url: str
     models: list[str] = []
     enabled: bool = True
+    context_window: int = 256_000
 
 
 class ProviderUpdateBody(BaseModel):
@@ -26,6 +27,7 @@ class ProviderUpdateBody(BaseModel):
     base_url: str | None = None
     models: list[str] | None = None
     enabled: bool | None = None
+    context_window: int | None = None
 
 
 class TestConnectionBody(BaseModel):
@@ -73,6 +75,7 @@ def create_provider(body: ProviderCreateBody, request: Request):
         base_url=body.base_url,
         models=body.models,
         enabled=body.enabled,
+        context_window=body.context_window,
     )
     mgr.save_config(config)
     return config.to_dict()

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from api.context_usage import estimate_context_usage
-from config.settings import get_settings
 
 router = APIRouter()
 
@@ -82,7 +81,15 @@ async def get_context_usage(session_id: str, request: Request):
     session = sm.get(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    settings = get_settings()
+    mgr = getattr(request.app.state, "provider_manager", None)
+    max_tokens = 256_000
+    model_name = ""
+    if mgr is not None and mgr.count > 0:
+        for provider in mgr.iter_enabled():
+            max_tokens = provider.config.context_window
+            model_name = provider.default_model
+            break
+
     system_prompt = request.app.state.system_prompt
     try:
         cpt = await session.checkpointer.aget_tuple(
@@ -94,8 +101,8 @@ async def get_context_usage(session_id: str, request: Request):
     usage = estimate_context_usage(
         messages=counting_messages,
         system_prompt=system_prompt,
-        max_tokens=settings.model_context_window,
-        model_name=settings.model_name,
+        max_tokens=max_tokens,
+        model_name=model_name,
     )
     usage["session_id"] = session_id
     return usage

--- a/api/server.py
+++ b/api/server.py
@@ -37,6 +37,10 @@ async def _load_const_sessions(app: FastAPI):
     if not const_list:
         return
 
+    if app.state.llm is None:
+        print(f"[const] Skipping {len(const_list)} const session(s) — no LLM available")
+        return
+
     from langgraph.checkpoint.memory import MemorySaver
 
     loaded = 0
@@ -96,13 +100,21 @@ async def lifespan(app: FastAPI):
     app.state.provider_manager = provider_manager
     print(f"[provider] loaded {provider_manager.count} provider(s)")
 
-    # 2. 其他共享资源（LLM 从 ProviderManager 优先退化到 .env）
-    app.state.llm = get_llm(provider_manager)
+    # 2. 其他共享资源（LLM 统一从 ProviderManager 获取）
+    try:
+        app.state.llm = get_llm(provider_manager)
+    except RuntimeError as e:
+        print(f"[llm] {e}")
+        print("[llm] No LLM configured — chat will be read-only until a provider is added")
+        app.state.llm = None
     app.state.system_prompt = get_system_prompt()
     app.state.native_tools = get_tools()
     app.state.session_manager = SessionManager()
     app.state.ltm = LongTermMemoryInterface(MEMORY_PATH)
-    app.state.ltm.start_listening(app.state.llm)
+    if app.state.llm is not None:
+        app.state.ltm.start_listening(app.state.llm)
+    else:
+        print("[ltm] Skipped (no LLM available)")
 
     # 加载 MCP 工具（Word 文档编辑能力）
     app.state.mcp_tools = await init_mcp_tools()

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,4 +1,9 @@
-"""Pydantic BaseSettings，从 .env 文件加载配置。"""
+"""Pydantic BaseSettings，从 .env 文件加载配置。
+
+LLM 提供商配置（API key、base_url、model、context_window）
+已移至 providers.yaml，通过 Web UI /providers 管理。
+此文件仅保留工具类凭据和第三方服务 API key。
+"""
 
 from pydantic_settings import BaseSettings
 
@@ -6,12 +11,8 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """全局配置，所有 API Key 从环境变量/.env 加载。"""
 
-    # ZhiPu AI (GLM-5V-Turbo 图片理解)
+    # ZhiPu AI (GLM-5V-Turbo 图片理解工具)
     zhipuai_api_key: str = ""
-
-    # DeepSeek
-    deepseek_api_key: str = ""
-    deepseek_base_url: str = "https://api.deepseek.com/v1"
 
     # Todoist
     todoist_api_token: str = ""
@@ -24,12 +25,6 @@ class Settings(BaseSettings):
 
     # Tavily（网络搜索/提取）
     tavily_api_key: str = ""
-
-    # 模型上下文窗口大小（DeepSeek V4 Flash = 1M tokens）
-    model_context_window: int = 256_000 # 避免上下文丢失现象
-
-    # 模型名称
-    model_name: str = "deepseek-v4-flash"
 
     model_config = {
         "env_file": ".env",

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -60,15 +60,12 @@
         <div class="input-right-group">
           <div class="dropdown">
             <button class="dropdown-trigger" :class="{ empty: providers.length === 0 }" @click.stop="toggleDropdown('provider')">
-              {{ providers.length === 0 ? '未配置模型' : (selectedProviderId ? (providers.find(p => p.id === selectedProviderId)?.label || selectedProviderId) : '默认模型') }}
+              {{ providers.length === 0 ? '未配置模型' : (providers.find(p => p.id === selectedProviderId)?.label || '选择提供商') }}
               <span class="dropdown-arrow">▾</span>
             </button>
             <div v-if="openDropdown === 'provider'" class="dropdown-menu">
               <button v-if="providers.length === 0" class="dropdown-option disabled">暂无可用的提供商，请先在模型设置中添加</button>
-              <template v-else>
-                <button class="dropdown-option" :class="{ selected: !selectedProviderId }" @click="selectProvider('')">默认模型</button>
-                <button v-for="p in providers" :key="p.id" class="dropdown-option" :class="{ selected: selectedProviderId === p.id }" @click="selectProvider(p.id)">{{ p.label }}</button>
-              </template>
+              <button v-for="p in providers" :key="p.id" class="dropdown-option" :class="{ selected: selectedProviderId === p.id }" @click="selectProvider(p.id)">{{ p.label }}</button>
             </div>
           </div>
           <div v-if="currentModels.length" class="dropdown">
@@ -471,6 +468,10 @@ async function loadProviders() {
   try {
     const res = await api.listProviders()
     providers.value = res.providers.filter(p => p.enabled)
+    // 默认选中第一个已启用的提供商
+    if (providers.value.length > 0 && !selectedProviderId.value) {
+      selectProvider(providers.value[0].id)
+    }
   } catch {
     // 静默失败
   }

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -59,13 +59,16 @@
         </div>
         <div class="input-right-group">
           <div class="dropdown">
-            <button class="dropdown-trigger" @click.stop="toggleDropdown('provider')">
-              {{ selectedProviderId ? (providers.find(p => p.id === selectedProviderId)?.label || selectedProviderId) : '默认模型' }}
+            <button class="dropdown-trigger" :class="{ empty: providers.length === 0 }" @click.stop="toggleDropdown('provider')">
+              {{ providers.length === 0 ? '未配置模型' : (selectedProviderId ? (providers.find(p => p.id === selectedProviderId)?.label || selectedProviderId) : '默认模型') }}
               <span class="dropdown-arrow">▾</span>
             </button>
             <div v-if="openDropdown === 'provider'" class="dropdown-menu">
-              <button class="dropdown-option" :class="{ selected: !selectedProviderId }" @click="selectProvider('')">默认模型</button>
-              <button v-for="p in providers" :key="p.id" class="dropdown-option" :class="{ selected: selectedProviderId === p.id }" @click="selectProvider(p.id)">{{ p.label }}</button>
+              <button v-if="providers.length === 0" class="dropdown-option disabled">暂无可用的提供商，请先在模型设置中添加</button>
+              <template v-else>
+                <button class="dropdown-option" :class="{ selected: !selectedProviderId }" @click="selectProvider('')">默认模型</button>
+                <button v-for="p in providers" :key="p.id" class="dropdown-option" :class="{ selected: selectedProviderId === p.id }" @click="selectProvider(p.id)">{{ p.label }}</button>
+              </template>
             </div>
           </div>
           <div v-if="currentModels.length" class="dropdown">
@@ -81,7 +84,8 @@
             <button
               v-if="!isStreaming"
               class="btn-send"
-              :disabled="!text.trim() || disabled"
+              :disabled="!text.trim() || disabled || noProvider"
+              :title="noProvider ? '请先在模型设置中添加 LLM 提供商' : ''"
               @click="handleSend"
             >
               <Icon name="send" :size="16" />
@@ -436,6 +440,7 @@ const selectedProviderId = ref('')
 const selectedModelName = ref('')
 const currentModels = ref<string[]>([])
 const openDropdown = ref<'provider' | 'model' | null>(null)
+const noProvider = computed(() => providers.value.length === 0)
 
 function toggleDropdown(name: 'provider' | 'model') {
   openDropdown.value = openDropdown.value === name ? null : name
@@ -561,6 +566,18 @@ function autoResize() {
 .dropdown-trigger:hover {
   background: var(--bg-secondary);
   color: var(--text-primary);
+}
+.dropdown-trigger.empty {
+  color: var(--status-error);
+  opacity: 0.7;
+}
+.dropdown-option.disabled {
+  color: var(--text-secondary);
+  font-style: italic;
+  cursor: default;
+  font-size: 11px;
+  white-space: normal;
+  line-height: 1.4;
 }
 .dropdown-arrow {
   font-size: 9px;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -289,6 +289,7 @@ export interface ProviderConfig {
   base_url: string
   models: string[]
   enabled: boolean
+  context_window?: number
 }
 
 export interface ListProvidersResponse {

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -1,5 +1,16 @@
 <template>
   <div class="chat-view">
+    <!-- 无提供商引导卡片 -->
+    <div v-if="!hasProviders" class="no-provider-overlay">
+      <div class="no-provider-card">
+        <div class="no-provider-icon">⚙️</div>
+        <h3>暂无已配置的 LLM 提供商</h3>
+        <p>请添加一个 API 提供商以开始对话。SonettoHere 支持任何 OpenAI 兼容 API。</p>
+        <router-link to="/providers" class="btn primary">前往模型设置</router-link>
+      </div>
+    </div>
+    <!-- 正常聊天界面 -->
+    <template v-else>
     <header class="chat-header">
       <StatusBadge :connected="connected" :health="health" />
       <span class="private-trigger hover-trigger">
@@ -71,6 +82,7 @@
     <div v-else class="sub-agent-readonly-bar">
       <span class="sub-agent-readonly-text">🔒 子 Agent 会话 — 只读</span>
     </div>
+    </template>
   </div>
 </template>
 
@@ -85,13 +97,23 @@ import { useChat } from '@/composables/useChat'
 import { health } from '@/composables/useHealth'
 import { useSession } from '@/composables/useSession'
 import type { ParsedRef } from '@/utils/references'
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 
 const { sessionId, sessions } = useSession()
 const { connected, isStreaming, turns, currentTurn, error, contextUsage, taskTrackerData, send, cancel, sendUserResponse, removeTurns, privateMode, setPrivateMode, autoApprove, setAutoApprove } =
   useChat(sessionId)
 
 const selectedModelName = ref('')
+const hasProviders = ref(true)
+
+onMounted(async () => {
+  try {
+    const res = await api.listProviders()
+    hasProviders.value = res.providers.some(p => p.enabled)
+  } catch {
+    hasProviders.value = true // fallback: assume there's a provider
+  }
+})
 
 function onModelChange(_providerId: string, modelName: string) {
   selectedModelName.value = modelName
@@ -304,5 +326,53 @@ async function handleUndo() {
 .sub-agent-readonly-text {
   font-size: 12px;
   color: var(--text-secondary);
+}
+
+/* ── 无提供商引导 ── */
+.no-provider-overlay {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.no-provider-card {
+  text-align: center;
+  max-width: 400px;
+  padding: 40px 32px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+}
+.no-provider-icon {
+  font-size: 48px;
+  margin-bottom: 16px;
+}
+.no-provider-card h3 {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: var(--text-primary);
+}
+.no-provider-card p {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 24px;
+}
+.btn.primary {
+  display: inline-block;
+  padding: 10px 24px;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 8px;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  transition: opacity 0.15s;
+}
+.btn.primary:hover {
+  opacity: 0.85;
 }
 </style>

--- a/web/src/views/ProvidersView.vue
+++ b/web/src/views/ProvidersView.vue
@@ -41,6 +41,11 @@
             </div>
           </div>
 
+          <!-- 上下文窗口 -->
+          <div class="card-context-window">
+            上下文窗口: {{ (p.context_window ?? 256000).toLocaleString() }} tokens
+          </div>
+
           <!-- 测试结果 -->
           <Transition name="fade">
             <div v-if="testResult?.[p.id]" class="test-result" :class="testResult[p.id].status">
@@ -84,6 +89,11 @@
       <div class="form-section">
         <label class="form-label">Base URL</label>
         <input v-model="form.base_url" class="input mono" placeholder="https://api.deepseek.com" />
+      </div>
+
+      <div class="form-section">
+        <label class="form-label">Context Window (tokens)</label>
+        <input v-model.number="form.context_window" class="input mono" type="number" placeholder="256000" />
       </div>
 
       <!-- 测试 & 拉取模型 -->
@@ -143,7 +153,7 @@ const providers = ref<ProviderConfig[]>([])
 const loading = ref(false)
 
 // ── 表单 ──
-const form = ref({ id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: '' })
+const form = ref({ id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: '', context_window: 256000 })
 const isEditing = computed(() => mode.value === 'edit')
 const editingId = ref('')
 
@@ -245,7 +255,7 @@ async function loadProviders() {
 
 function startAdd() {
   mode.value = 'add'
-  form.value = { id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: presetBaseUrl('deepseek') }
+  form.value = { id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: presetBaseUrl('deepseek'), context_window: 256000 }
   discoveredModels.value = []
   selectedModels.value = []
   formError.value = ''
@@ -261,6 +271,7 @@ function startEdit(p: ProviderConfig) {
     label: p.label,
     api_key: '',
     base_url: p.base_url,
+    context_window: p.context_window ?? 256000,
   }
   discoveredModels.value = [...p.models]
   selectedModels.value = [...p.models]
@@ -285,10 +296,11 @@ async function handleSave() {
       base_url: form.value.base_url,
       models: selectedModels.value,
       enabled: true,
+      context_window: form.value.context_window,
     }
     if (isEditing.value) {
       // PUT — only send changed fields
-      const updateBody: any = { label: body.label, base_url: body.base_url, models: body.models }
+      const updateBody: any = { label: body.label, base_url: body.base_url, models: body.models, context_window: body.context_window }
       if (form.value.api_key) updateBody.api_key = form.value.api_key
       await api.updateProvider(editingId.value, updateBody)
     } else {
@@ -496,6 +508,11 @@ onMounted(loadProviders)
 .model-tag.empty {
   color: #d1d5db;
   font-family: inherit;
+}
+
+.card-context-window {
+  font-size: 12px;
+  color: #9ca3af;
 }
 
 /* ── 测试结果 ── */


### PR DESCRIPTION
## 动机

移除 .env 对模型配置的强制依赖，所有 LLM 提供商统一经 providers.yaml 管理。

**关联 Issue：** Closes #110 问题一（.env 强制依赖 API Key）、#109 问题三（MCP 容错）

## 核心变更

### 后端
| 文件 | 变更 |
|---|---|
| `config/settings.py` | 移除 `deepseek_api_key`、`deepseek_base_url`、`model_name`、`model_context_window` |
| `api/providers/__init__.py` | `ProviderConfig` 新增 `context_window` 字段 |
| `api/providers/store.py` | `migrate_from_env()` 改为直接读 `os.environ` |
| `api/dependencies.py` | 移除 ENV 降级分支，无 provider 时抛 `RuntimeError` |
| `api/health.py` | `check_llm()` 改为通过 ProviderManager 遍历 |
| `api/routes/balance.py` | 从 ProviderManager 查找 DeepSeek key |
| `api/server.py` | 优雅处理无 LLM 状态 |
| `api/routes/chat.py` | 传递 `context_window`；无 LLM 时 WS 返回 `NO_LLM` |
| `api/routes/sessions.py` | 从 ProviderManager 获取 `context_window` |
| `api/routes/providers.py` | CRUD 支持 `context_window` |

### 前端
| 文件 | 变更 |
|---|---|
| `web/src/types/index.ts` | `ProviderConfig` 添加 `context_window` |
| `web/src/views/ProvidersView.vue` | 表单/卡片增加 context_window |
| `web/src/views/ChatView.vue` | 无提供商时显示引导卡片 |
| `web/src/components/ChatInput.vue` | 无提供商时禁用发送 |

### 文档
| 文件 | 变更 |
|---|---|
| `.env.example` / `README.md` | 更新配置指引 |

Ref #110