### PR TITLE
fix: 修复按钮样式统一、UI 文本及时间轴对齐问题

### DIFF
--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="session-sidebar" :class="{ collapsed }">
     <div class="sidebar-section-header">
-      <span>会话列表</span>
+      <span>会话 Sessions</span>
       <button class="btn-new" @click="$emit('create')" title="新会话">+</button>
     </div>
     <div class="session-list">
@@ -189,10 +189,10 @@
 </template>
 
 <script setup lang="ts">
-import type { SessionInfo } from '@/types';
 import ContextMenu from '@/components/ContextMenu.vue';
 import Icon from '@/components/Icon.vue';
 import { generateSessionTitle } from '@/composables/useSession';
+import type { SessionInfo } from '@/types';
 import { computed, nextTick, ref, watch } from 'vue';
 
 const props = defineProps<{

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -178,13 +178,13 @@ async function handleUndo() {
   justify-content: center;
   gap: 6px;
   min-width: 62px;
+  height: 26px;
   padding: 4px 12px;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: transparent;
   color: var(--text-secondary);
   font-size: 12px;
-  line-height: 1;
   cursor: pointer;
   transition: all 0.15s;
   user-select: none;

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -184,6 +184,7 @@ async function handleUndo() {
   background: transparent;
   color: var(--text-secondary);
   font-size: 12px;
+  line-height: 1;
   cursor: pointer;
   transition: all 0.15s;
   user-select: none;

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -174,7 +174,9 @@ async function handleUndo() {
 .private-toggle {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
+  min-width: 64px;
   padding: 4px 12px;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -232,7 +234,9 @@ async function handleUndo() {
 .auto-approve-toggle {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
+  min-width: 64px;
   padding: 4px 12px;
   border: 1px solid var(--border);
   border-radius: 6px;

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -42,7 +42,7 @@
           @click="setAutoApprove(!autoApprove)"
         >
           <span class="auto-approve-indicator"></span>
-          {{ autoApprove ? 'ATE' : 'ABE' }}
+          {{ autoApprove ? '自动' : '检查' }}
         </button>
         <div class="hover-card card-auto-approve">
           <div class="card-row">

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -171,12 +171,13 @@ async function handleUndo() {
   border-bottom: 1px solid var(--border);
   background: var(--bg-card);
 }
-.private-toggle {
+.private-toggle,
+.auto-approve-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
-  min-width: 64px;
+  min-width: 62px;
   padding: 4px 12px;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -230,22 +231,6 @@ async function handleUndo() {
   visibility: visible;
   opacity: 1;
   transform: translateY(0);
-}
-.auto-approve-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  min-width: 64px;
-  padding: 4px 12px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
-  cursor: pointer;
-  transition: all 0.15s;
-  user-select: none;
 }
 .auto-approve-toggle:hover {
   border-color: var(--text-secondary);

--- a/web/src/views/NewsView.vue
+++ b/web/src/views/NewsView.vue
@@ -23,7 +23,7 @@
           v-for="node in versionNodes"
           :key="node.version"
           class="tl-node"
-          :style="{ top: node.top + '%' }"
+          :style="{ top: node.top + 'px' }"
         >
           <div class="tl-dot"></div>
           <span class="tl-label">{{ node.version }}</span>
@@ -37,12 +37,13 @@
 import { api } from '@/api'
 import type { NewsEntry } from '@/types'
 import NewsCard from '@/components/NewsCard.vue'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 
 const news = ref<NewsEntry[]>([])
 const loading = ref(false)
 const cardGridRef = ref<HTMLElement | null>(null)
 const tlBounds = ref<{ top: string; height: string }>()
+const versionNodes = ref<{ version: string; top: number }[]>([])
 
 let observer: ResizeObserver | null = null
 
@@ -65,6 +66,23 @@ function updateTimelineBounds() {
     top: top + 'px',
     height: (bottom - top) + 'px',
   }
+
+  // 根据卡片实际 DOM 位置计算版本圆点的 top 值，而非按索引均分
+  const tlTop = bodyRect.top + top
+  const seen = new Set<string>()
+  const nodes: { version: string; top: number }[] = []
+  news.value.forEach((entry, idx) => {
+    if (seen.has(entry.version)) return
+    seen.add(entry.version)
+    const card = cards[idx]
+    if (!card) return
+    const cardRect = card.getBoundingClientRect()
+    nodes.push({
+      version: entry.version,
+      top: cardRect.top + cardRect.height / 2 - tlTop,
+    })
+  })
+  versionNodes.value = nodes
 }
 
 async function loadNews() {
@@ -90,25 +108,6 @@ onUnmounted(() => {
   observer?.disconnect()
 })
 
-const versionNodes = computed(() => {
-  const entries = news.value
-  if (entries.length === 0) return []
-
-  const seen = new Set<string>()
-  const nodes: { version: string; top: number }[] = []
-
-  entries.forEach((entry, idx) => {
-    if (!seen.has(entry.version)) {
-      seen.add(entry.version)
-      nodes.push({
-        version: entry.version,
-        top: entries.length > 1 ? (idx / (entries.length - 1)) * 100 : 50,
-      })
-    }
-  })
-
-  return nodes
-})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- 统一按钮 min-width 为 62px，消除状态切换时的尺寸跳动
- 按钮改用固定 height:26px，line-height:1
- 自动审核按钮文本从 'ATE'/'ABE' 改为 '自动'/'检查'
- 新闻时间轴圆点按卡片实际 DOM 位置对齐，而非按索引均分
- 会话列表标题从 '会话列表' 改为 '会话 Sessions'
- 优化 import 顺序

## Test Plan
- [ ] 按钮在不同状态间切换无尺寸跳动
- [ ] 新闻时间轴版本圆点与对应卡片对齐
- [ ] 自动审核按钮显示正确中文

🤖 Generated with [Claude Code](https://claude.com/claude-code)