### PR TITLE
feat: 本地文件安全防护系统（SonettoBlocker + 路径白名单）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,8 @@ config/personas/memory.yaml
 # Provider credentials (明文 API key)
 providers.yaml
 
+# 路径白名单（自动生成，每用户本地配置）
+api/data/path_whitelist.yaml
+
 # Anthropic Skills（忽略 skill 子目录，保留目录本身用于 .gitkeep）
 anthropic_skills/*/

--- a/api/callbacks/tool_extractors.py
+++ b/api/callbacks/tool_extractors.py
@@ -52,7 +52,9 @@ def _dispatch(tool_name: str, parsed: dict[str, Any],
 # ── Helper ─────────────────────────────────────────────────────────────
 
 def _get_data(parsed: dict[str, Any]) -> dict[str, Any] | None:
-    """提取 parsed['data'] 并校验为 dict。"""
+    """提取 parsed['data'] 并校验为 dict。success=false 时视为错误返回 None。"""
+    if parsed.get("success") is False:
+        return None
     data = parsed.get("data", {})
     return data if isinstance(data, dict) else None
 

--- a/api/callbacks/websocket_callback.py
+++ b/api/callbacks/websocket_callback.py
@@ -94,6 +94,23 @@ class WebSocketCallback(BaseCallbackHandler):
 
         out_str = _extract_content(output)
 
+        # ── 检测 format_error 响应 → 路由到 tool_error ────────────
+        try:
+            parsed = json.loads(out_str)
+            if isinstance(parsed, dict) and parsed.get("success") is False:
+                error_msg = parsed.get("error", "操作执行失败")
+                await self._ws.send_json({
+                    "type": "tool_error",
+                    "payload": {
+                        "tool_name": tool_name,
+                        "error": error_msg,
+                    },
+                })
+                return
+        except (json.JSONDecodeError, TypeError):
+            pass
+        # ──────────────────────────────────────────────────────────
+
         # 提取工具专属结构化数据
         tool_data = self._extract_tool_data(tool_name, output, tool_input)
 

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -1,4 +1,12 @@
 news:
+  - id: "local-file-security"
+    title: "本地文件安全防护"
+    description: "新增 SonettoBlocker 黑名单阻断与路径白名单双层安全机制。Blocker 通过目录标记文件即可阻断访问，白名单自动生成仅开放技能目录。两大工具系列（文件/exec）全部同步覆盖，Blocker 优先拦截。"
+    type: "feat"
+    date: "2026-06-18"
+    tags: ["安全", "文件", "权限"]
+    version: "PREVIEW"
+    pr_number: 124
   - id: "v2.0.0-release"
     title: "发布 v2.0.0 版本"
     description: "v2.0.0 版本标志项目进入新的里程碑。提供商管理全面升级：彻底移除 .env 配置，统一由 providers.yaml + 前端面板管理。Markdown 渲染引擎从 marked 切换到 markdown-it，新增数学公式定界符支持。所有工具 description 添加调用策略标签，协作更规范。"

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -6,7 +6,7 @@ news:
     date: "2026-06-18"
     tags: ["安全", "文件", "权限"]
     version: "PREVIEW"
-    pr_number: 124
+    pr_number: 127
   - id: "v2.0.0-release"
     title: "发布 v2.0.0 版本"
     description: "v2.0.0 版本标志项目进入新的里程碑。提供商管理全面升级：彻底移除 .env 配置，统一由 providers.yaml + 前端面板管理。Markdown 渲染引擎从 marked 切换到 markdown-it，新增数学公式定界符支持。所有工具 description 添加调用策略标签，协作更规范。"

--- a/dev_docs/path-whitelist.md
+++ b/dev_docs/path-whitelist.md
@@ -1,0 +1,240 @@
+# 路径白名单审查机制
+
+## 背景
+
+SonettoHere 的 Python 执行工具（`run_python`、`debugger`）通过 `exec()` 执行 LLM 生成的代码时，原先暴露了完整的 Python 内置函数，被执行代码可以自由读写系统中任何路径的文件。同时 `unit_test_runner`、`syntax_checker`、`code_quality_analyzer` 等工具接受文件路径参数却未做任何验证。
+
+此前仅有文件操作工具通过 `check_sonetto_blocker()` 实现了基本的阻断机制（检查目录中是否存在 `SonettoBlocker` 标记文件），但缺少一个"白名单允许"机制——即只有明确授权的路径才能被访问。
+
+## 设计目标
+
+1. **简单** —— 白名单定义在一个本地 YAML 文件中，无需数据库或 UI
+2. **零配置启动** —— 首次运行自动创建，根据当前工程目录自动填入项目根目录
+3. **不提交 git** —— 白名单文件在 `.gitignore` 中，每用户本地独立配置
+4. **工程移动自适应** —— 工程目录变更后自动替换项目根路径，用户自定义条目保留
+5. **安全默认** —— 默认只允许项目根目录，白名单缺失时全阻断（fail-secure）
+6. **低侵入** —— 不依赖第三方沙箱库，不改动项目框架
+7. **日常友好** —— 不影响 LLM 正常使用 `import`、`eval` 等语法特性
+
+## 架构概览
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    LLM / Agent                           │
+└──────────┬──────────────────────┬───────────────────────┘
+           │                      │
+           ▼                      ▼
+┌──────────────────┐   ┌──────────────────────────┐
+│  工具参数路径     │   │  exec() 内 open() 调用    │
+│  (test_file/     │   │  (run_python / debugger)  │
+│   file_path)     │   │                          │
+└────────┬─────────┘   └───────────┬──────────────┘
+         │                         │
+         ▼                         ▼
+┌────────────────────────────────────────────────────────┐
+│              check_path_whitelisted()                   │
+│   ┌────────────────────────────────────────────────┐   │
+│   │  遍历白名单，检查目标是否以任一允许前缀开头      │   │
+│   │  精确匹配 / 前缀+分隔符匹配，防前缀碰撞逃逸     │   │
+│   └────────────────────────────────────────────────┘   │
+└──────────────────────┬─────────────────────────────────┘
+                       │
+                       ▼
+┌────────────────────────────────────────────────────────┐
+│           api/data/path_whitelist.yaml                  │
+│   ┌────────────────────────────────────────────────┐   │
+│   │   启动时自动生成（_ensure_whitelist()）          │   │
+│   │   - 文件缺失 → 创建，写入当前项目根目录         │   │
+│   │   - 工程移动 → 替换根路径，保留用户条目         │   │
+│   │   - 文件已就绪 → 不做操作                      │   │
+│   └────────────────────────────────────────────────┘   │
+│   whitelist:                                           │
+│     - path: "{project_root}"                           │
+│       description: 项目根目录（自动生成）               │
+└────────────────────────────────────────────────────────┘
+```
+
+## 核心实现
+
+### 1. 白名单文件
+
+**路径**: `api/data/path_whitelist.yaml`
+
+该文件**不提交 git**（已在 `.gitignore` 中），首次启动时由 `_ensure_whitelist()` 自动创建：
+
+```yaml
+# 路径白名单（自动生成，首次 import 时创建）
+# 编辑此文件以添加更多允许的路径前缀。
+whitelist:
+- description: 项目根目录（自动生成）
+  path: C:\Users\xxx\PycharmProjects\SonettoHere
+```
+
+- 每个条目包含 `path`（允许的路径前缀，支持正斜杠/反斜杠）和可选的 `description`
+- 可添加多个条目来允许不同目录
+- 白名单为空、缺失或解析失败时，所有路径都被阻断（fail-secure）
+
+#### 自动生成行为
+
+`_ensure_whitelist()` 在模块导入时（即应用启动时）运行一次：
+
+| 场景 | 行为 |
+|------|------|
+| 文件不存在（首次启动 / git clone 后） | 自动创建，写入当前工程根目录 |
+| 工程被移动（文件有旧路径） | 替换项目根目录条目，用户添加的额外条目保留 |
+| 文件已存在且工程目录匹配 | 不做任何操作 |
+
+### 2. 核心函数
+
+定义在 `tools/base.py`，与已有的 `check_sonetto_blocker()` 同级。
+
+#### `_ensure_whitelist()`
+
+启动时自动调用一次，确保白名单文件存在且项目根目录正确：
+
+1. 文件不存在 → 调用 `_write_whitelist()` 创建默认文件
+2. 文件存在但内容无效（损坏 / 不是列表） → 重写默认文件
+3. 文件存在且有效 → 检查是否有条目匹配当前项目根目录
+   - 匹配 → 不做操作
+   - 不匹配 → 寻找 `description == "项目根目录（自动生成）"` 的旧条目并更新其 `path`；若无则插入新条目
+4. YAML 加载异常时全量重写（fail-secure）
+
+> 用户手动添加的额外条目（不带"自动生成"标记）在工程移动更新时会被保留。
+
+#### `check_path_whitelisted(target_path: str) -> str | None`
+
+路径白名单检查的统一入口：
+
+1. 将 `target_path` 正规化为绝对路径（`os.path.normpath(os.path.abspath())`），消除 `../` 等相对路径绕过
+2. 加载白名单文件中的路径前缀列表
+3. 逐一比对：若目标路径**精确等于**某个前缀，或目标路径以**前缀 + `os.sep`** 开头，则允许
+4. 返回 `None` = 允许；返回 `str` = 阻断原因描述
+
+> 使用 `startswith(allowed_prefix + os.sep)` 而非简单的 `startswith(allowed_prefix)`，防止 `/home/project` 误匹配 `/home/project-evil`。
+
+#### `_whitelisted_open(file, mode, ...) -> file object`
+
+Python 内置 `open()` 的包装版本，`get_safe_builtins()` 在构造 exec 环境时用此函数替代原版 `open`：
+
+1. 检查 `file` 参数是否为字符串路径（跳过已打开的文件描述符）
+2. 调用 `check_path_whitelisted()` 检查该路径
+3. 未通过 → 抛出 `PermissionError`
+4. 通过 → 调用真正的 `open()` 执行操作
+
+#### `get_safe_builtins() -> dict`
+
+构造一个安全的 `__builtins__` 字典给 `exec()` 使用：
+
+1. 复制全部内置函数（152+ 个）
+2. 仅将 `open` 替换为 `_whitelisted_open`，其余所有函数（`__import__`、`eval`、`getattr` 等）保留
+3. 设置 `__builtins__` 自引用，使被执行代码看到的 `__builtins__` 也是同一份安全版本
+
+### 3. 在各工具中的应用
+
+#### 路径参数验证（编译时检查）
+
+在工具接受文件路径参数的入口处显式调用 `check_path_whitelisted()`：
+
+| 工具 | 文件 | 验证的参数 |
+|------|------|-----------|
+| `unit_test_runner` | `tools/development/tool_unit_test.py` | `test_file` |
+| `syntax_checker` | `tools/development/tool_syntax.py` | `file_path` |
+| `code_quality_analyzer` | `tools/development/tool_code_quality.py` | `file_path` |
+
+调用模式：
+
+```python
+blocked = check_path_whitelisted(test_file)
+if blocked:
+    return format_error(blocked)
+```
+
+#### exec() 运行时拦截（运行时检查）
+
+`run_python` 和 `debugger` 通过 `exec()` 执行的代码无法预先知道会访问哪些路径，因此采用运行时拦截：
+
+- `exec()` 的全局命名空间传入 `get_safe_builtins()` 返回的字典
+- 被执行代码中的 `open()` 实际上是 `_whitelisted_open`，在每次打开文件时实时检查白名单
+- 非白名单路径 → `PermissionError`，由 exec 的异常捕获流程返回给 LLM
+
+### 4. 与 SonettoBlocker 的关系
+
+现有 SonettoBlocker 和白名单是互补的两层：
+
+| 机制 | 作用 | 范围 |
+|------|------|------|
+| **SonettoBlocker** | 黑名单式阻断（目录中存在标记文件即阻断） | 仅文件操作工具 |
+| **路径白名单** | 白名单式允许（仅允许已列出的前缀） | Python 执行工具 + 开发工具 |
+
+SonettoBlocker 的"阻断"层级更高——即使路径在白名单内，如果某级目录存在 `SonettoBlocker` 文件，仍然会被阻断。
+
+## 安全边界与局限
+
+### 防护范围
+
+- **直接 `open()` 调用** —— ✅ 受控，白名单外路径抛 `PermissionError`
+- **相对路径遍历** —— ✅ `abspath()` 解析后检查，`../../etc/passwd` 无法绕过
+- **前缀碰撞** —— ✅ `startswith(prefix + os.sep)` 排除
+- **文件描述符绕过** —— ✅ `_whitelisted_open` 对 `int` 类型的 `file` 参数跳过检查（此类调用由内部代码而非 LLM 生成代码发起）
+
+### 已知局限
+
+- **`os.open()` / `os.system()` / `subprocess` 等间接路径访问不受限** —— 因为 LLM 代码可以通过 `import os` 获得 `os.open()`，其绕过白名单。要拦截这些需要对模块本身的函数做替换，超出了"简单机制"的范围。如果后续需要加强，可以考虑替换 `__import__` 返回包装过的模块，但这会显著增加复杂度。
+
+- **类层级遍历逃逸** —— 即使替换了 `open`，`().__class__.__bases__[0].__subclasses__()` 仍能找到原始 `open`。这是 Python `exec()` 沙箱的固有难题，不在本机制的解决范围内。
+
+- **`PermissionError` 可被捕获** —— 被执行代码可以用 `try/except PermissionError` 捕获阻断异常，但这不影响阻断本身的效果，文件仍然不会被打开。
+
+## 配置指南
+
+### 添加允许路径
+
+编辑 `api/data/path_whitelist.yaml`，添加新条目：
+
+```yaml
+whitelist:
+  - path: "D:/data"
+    description: 用户数据目录
+  - path: "/tmp"
+    description: 系统临时目录
+  - path: "/mnt/share"
+    description: 网络共享目录
+```
+
+> 项目根目录由启动时自动生成，无需手动添加。用户只需添加额外需要访问的目录。
+> 路径格式支持 Windows (`D:/xxx`) 和 POSIX (`/tmp`) 风格，`os.path.abspath()` 会做平台相关解析。
+
+### 安全建议
+
+- 只添加必要的目录，遵循最小权限原则
+- 对于临时文件读写，优先指向项目目录内的临时目录
+- 生产环境不应包含 `/tmp` 等全局可写目录
+
+## 测试
+
+在项目根目录执行以下验证（无需启动服务）：
+
+```bash
+python -c "
+import sys; sys.path.insert(0, '.')
+from tools.base import check_path_whitelisted, get_safe_builtins
+
+# 测试白名单
+assert check_path_whitelisted('tools/base.py') is None           # 允许
+assert check_path_whitelisted('C:/Windows/System32') is not None # 阻断
+
+# 测试 safe builtins
+rb = get_safe_builtins()
+exec('import math; print(math.pi)', {'__builtins__': rb})       # 正常
+exec('open(\"C:/Windows/System32/hosts\")', {'__builtins__': rb})  # PermissionError
+
+print('All checks passed.')
+"
+```
+
+## 变更历史
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-06-18 | 初始实现：路径白名单 + open 运行时拦截 + 工具参数验证 | Claude Code |
+| 2026-06-18 | 白名单改为自动生成，不跟踪 git，工程移动自适应 | Claude Code |

--- a/dev_docs/path-whitelist.md
+++ b/dev_docs/path-whitelist.md
@@ -49,8 +49,8 @@ SonettoHere 的 Python 执行工具（`run_python`、`debugger`）通过 `exec()
 │   │   - 文件已就绪 → 不做操作                      │   │
 │   └────────────────────────────────────────────────┘   │
 │   whitelist:                                           │
-│     - path: "{project_root}"                           │
-│       description: 项目根目录（自动生成）               │
+│     - path: "{project_root}/anthropic_skills"           │
+│       description: 技能目录（自动生成）                 │
 └────────────────────────────────────────────────────────┘
 ```
 
@@ -66,8 +66,8 @@ SonettoHere 的 Python 执行工具（`run_python`、`debugger`）通过 `exec()
 # 路径白名单（自动生成，首次 import 时创建）
 # 编辑此文件以添加更多允许的路径前缀。
 whitelist:
-- description: 项目根目录（自动生成）
-  path: C:\Users\xxx\PycharmProjects\SonettoHere
+- description: 技能目录（自动生成）
+  path: C:\Users\xxx\PycharmProjects\SonettoHere\anthropic_skills
 ```
 
 - 每个条目包含 `path`（允许的路径前缀，支持正斜杠/反斜杠）和可选的 `description`
@@ -80,9 +80,11 @@ whitelist:
 
 | 场景 | 行为 |
 |------|------|
-| 文件不存在（首次启动 / git clone 后） | 自动创建，写入当前工程根目录 |
-| 工程被移动（文件有旧路径） | 替换项目根目录条目，用户添加的额外条目保留 |
-| 文件已存在且工程目录匹配 | 不做任何操作 |
+| 文件不存在（首次启动 / git clone 后） | 自动创建，写入 `_PROJECT_ROOT/anthropic_skills` |
+| 工程被移动（自动条目路径不匹配） | 替换自动条目路径，用户添加的额外条目保留 |
+| 文件已存在且自动条目匹配 | 不做任何操作 |
+
+> **为什么是 `anthropic_skills`？** 该目录存放用户自定义的技能文件，是工具执行时最常需要读写的位置。项目根目录下其余代码库（`tools/`、`api/` 等）不被默认暴露，遵循最小权限原则。
 
 ### 2. 核心函数
 
@@ -201,13 +203,14 @@ whitelist:
     description: 网络共享目录
 ```
 
-> 项目根目录由启动时自动生成，无需手动添加。用户只需添加额外需要访问的目录。
+> 自动生成的技能目录无需手动添加。用户只需添加额外需要访问的目录。
 > 路径格式支持 Windows (`D:/xxx`) 和 POSIX (`/tmp`) 风格，`os.path.abspath()` 会做平台相关解析。
 
 ### 安全建议
 
-- 只添加必要的目录，遵循最小权限原则
-- 对于临时文件读写，优先指向项目目录内的临时目录
+- 遵循最小权限原则——只添加必要的目录
+- 默认仅开放 `anthropic_skills`，不要随意放回整个项目根目录
+- 对于临时文件读写，应在项目目录内创建专门的子目录并单独添加
 - 生产环境不应包含 `/tmp` 等全局可写目录
 
 ## 测试

--- a/dev_docs/security/local-file-security.md
+++ b/dev_docs/security/local-file-security.md
@@ -1,0 +1,381 @@
+# SonettoHere 本地文件读写安全机制
+
+## 概述
+
+SonettoHere 采用**两层互补**的安全机制保护本地文件系统，防止 LLM 生成的代码或工具调用越权读写文件：
+
+| 层级 | 机制 | 类型 | 粒度 | 定义方式 |
+|------|------|------|------|----------|
+| 第一层 | **SonettoBlocker** | 黑名单式阻断 | 目录级 | 在目标目录放置标记文件 |
+| 第二层 | **路径白名单** | 白名单式允许 | 路径前缀 | YAML 配置文件 |
+
+两条防线分别覆盖两类工具入口：
+
+- **文件工具系列**（`file_ops`、`file_edit`、`pdf_reader`、`doc_reader`）—— 在工具入口处**显式调用**两层检查
+- **exec 工具系列**（`run_python`、`debugger`）—— 通过**运行时拦截 `open()`** 隐式检查
+
+此外，`unit_test_runner`、`syntax_checker`、`code_quality_analyzer` 等开发工具也在其 `file_path` 参数入口处执行路径白名单检查。
+
+---
+
+## 第一层：SonettoBlocker（黑名单阻断）
+
+### 原理
+
+SonettoBlocker 是一种基于**目录标记文件**的阻断机制。当某目录（或其任意级父目录）中存在文件名为 `SonettoBlocker`（不区分大小写，不限制扩展名）的文件时，该目录及其所有子目录下的文件操作都会被拒绝。
+
+这种方式允许用户在**不修改代码**的前提下，通过简单的"放置一个文件"来标记敏感目录。
+
+### 实现
+
+核心函数 `check_sonetto_blocker()` 定义在 `tools/base.py:88`：
+
+```python
+def check_sonetto_blocker(target_path: str) -> str | None:
+```
+
+**检查逻辑**：
+
+1. 将 `target_path` 解析为绝对路径（`os.path.abspath()`）
+2. 从**盘符根目录**开始，逐级向下检查每一层目录
+3. 每层目录中遍历所有条目，匹配忽略大小写和扩展名的 `SonettoBlocker` 文件名
+4. 一旦发现标记文件，**立即返回**该目录路径（阻断）
+5. 全部检查通过 → 返回 `None`（允许）
+
+> 为什么从根向下？因为用户可能在项目根目录放置 `SonettoBlocker`，这应该拦截整个项目范围内的文件访问。
+
+### 应用场景
+
+- 用户在某些敏感目录（如包含密钥/配置的目录）中放置 `SonettoBlocker` 文件，防止 LLM 意外读取
+- 根阻断：在项目根目录放置此文件，可彻底禁止 LLM 访问本地文件
+
+---
+
+## 第二层：路径白名单（白名单允许）
+
+### 原理
+
+路径白名单定义了一组**允许访问的路径前缀**。只有当目标路径精确等于某个前缀，或以"前缀 + 系统路径分隔符"开头时，才允许访问。
+
+白名单文件保存在 `api/data/path_whitelist.yaml`，此文件加入 `.gitignore` 不提交。
+
+### 自动生成
+
+`_ensure_whitelist()` 在模块加载时自动调用一次：
+
+| 场景 | 行为 |
+|------|------|
+| 文件不存在（首次启动 / git clone 后） | 自动创建，写入 `{project_root}/anthropic_skills` |
+| 工程被移动（自动条目路径不匹配） | 替换自动条目路径，**保留用户添加的额外条目** |
+| 文件已存在且自动条目匹配 | 不做任何操作 |
+| 文件损坏或格式异常 | 全量重写（fail-secure） |
+
+默认白名单仅包含 `anthropic_skills` 目录，遵循最小权限原则。
+
+### 实现
+
+核心函数 `check_path_whitelisted()` 定义在 `tools/base.py:256`：
+
+```python
+def check_path_whitelisted(target_path: str) -> str | None:
+```
+
+**检查逻辑**：
+
+1. 目标路径正规化：`os.path.normpath(os.path.abspath(target_path))`，消除 `../` 等相对路径绕过
+2. 加载 YAML 白名单 → 所有路径前缀全部正规化为绝对路径
+3. 遍历比对：精确匹配 **或** 以 `allowed_prefix + os.sep` 开头 → 允许
+4. **无一匹配** → 返回阻断描述字符串
+
+> 使用 `startswith(allowed_prefix + os.sep)` 而非简单的 `startswith(allowed_prefix)`，防止 `/home/project` 误匹配 `/home/project-evil`（前缀碰撞攻击）。
+
+### Fail-secure
+
+- 白名单文件不存在、格式损坏、解析失败 → `_load_path_whitelist()` 返回空列表
+- 空列表 → `check_path_whitelisted()` 对所有路径返回阻断
+- 白名单为空时阻断消息明确提示："白名单为空或未配置"
+
+---
+
+## 运行时 open() 拦截
+
+### 动机
+
+`run_python` 和 `debugger` 通过 `exec()` 执行 LLM 生成的代码，这类代码的路径访问在**编译时无法预测**，因此需要运行时实时拦截。
+
+### 实现
+
+`_whitelisted_open()` — `open()` 的完整包装（`tools/base.py:288`）：
+
+```python
+def _whitelisted_open(file, mode="r", buffering=-1, encoding=None, ...):
+```
+
+与原版 `open()` 完全兼容，保留全部参数签名。检查流程：
+
+1. 仅对字符串路径检查（跳过 `int` 类型文件描述符）
+2. **先检 SonettoBlocker** → 阻断则抛 `PermissionError`（Blocker 优先）
+3. **再检路径白名单** → 未通过则抛 `PermissionError`
+4. 全部通过 → 调用真正的 `open()`
+
+`get_safe_builtins()` 构造 exec 环境时替换 `open`：
+
+```python
+def get_safe_builtins() -> dict:
+    safe = dict(__builtins__)  # 保留全部内置函数
+    safe["open"] = _whitelisted_open  # 仅替换 open
+    safe["__builtins__"] = safe
+    return safe
+```
+
+所有其他内置函数（`__import__`、`eval`、`getattr` 等）保持不变，确保 LLM 代码正常使用 Python 语法特性。
+
+---
+
+## 两层协作策略与优先级
+
+### 优先级规则
+
+**SonettoBlocker 永远优先于路径白名单**。具体体现在：
+
+1. **所有入口先检查 Blocker** → 阻断则立即返回，不继续检查白名单
+2. **Blocker 通过后再检查白名单**
+3. 当路径同时触发 Blocker 且不在白名单中时，**只返回 Blocker 的错误信息**
+
+### 实现方式
+
+**exec 工具**（`_whitelisted_open` 中）：
+
+```python
+# 1. Blocker 优先
+blocked = check_sonetto_blocker(file_str)
+if blocked:
+    raise PermissionError("🚫 安全阻断：操作已被 SonettoBlocker 阻断。...")
+
+# 2. 白名单次之
+blocked = check_path_whitelisted(file_str)
+if blocked:
+    raise PermissionError(blocked)
+```
+
+**文件工具**：
+
+```python
+# 1. Blocker 优先
+blocked = check_sonetto_blocker(file_path)
+if blocked:
+    return format_error("🚫 安全阻断：操作已被 SonettoBlocker 阻断。...")
+
+# 2. 白名单次之
+blocked = check_path_whitelisted(file_path)
+if blocked:
+    return format_error(blocked)
+```
+
+这个优先级确保用户可以**一票否决**：即使路径在白名单内，只要放置了 `SonettoBlocker` 文件就立即阻断。
+
+---
+
+## 覆盖矩阵
+
+### 文件工具系列（显式调用两层检查）
+
+| 工具 | 文件 | Blocker | 白名单 | 检查对象 |
+|------|------|---------|--------|---------|
+| `file_operations` | `tools/files/tool_file_ops.py` | ✅ 分支检查 | ✅ 分支检查 | read/write/delete 检 `file_path`，rename 检 src+dst，create/list 检 `directory_path`，search 检 `search_directory` |
+| `file_edit` | `tools/files/tool_file_edit.py` | ✅ | ✅ | `file_path` |
+| `pdf_reader` | `tools/files/tool_pdf_reader.py` | ✅ | ✅ | `file_path` |
+| `doc_reader` | `tools/files/tool_doc_reader.py` | ✅ | ✅ | `file_path` |
+
+### exec 工具系列（运行时拦截 open()）
+
+| 工具 | 文件 | Blocker | 白名单 | 检查方式 |
+|------|------|---------|--------|---------|
+| `run_python` | `tools/system/tool_python.py` | ✅ 通过 `_whitelisted_open` | ✅ 通过 `_whitelisted_open` | `exec(code, {"__builtins__": _SAFE_BUILTINS})` |
+| `debugger` | `tools/development/tool_debug.py` | ✅ 通过 `_whitelisted_open` | ✅ 通过 `_whitelisted_open` | `exec(code, {"__builtins__": get_safe_builtins()}, env)` |
+
+### 开发工具系列（仅显式白名单检查）
+
+| 工具 | 文件 | Blocker | 白名单 | 检查对象 |
+|------|------|---------|--------|---------|
+| `unit_test_runner` | `tools/development/tool_unit_test.py` | ❌ | ✅ | `test_file` |
+| `syntax_checker` | `tools/development/tool_syntax.py` | ❌ | ✅ | `file_path` |
+| `code_quality_analyzer` | `tools/development/tool_code_quality.py` | ❌ | ✅ | `file_path` |
+
+> 开发工具系列没有运行时 exec()，所有路径都通过参数显式传入，因此只需在入口处检查白名单。
+
+---
+
+## 工具安全调用示例
+
+### 文件工具（以 `file_edit.py` 为例）
+
+```python
+# 1. Blocker 检查
+blocked = check_sonetto_blocker(file_path)
+if blocked:
+    return format_error("🚫 安全阻断：操作已被 SonettoBlocker 阻断。\n"
+                        f"在目录 \"{blocked}\" 中发现了 SonettoBlocker 文件。\n"
+                        "请立即停止当前任务，先说明你为什么需要访问该路径，"
+                        "再说明下一步打算做什么。")
+
+# 2. 白名单检查
+blocked = check_path_whitelisted(file_path)
+if blocked:
+    return format_error(blocked)
+```
+
+### exec 工具（`run_python`）
+
+```python
+_SAFE_BUILTINS = get_safe_builtins()  # 模块级，只构造一次
+
+def _exec_code(code: str) -> str:
+    exec(code, {"__builtins__": _SAFE_BUILTINS})
+    # 代码内的 open() 实际调用 _whitelisted_open
+```
+
+### 复杂操作的分支检查（`file_ops.py`）
+
+`rename_file` 操作需要同时检查源和目标路径：
+
+```python
+# Blocker（优先）
+if operation == "rename_file":
+    for p in (file_path, new_path):
+        if p:
+            blocked = check_sonetto_blocker(p)
+            if blocked:
+                blocker_paths.append(blocked)
+
+# 白名单（次之，仅当 Blocker 未阻断时）
+if whitelist_checks_needed:
+    for p in (file_path, new_path):
+        if p:
+            blocked = check_path_whitelisted(p)
+            if blocked:
+                whitelist_blocked.append(p)
+```
+
+---
+
+## 安全边界与局限
+
+### 防护范围 ✅
+
+| 攻击向量 | 防护状态 | 说明 |
+|----------|----------|------|
+| 直接 `open()` | ✅ 受控 | `_whitelisted_open` 拦截所有 `open()` 调用 |
+| 相对路径遍历（`../../etc`） | ✅ 受控 | `abspath()` + `normpath()` 正规化后检查 |
+| 前缀碰撞（`/proj-evil`） | ✅ 受控 | `startswith(prefix + os.sep)` 精准匹配 |
+| 文件描述符绕过 | ✅ 受控 | `int` 类型 file 参数跳过检查（此类调用仅来自内部代码） |
+| Blocker 标记文件 | ✅ 受控 | 从根逐级检查所有父目录 |
+
+### 已知局限 ⚠️
+
+| 局限 | 原因 | 影响评估 |
+|------|------|----------|
+| `os.open()` / `os.system()` / `subprocess` 不受控 | 只替换了 `open`，未替换 `os` / `subprocess` 模块 | 中等 — LLM 可通过这些 API 绕过白名单 |
+| 类层级遍历可找回原始 `open` | `().__class__.__bases__[0].__subclasses__()` 可绕过一切 Python exec 沙箱 | 低 — 需要刻意对抗，日常不会发生 |
+| `PermissionError` 可被 `try/except` 捕获 | exec 代码可捕获异常，阻塞被感知但不影响阻断效果 | 低 — 文件仍然不会被打开 |
+| 白名单文件本身未受保护 | 用户可以直接编辑 `path_whitelist.yaml` | 低 — 文件在用户本地，信任用户 |
+| 开发工具无 Blocker 检查 | `unit_test_runner` 等工具只有白名单检查 | 低 — 这些工具只接受文件路径参数，不走 exec |
+
+### 不在此设计范围内的威胁
+
+- **任意代码执行防护**：`exec()` 本身就可以执行任意 Python 代码，防护它的所有攻击面是沙箱工程，不在本机制范围内
+- **模块导入劫持**：`__import__` 保持原生状态，不做模块级路径过滤
+- **对外网络请求**：文件安全机制不涉及网络层防护
+
+---
+
+## 数据流全景
+
+```
+LLM / Agent
+  │
+  ├── 调用文件工具 ───────────────────────┐
+  │     │                                │
+  │     ▼                                │
+  │   file_path / directory_path         │
+  │     │                                │
+  │     ▼                                │
+  │   check_sonetto_blocker(path)        │
+  │     │  ┌─ 找到 SonettoBlocker? ──►   │
+  │     │  │  返回阻断消息 (Blocker 优先)  │
+  │     │  └─ 未找到 ─────────────────►   │
+  │     ▼                                │
+  │   check_path_whitelisted(path)       │
+  │     │  ┌─ 在白名单内? ────────────►   │
+  │     │  │  → 执行操作                  │
+  │     │  └─ 不在白名单内 ───────────►   │
+  │     │    返回阻断消息                  │
+  │                                      │
+  ├── 调用 exec 工具 ─────────────────────┐
+  │     │                                │
+  │     ▼                                │
+  │   exec(code, {"__builtins__": ...})  │
+  │     │                                │
+  │     ▼  (代码内调用 open())            │
+  │   _whitelisted_open(path)            │
+  │     │                                │
+  │     ▼                                │
+  │   check_sonetto_blocker(path)        │
+  │     │  ┌─ 阻断? ──► PermissionError   │
+  │     │  └─ 通过 ──►                   │
+  │     ▼                                │
+  │   check_path_whitelisted(path)       │
+  │     │  ┌─ 阻断? ──► PermissionError   │
+  │     │  └─ 通过 ──► 真正 open()        │
+  │                                      │
+  └── 调用开发工具 ───────────────────────┐
+        │                                │
+        ▼                                │
+     check_path_whitelisted(test_file)   │
+        │  ┌─ 阻断? ──► 返回错误           │
+        │  └─ 通过 ──► 执行分析            │
+```
+
+---
+
+## 配置与使用
+
+### 添加白名单路径
+
+编辑 `api/data/path_whitelist.yaml`：
+
+```yaml
+whitelist:
+  - path: "D:/data"
+    description: 用户数据目录
+  - path: "/mnt/share"
+    description: 网络共享目录
+```
+
+### 添加 Blocker 阻断
+
+在要拦截的目录中创建任意文件，文件名忽略大小写为 `SonettoBlocker`（可带任意扩展名）：
+
+```bash
+# 阻断整个文档目录
+echo "DO NOT READ" > ~/Documents/SonettoBlocker
+# 也可带扩展名
+echo "" > ./secrets/SonettoBlocker.txt
+```
+
+### 移除阻断
+
+删除对应目录下的 `SonettoBlocker` 文件即可：
+
+```bash
+rm ~/Documents/SonettoBlocker
+```
+
+---
+
+## 变更历史
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-06-18 | 初始编写：完整记录两层安全体系 | Claude Code |
+| 2026-06-18 | 补充覆盖矩阵和数据流全景 | Claude Code |

--- a/tools/base.py
+++ b/tools/base.py
@@ -1,6 +1,7 @@
 """工具（Tool）基类和共享 HTTP 客户端。"""
 
 import json
+import os
 from pathlib import Path
 
 import requests
@@ -80,3 +81,50 @@ def format_success(data: dict) -> str:
 def format_error(message: str) -> str:
     """统一错误响应格式。"""
     return json.dumps({"success": False, "error": message}, ensure_ascii=False)
+
+
+def check_sonetto_blocker(target_path: str) -> str | None:
+    """逐级检查路径的每一级目录是否包含 SonettoBlocker 文件（不区分大小写，不匹配后缀名）。
+
+    从盘符根目录开始，依次检查每一层父目录中是否存在名为 "SonettoBlocker"
+    的文件（任何扩展名均匹配）。一旦发现，返回该目录路径；否则返回 None。
+    """
+    if not target_path:
+        return None
+
+    abs_path = os.path.abspath(target_path)
+    p = Path(abs_path)
+
+    # 收集待检查的所有目录层级
+    dirs_to_check: list[str] = []
+
+    if p.is_dir():
+        dirs_to_check.append(str(p))
+    else:
+        # 文件还不存在（如 write_file 写入新文件）则检查父目录
+        parent = p.parent
+        if parent:
+            dirs_to_check.append(str(parent))
+
+    # parents 从父目录向上直到根
+    dirs_to_check.extend(str(parent) for parent in p.parents)
+
+    # 从根向下逐级检查
+    seen: set[str] = set()
+    for dir_path in reversed(dirs_to_check):
+        normalized = os.path.normpath(dir_path)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        if not os.path.isdir(normalized):
+            continue
+        try:
+            for entry in os.listdir(normalized):
+                entry_name, _ = os.path.splitext(entry)
+                if entry_name.lower() == "sonettoblocker":
+                    # 返回友好的展示形式
+                    return normalized
+        except (PermissionError, OSError):
+            continue
+
+    return None

--- a/tools/base.py
+++ b/tools/base.py
@@ -140,16 +140,24 @@ _WHITELIST_PATH = (
 
 # 项目根目录：由 base.py 所在位置 (tools/base.py) 向上推一级
 _PROJECT_ROOT = os.path.normpath(os.path.abspath(Path(__file__).resolve().parent.parent))
+# 默认白名单路径：仅暴露 anthropic_skills 目录
+_DEFAULT_WHITELIST_PATH = os.path.join(_PROJECT_ROOT, "anthropic_skills")
+
+# ── 路径白名单 ──────────────────────────────────────────────
+
+_WHITELIST_PATH = (
+    Path(__file__).resolve().parent.parent / "api" / "data" / "path_whitelist.yaml"
+)
 
 
 def _ensure_whitelist() -> None:
-    """确保白名单文件存在且包含当前项目根目录。
+    """确保白名单文件存在且包含当前工程的 anthropic_skills 目录。
 
     在模块导入时（即应用启动时）调用一次：
-    - 文件不存在 → 自动创建，写入当前项目根目录
-    - 项目被移动（文件里没有当前项目根目录） → 更新文件，
-      保留用户添加的额外条目，仅替换/添加项目根目录条目
-    - 文件已存在且项目根目录匹配 → 不做任何操作
+    - 文件不存在 → 自动创建，写入 anthropic_skills 路径
+    - 工程被移动（自动条目路径不匹配当前路径） → 更新文件，
+      保留用户添加的额外条目，仅替换/添加自动生成条目
+    - 文件已存在且自动条目匹配 → 不做任何操作
     """
     if not _WHITELIST_PATH.parent.exists():
         _WHITELIST_PATH.parent.mkdir(parents=True)
@@ -158,7 +166,7 @@ def _ensure_whitelist() -> None:
         _write_whitelist([_default_entry()])
         return
 
-    # 文件已存在，检查项目根目录是否已在白名单中
+    # 文件已存在，检查默认路径是否已在白名单中
     try:
         with open(_WHITELIST_PATH, encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
@@ -167,7 +175,7 @@ def _ensure_whitelist() -> None:
             _write_whitelist([_default_entry()])
             return
 
-        current_root_norm = _PROJECT_ROOT
+        current_default = _DEFAULT_WHITELIST_PATH
         has_current = False
         auto_entry_idx = -1
 
@@ -175,18 +183,18 @@ def _ensure_whitelist() -> None:
             if not isinstance(entry, dict) or "path" not in entry:
                 continue
             entry_path = os.path.normpath(os.path.abspath(entry["path"]))
-            if entry_path == current_root_norm:
+            if entry_path == current_default:
                 has_current = True
                 break
-            if entry.get("description") == "项目根目录（自动生成）":
+            if entry.get("description") == "技能目录（自动生成）":
                 auto_entry_idx = i
 
         if has_current:
             return  # 没有变化
 
-        # 项目移动了：更新旧的自动条目，或在开头插入新条目
+        # 工程移动了：更新旧的自动条目，或在开头插入新条目
         if auto_entry_idx >= 0:
-            entries[auto_entry_idx]["path"] = str(_PROJECT_ROOT)
+            entries[auto_entry_idx]["path"] = str(_DEFAULT_WHITELIST_PATH)
         else:
             entries.insert(0, _default_entry())
 
@@ -200,8 +208,8 @@ def _ensure_whitelist() -> None:
 
 def _default_entry() -> dict:
     return {
-        "path": str(_PROJECT_ROOT),
-        "description": "项目根目录（自动生成）",
+        "path": str(_DEFAULT_WHITELIST_PATH),
+        "description": "技能目录（自动生成）",
     }
 
 

--- a/tools/base.py
+++ b/tools/base.py
@@ -4,6 +4,8 @@ import json
 import os
 from pathlib import Path
 
+import yaml
+
 import requests
 from langchain_core.tools import BaseTool
 from todoist_api_python.api import TodoistAPI
@@ -128,3 +130,199 @@ def check_sonetto_blocker(target_path: str) -> str | None:
             continue
 
     return None
+
+
+# ── 路径白名单 ──────────────────────────────────────────────
+
+_WHITELIST_PATH = (
+    Path(__file__).resolve().parent.parent / "api" / "data" / "path_whitelist.yaml"
+)
+
+# 项目根目录：由 base.py 所在位置 (tools/base.py) 向上推一级
+_PROJECT_ROOT = os.path.normpath(os.path.abspath(Path(__file__).resolve().parent.parent))
+
+
+def _ensure_whitelist() -> None:
+    """确保白名单文件存在且包含当前项目根目录。
+
+    在模块导入时（即应用启动时）调用一次：
+    - 文件不存在 → 自动创建，写入当前项目根目录
+    - 项目被移动（文件里没有当前项目根目录） → 更新文件，
+      保留用户添加的额外条目，仅替换/添加项目根目录条目
+    - 文件已存在且项目根目录匹配 → 不做任何操作
+    """
+    if not _WHITELIST_PATH.parent.exists():
+        _WHITELIST_PATH.parent.mkdir(parents=True)
+
+    if not _WHITELIST_PATH.exists():
+        _write_whitelist([_default_entry()])
+        return
+
+    # 文件已存在，检查项目根目录是否已在白名单中
+    try:
+        with open(_WHITELIST_PATH, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        entries = raw.get("whitelist", [])
+        if not isinstance(entries, list):
+            _write_whitelist([_default_entry()])
+            return
+
+        current_root_norm = _PROJECT_ROOT
+        has_current = False
+        auto_entry_idx = -1
+
+        for i, entry in enumerate(entries):
+            if not isinstance(entry, dict) or "path" not in entry:
+                continue
+            entry_path = os.path.normpath(os.path.abspath(entry["path"]))
+            if entry_path == current_root_norm:
+                has_current = True
+                break
+            if entry.get("description") == "项目根目录（自动生成）":
+                auto_entry_idx = i
+
+        if has_current:
+            return  # 没有变化
+
+        # 项目移动了：更新旧的自动条目，或在开头插入新条目
+        if auto_entry_idx >= 0:
+            entries[auto_entry_idx]["path"] = str(_PROJECT_ROOT)
+        else:
+            entries.insert(0, _default_entry())
+
+        with open(_WHITELIST_PATH, "w", encoding="utf-8") as f:
+            yaml.dump({"whitelist": entries}, f, allow_unicode=True, default_flow_style=False)
+
+    except (yaml.YAMLError, OSError, ValueError):
+        # 文件损坏 → 重写
+        _write_whitelist([_default_entry()])
+
+
+def _default_entry() -> dict:
+    return {
+        "path": str(_PROJECT_ROOT),
+        "description": "项目根目录（自动生成）",
+    }
+
+
+def _write_whitelist(entries: list) -> None:
+    content = {
+        "whitelist": entries,
+    }
+    with open(_WHITELIST_PATH, "w", encoding="utf-8") as f:
+        # 写入手动头注释
+        f.write("# 路径白名单（自动生成，首次 import 时创建）\n")
+        f.write("# 编辑此文件以添加更多允许的路径前缀。\n")
+        yaml.dump(content, f, allow_unicode=True, default_flow_style=False)
+
+
+# 模块加载时自动执行：确保白名单存在（首次 import 时运行一次）
+_ensure_whitelist()
+
+
+def _load_path_whitelist() -> list[str]:
+    """从 YAML 文件加载白名单路径前缀列表，按绝对路径规范化后返回。
+
+    文件格式:
+        whitelist:
+          - path: "/some/allowed/dir"
+            description: ...
+    读取失败时返回空列表（会触发 fail-secure 全阻断）。
+    """
+    try:
+        with open(_WHITELIST_PATH, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        entries = raw.get("whitelist", [])
+        if not isinstance(entries, list):
+            return []
+        result: list[str] = []
+        for entry in entries:
+            if isinstance(entry, dict) and "path" in entry:
+                normalized = os.path.normpath(os.path.abspath(entry["path"]))
+                result.append(normalized)
+        return result
+    except (yaml.YAMLError, OSError, ValueError):
+        return []
+
+
+def check_path_whitelisted(target_path: str) -> str | None:
+    """检查 *target_path* 是否位于白名单设置的任一前缀下。
+
+    参数:
+        target_path: 待验证的文件或目录路径（相对/绝对均可）。
+
+    返回:
+        None      — 允许访问（路径在白名单内）。
+        str       — 阻断原因描述，调用方应将其传给 format_error()。
+    """
+    if not target_path:
+        return None
+
+    abs_target = os.path.normpath(os.path.abspath(target_path))
+    whitelist = _load_path_whitelist()
+
+    if not whitelist:
+        return f"路径不在白名单中: {target_path}（白名单为空或未配置）"
+
+    for allowed_prefix in whitelist:
+        # 精确匹配或前缀 + 分隔符匹配，防止 "/home/proj" 误匹配 "/home/project-evil"
+        if abs_target == allowed_prefix or abs_target.startswith(
+            allowed_prefix + os.sep
+        ):
+            return None
+
+    return f"路径不在白名单中: {target_path}"
+
+
+# ── exec() 安全 builtins（维持日常功能，仅拦截 open） ──────
+
+
+def _whitelisted_open(
+    file,
+    mode: str = "r",
+    buffering: int = -1,
+    encoding: str | None = None,
+    errors: str | None = None,
+    newline: str | None = None,
+    closefd: bool = True,
+    opener=None,
+):
+    """``open()`` 的包装版本，在打开文件前检查路径是否在白名单内。
+
+    完全兼容内置 ``open()`` 的全部参数签名，但会在调用前
+    对 *file* 参数执行 ``check_path_whitelisted()`` 检查。
+    未通过白名单的路径抛出 ``PermissionError``。
+    """
+    import builtins as _real_builtins
+
+    # 仅对字符串路径进行检查，跳过已打开的文件描述符
+    file_str = file
+    if isinstance(file, os.PathLike):
+        file_str = os.fspath(file)
+    if isinstance(file_str, str):
+        blocked = check_path_whitelisted(file_str)
+        if blocked:
+            raise PermissionError(blocked)
+
+    return _real_builtins.open(
+        file, mode, buffering, encoding, errors, newline, closefd, opener
+    )
+
+
+def get_safe_builtins() -> dict:
+    """构造用于 ``exec()`` 的安全 builtins 字典。
+
+    保留全部内置函数（包括 ``__import__``、``eval`` 等），
+    仅将 ``open()`` 替换为经过 ``check_path_whitelisted()``
+    审查的包装版本。日常计算、模块导入、调试等功能均不受影响。
+    """
+    # 在非 __main__ 模块中，__builtins__ 是模块对象而非 dict
+    if isinstance(__builtins__, dict):  # type: ignore[name-defined]
+        source = __builtins__  # type: ignore[name-defined]
+    else:
+        source = __builtins__.__dict__  # type: ignore[name-defined]
+
+    safe = dict(source)
+    safe["open"] = _whitelisted_open
+    safe["__builtins__"] = safe
+    return safe

--- a/tools/base.py
+++ b/tools/base.py
@@ -295,11 +295,11 @@ def _whitelisted_open(
     closefd: bool = True,
     opener=None,
 ):
-    """``open()`` 的包装版本，在打开文件前检查路径是否在白名单内。
+    """``open()`` 的包装版本，在打开文件前先检查 SonettoBlocker，再检查白名单。
 
-    完全兼容内置 ``open()`` 的全部参数签名，但会在调用前
-    对 *file* 参数执行 ``check_path_whitelisted()`` 检查。
-    未通过白名单的路径抛出 ``PermissionError``。
+    完全兼容内置 ``open()`` 的全部参数签名。检查顺序：
+    1. ``check_sonetto_blocker()`` — 若阻断则抛出 ``PermissionError``（Blocker 优先）
+    2. ``check_path_whitelisted()`` — 若不在白名单则抛出 ``PermissionError``
     """
     import builtins as _real_builtins
 
@@ -308,6 +308,15 @@ def _whitelisted_open(
     if isinstance(file, os.PathLike):
         file_str = os.fspath(file)
     if isinstance(file_str, str):
+        # 1. SonettoBlocker 优先
+        blocked = check_sonetto_blocker(file_str)
+        if blocked:
+            raise PermissionError(
+                "🚫 安全阻断：操作已被 SonettoBlocker 阻断。\n"
+                f"SonettoBlocker 文件位于: {blocked}\n"
+                "请立即停止当前任务。"
+            )
+        # 2. 白名单次之
         blocked = check_path_whitelisted(file_str)
         if blocked:
             raise PermissionError(blocked)

--- a/tools/development/tool_code_quality.py
+++ b/tools/development/tool_code_quality.py
@@ -4,7 +4,7 @@ import ast
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, check_path_whitelisted, format_error, format_success
 
 
 class CodeQualityInput(BaseModel):
@@ -33,6 +33,9 @@ class CodeQualityTool(ToolBase):
             return self._load_doc()
 
         if file_path:
+            blocked = check_path_whitelisted(file_path)
+            if blocked:
+                return format_error(blocked)
             try:
                 with open(file_path, "r", encoding="utf-8") as f:
                     code = f.read()

--- a/tools/development/tool_debug.py
+++ b/tools/development/tool_debug.py
@@ -4,7 +4,7 @@ import traceback
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, format_error, format_success, get_safe_builtins
 
 
 class DebuggerInput(BaseModel):
@@ -37,7 +37,7 @@ class DebuggerTool(ToolBase):
 
         env: dict = {}
         try:
-            exec(code, {"__builtins__": __builtins__}, env)
+            exec(code, {"__builtins__": get_safe_builtins()}, env)
             return format_success({
                 "status": "success",
                 "variables": {v: repr(env.get(v, "未定义")) for v in variables},

--- a/tools/development/tool_syntax.py
+++ b/tools/development/tool_syntax.py
@@ -7,7 +7,7 @@ import tempfile
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, check_path_whitelisted, format_error, format_success
 
 
 class SyntaxCheckerInput(BaseModel):
@@ -36,6 +36,9 @@ class SyntaxCheckerTool(ToolBase):
             return self._load_doc()
 
         if file_path:
+            blocked = check_path_whitelisted(file_path)
+            if blocked:
+                return format_error(blocked)
             try:
                 with open(file_path, "r", encoding="utf-8") as f:
                     code = f.read()

--- a/tools/development/tool_unit_test.py
+++ b/tools/development/tool_unit_test.py
@@ -5,7 +5,7 @@ import unittest
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, check_path_whitelisted, format_error, format_success
 
 
 class UnitTestInput(BaseModel):
@@ -34,6 +34,10 @@ class UnitTestTool(ToolBase):
             return self._load_doc()
         if not test_file:
             return format_error("test_file 不能为空")
+
+        blocked = check_path_whitelisted(test_file)
+        if blocked:
+            return format_error(blocked)
 
         try:
             spec = importlib.util.spec_from_file_location("test_module", test_file)

--- a/tools/files/tool_doc_reader.py
+++ b/tools/files/tool_doc_reader.py
@@ -4,7 +4,7 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, check_sonetto_blocker, format_error, format_success
 
 
 class DocReaderInput(BaseModel):
@@ -46,6 +46,18 @@ class DocReaderTool(ToolBase):
             return format_error("operation 不能为空")
         if not file_path:
             return format_error("file_path 不能为空")
+
+        # ── SonettoBlocker 安全检查 ────────────────────────────────
+        blocked = check_sonetto_blocker(file_path)
+        if blocked:
+            return format_error(
+                "🚫 安全阻断：操作已被 SonettoBlocker 阻断。\n"
+                f"在目录 \"{blocked}\" 中发现了 SonettoBlocker 文件。\n\n"
+                "请立即停止当前任务，先说明你为什么需要访问该路径，"
+                "再说明下一步打算做什么。"
+            )
+        # ────────────────────────────────────────────────────────────
+
         if not os.path.exists(file_path):
             return format_error(f"文件不存在: {file_path}")
 

--- a/tools/files/tool_doc_reader.py
+++ b/tools/files/tool_doc_reader.py
@@ -4,7 +4,7 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_sonetto_blocker, format_error, format_success
+from tools.base import ToolBase, check_path_whitelisted, check_sonetto_blocker, format_error, format_success
 
 
 class DocReaderInput(BaseModel):
@@ -56,6 +56,12 @@ class DocReaderTool(ToolBase):
                 "请立即停止当前任务，先说明你为什么需要访问该路径，"
                 "再说明下一步打算做什么。"
             )
+        # ────────────────────────────────────────────────────────────
+
+        # ── 路径白名单检查 ──────────────────────────────────────────
+        blocked = check_path_whitelisted(file_path)
+        if blocked:
+            return format_error(blocked)
         # ────────────────────────────────────────────────────────────
 
         if not os.path.exists(file_path):

--- a/tools/files/tool_file_edit.py
+++ b/tools/files/tool_file_edit.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, check_sonetto_blocker, format_error, format_success
 
 
 class FileEditInput(BaseModel):
@@ -69,6 +69,18 @@ class FileEditTool(ToolBase):
             return format_error("operation 必填: edit / multi_edit / read / search")
         if not file_path:
             return format_error("file_path 不能为空")
+
+        # ── SonettoBlocker 安全检查 ────────────────────────────────
+        blocked = check_sonetto_blocker(file_path)
+        if blocked:
+            return format_error(
+                "🚫 安全阻断：操作已被 SonettoBlocker 阻断。\n"
+                f"在目录 \"{blocked}\" 中发现了 SonettoBlocker 文件。\n\n"
+                "请立即停止当前任务，先说明你为什么需要访问该路径，"
+                "再说明下一步打算做什么。"
+            )
+        # ────────────────────────────────────────────────────────────
+
         if not os.path.exists(file_path):
             return format_error(f"文件不存在: {file_path}")
         if not os.path.isfile(file_path):

--- a/tools/files/tool_file_edit.py
+++ b/tools/files/tool_file_edit.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_sonetto_blocker, format_error, format_success
+from tools.base import ToolBase, check_path_whitelisted, check_sonetto_blocker, format_error, format_success
 
 
 class FileEditInput(BaseModel):
@@ -79,6 +79,12 @@ class FileEditTool(ToolBase):
                 "请立即停止当前任务，先说明你为什么需要访问该路径，"
                 "再说明下一步打算做什么。"
             )
+        # ────────────────────────────────────────────────────────────
+
+        # ── 路径白名单检查 ──────────────────────────────────────────
+        blocked = check_path_whitelisted(file_path)
+        if blocked:
+            return format_error(blocked)
         # ────────────────────────────────────────────────────────────
 
         if not os.path.exists(file_path):

--- a/tools/files/tool_file_ops.py
+++ b/tools/files/tool_file_ops.py
@@ -6,7 +6,7 @@ import shutil
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_sonetto_blocker, format_error, format_success
+from tools.base import ToolBase, check_path_whitelisted, check_sonetto_blocker, format_error, format_success
 
 
 class FileOpsInput(BaseModel):
@@ -86,6 +86,37 @@ class FileOperationsTool(ToolBase):
                 + "\n".join(f"  • {d}" for d in blocker_paths)
                 + "\n\n请立即停止当前任务，先说明你为什么需要访问该路径，"
                   "再说明下一步打算做什么。"
+            )
+        # ────────────────────────────────────────────────────────────
+
+        # ── 路径白名单检查 ──────────────────────────────────────────
+        whitelist_blocked = []
+        if operation == "rename_file":
+            for p in (file_path, new_path):
+                if p:
+                    blocked = check_path_whitelisted(p)
+                    if blocked:
+                        whitelist_blocked.append(p)
+        elif operation in ("create_directory", "list_directory"):
+            if directory_path:
+                blocked = check_path_whitelisted(directory_path)
+                if blocked:
+                    whitelist_blocked.append(directory_path)
+        elif operation == "search_files":
+            if search_directory:
+                blocked = check_path_whitelisted(search_directory)
+                if blocked:
+                    whitelist_blocked.append(search_directory)
+        else:
+            if file_path:
+                blocked = check_path_whitelisted(file_path)
+                if blocked:
+                    whitelist_blocked.append(file_path)
+
+        if whitelist_blocked:
+            return format_error(
+                "路径不在白名单中，已拒绝访问：\n"
+                + "\n".join(f"  • {p}" for p in whitelist_blocked)
             )
         # ────────────────────────────────────────────────────────────
 

--- a/tools/files/tool_file_ops.py
+++ b/tools/files/tool_file_ops.py
@@ -6,7 +6,7 @@ import shutil
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, check_sonetto_blocker, format_error, format_success
 
 
 class FileOpsInput(BaseModel):
@@ -52,6 +52,42 @@ class FileOperationsTool(ToolBase):
             return self._load_doc()
         if not operation:
             return format_error("operation 不能为空")
+
+        # ── SonettoBlocker 安全检查 ────────────────────────────────
+        blocker_paths = []
+        if operation == "rename_file":
+            # 源和目标路径都检查
+            for p in (file_path, new_path):
+                if p:
+                    blocked = check_sonetto_blocker(p)
+                    if blocked:
+                        blocker_paths.append(blocked)
+        elif operation in ("create_directory", "list_directory"):
+            if directory_path:
+                blocked = check_sonetto_blocker(directory_path)
+                if blocked:
+                    blocker_paths.append(blocked)
+        elif operation == "search_files":
+            if search_directory:
+                blocked = check_sonetto_blocker(search_directory)
+                if blocked:
+                    blocker_paths.append(blocked)
+        else:
+            # read_file / write_file / delete_file
+            if file_path:
+                blocked = check_sonetto_blocker(file_path)
+                if blocked:
+                    blocker_paths.append(blocked)
+
+        if blocker_paths:
+            return format_error(
+                "🚫 安全阻断：操作已被 SonettoBlocker 阻断。\n"
+                f"在以下目录中发现了 SonettoBlocker 文件：\n"
+                + "\n".join(f"  • {d}" for d in blocker_paths)
+                + "\n\n请立即停止当前任务，先说明你为什么需要访问该路径，"
+                  "再说明下一步打算做什么。"
+            )
+        # ────────────────────────────────────────────────────────────
 
         try:
             if operation == "read_file":

--- a/tools/files/tool_pdf_reader.py
+++ b/tools/files/tool_pdf_reader.py
@@ -4,7 +4,7 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_sonetto_blocker, format_error, format_success
+from tools.base import ToolBase, check_path_whitelisted, check_sonetto_blocker, format_error, format_success
 
 
 class PDFReaderInput(BaseModel):
@@ -58,6 +58,12 @@ class PDFReaderTool(ToolBase):
                 "请立即停止当前任务，先说明你为什么需要访问该路径，"
                 "再说明下一步打算做什么。"
             )
+        # ────────────────────────────────────────────────────────────
+
+        # ── 路径白名单检查 ──────────────────────────────────────────
+        blocked = check_path_whitelisted(file_path)
+        if blocked:
+            return format_error(blocked)
         # ────────────────────────────────────────────────────────────
 
         if not os.path.exists(file_path):

--- a/tools/files/tool_pdf_reader.py
+++ b/tools/files/tool_pdf_reader.py
@@ -4,7 +4,7 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, check_sonetto_blocker, format_error, format_success
 
 
 class PDFReaderInput(BaseModel):
@@ -48,6 +48,18 @@ class PDFReaderTool(ToolBase):
             return format_error("operation 不能为空")
         if not file_path:
             return format_error("file_path 不能为空")
+
+        # ── SonettoBlocker 安全检查 ────────────────────────────────
+        blocked = check_sonetto_blocker(file_path)
+        if blocked:
+            return format_error(
+                "🚫 安全阻断：操作已被 SonettoBlocker 阻断。\n"
+                f"在目录 \"{blocked}\" 中发现了 SonettoBlocker 文件。\n\n"
+                "请立即停止当前任务，先说明你为什么需要访问该路径，"
+                "再说明下一步打算做什么。"
+            )
+        # ────────────────────────────────────────────────────────────
+
         if not os.path.exists(file_path):
             return format_error(f"文件不存在: {file_path}")
         if not file_path.lower().endswith(".pdf"):

--- a/tools/system/tool_python.py
+++ b/tools/system/tool_python.py
@@ -7,7 +7,10 @@ import sys
 from pydantic import BaseModel, Field
 
 from api import interaction
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, format_error, format_success, get_safe_builtins
+
+# 模块级常量：安全 builtins 只构造一次
+_SAFE_BUILTINS = get_safe_builtins()
 
 
 def _exec_code(code: str) -> str:
@@ -15,7 +18,7 @@ def _exec_code(code: str) -> str:
     old_stdout = sys.stdout
     sys.stdout = io.StringIO()
     try:
-        exec(code, {"__builtins__": __builtins__})
+        exec(code, {"__builtins__": _SAFE_BUILTINS})
         return sys.stdout.getvalue() or "（代码执行完毕，无输出）"
     except Exception as e:
         raise RuntimeError(f"代码执行错误: {e}") from e

--- a/web/src/components/tools/DocReaderBubble.vue
+++ b/web/src/components/tools/DocReaderBubble.vue
@@ -5,10 +5,12 @@
       <span>{{ runningLabel }}</span>
     </div>
 
-    <!-- 错误 -->
-    <div v-else-if="toolCall.status === 'error'" class="bubble-error">
-      {{ toolCall.output || '读取失败' }}
-    </div>
+    <!-- 错误（含 SonettoBlocker 特殊渲染） -->
+    <SonettoBlockerError
+      v-else-if="toolCall.status === 'error'"
+      :output="toolCall.output"
+      fallback="读取失败"
+    />
 
     <!-- 完成 -->
     <template v-else-if="toolCall.status === 'done'">
@@ -115,6 +117,7 @@
 import { computed } from 'vue'
 import type { ToolCall } from '@/types'
 import BubbleChrome from './_shared/BubbleChrome.vue'
+import SonettoBlockerError from './_shared/SonettoBlockerError.vue'
 
 const props = defineProps<{ toolCall: ToolCall }>()
 const emit = defineEmits<{ (e: 'action', p: { action: string; data?: unknown }): void }>()

--- a/web/src/components/tools/FileEditBubble.vue
+++ b/web/src/components/tools/FileEditBubble.vue
@@ -5,10 +5,12 @@
       <span>{{ runningLabel }}</span>
     </div>
 
-    <!-- 错误 -->
-    <div v-else-if="toolCall.status === 'error'" class="bubble-error">
-      {{ toolCall.output || '编辑操作失败' }}
-    </div>
+    <!-- 错误（含 SonettoBlocker 特殊渲染） -->
+    <SonettoBlockerError
+      v-else-if="toolCall.status === 'error'"
+      :output="toolCall.output"
+      fallback="编辑操作失败"
+    />
 
     <!-- 完成 -->
     <template v-else-if="toolCall.status === 'done'">
@@ -132,6 +134,7 @@
 import { computed } from 'vue'
 import type { ToolCall } from '@/types'
 import BubbleChrome from './_shared/BubbleChrome.vue'
+import SonettoBlockerError from './_shared/SonettoBlockerError.vue'
 
 const props = defineProps<{ toolCall: ToolCall }>()
 const emit = defineEmits<{ (e: 'action', p: { action: string; data?: unknown }): void }>()

--- a/web/src/components/tools/FilesBubble.vue
+++ b/web/src/components/tools/FilesBubble.vue
@@ -5,10 +5,12 @@
       <span>{{ runningLabel }}</span>
     </div>
 
-    <!-- 错误 -->
-    <div v-else-if="toolCall.status === 'error'" class="bubble-error">
-      {{ toolCall.output || '文件操作失败' }}
-    </div>
+    <!-- 错误（含 SonettoBlocker 特殊渲染） -->
+    <SonettoBlockerError
+      v-else-if="toolCall.status === 'error'"
+      :output="toolCall.output"
+      fallback="文件操作失败"
+    />
 
     <!-- 完成 -->
     <template v-else-if="toolCall.status === 'done'">
@@ -142,6 +144,7 @@
 import { computed } from 'vue'
 import type { ToolCall } from '@/types'
 import BubbleChrome from './_shared/BubbleChrome.vue'
+import SonettoBlockerError from './_shared/SonettoBlockerError.vue'
 
 const props = defineProps<{ toolCall: ToolCall }>()
 const emit = defineEmits<{ (e: 'action', p: { action: string; data?: unknown }): void }>()

--- a/web/src/components/tools/PdfReaderBubble.vue
+++ b/web/src/components/tools/PdfReaderBubble.vue
@@ -5,10 +5,12 @@
       <span>{{ runningLabel }}</span>
     </div>
 
-    <!-- 错误 -->
-    <div v-else-if="toolCall.status === 'error'" class="bubble-error">
-      {{ toolCall.output || '读取失败' }}
-    </div>
+    <!-- 错误（含 SonettoBlocker 特殊渲染） -->
+    <SonettoBlockerError
+      v-else-if="toolCall.status === 'error'"
+      :output="toolCall.output"
+      fallback="读取失败"
+    />
 
     <!-- 完成 -->
     <template v-else-if="toolCall.status === 'done'">
@@ -109,6 +111,7 @@
 import { computed } from 'vue'
 import type { ToolCall } from '@/types'
 import BubbleChrome from './_shared/BubbleChrome.vue'
+import SonettoBlockerError from './_shared/SonettoBlockerError.vue'
 
 const props = defineProps<{ toolCall: ToolCall }>()
 const emit = defineEmits<{ (e: 'action', p: { action: string; data?: unknown }): void }>()

--- a/web/src/components/tools/_shared/SonettoBlockerError.vue
+++ b/web/src/components/tools/_shared/SonettoBlockerError.vue
@@ -1,0 +1,189 @@
+<template>
+  <!-- SonettoBlocker 阻断错误（特殊视觉） -->
+  <div v-if="isBlocked" class="blocker-banner">
+    <div class="blocker-header">
+      <span class="blocker-shield">🛡️</span>
+      <span class="blocker-title">访问已被安全阻断</span>
+    </div>
+    <div class="blocker-divider" />
+    <div class="blocker-body">
+      <p class="blocker-intro">此操作因 <strong>SonettoBlocker</strong> 安全机制被阻止：</p>
+
+      <div v-if="blockedPaths.length" class="blocker-section">
+        <div class="blocker-label">阻断位置</div>
+        <div v-for="(p, i) in blockedPaths" :key="i" class="blocker-path-item">
+          <span class="blocker-path-icon">📁</span>
+          <code class="blocker-path-text">{{ p }}</code>
+        </div>
+      </div>
+
+      <div class="blocker-notice">
+        <span class="blocker-notice-icon">⚠️</span>
+        <span>Agent 正在尝试访问以上路径，请等待其说明访问原因及下一步计划。</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 普通错误 -->
+  <div v-else class="bubble-error">
+    {{ displayText }}
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  output: string | null
+  fallback?: string
+}>()
+
+const displayText = computed(() => props.output || props.fallback || '操作失败')
+
+const isBlocked = computed(() => {
+  return !!props.output && props.output.includes('SonettoBlocker')
+})
+
+/** 从后端错误消息中提取被阻断的目录路径 */
+const blockedPaths = computed<string[]>(() => {
+  if (!props.output) return []
+  const lines = props.output.split('\n')
+  const paths: string[] = []
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    // 格式1: "  • C:\path"
+    const bulletMatch = trimmed.match(/^[•\-*]\s+(.+)$/)
+    if (bulletMatch) {
+      const path = bulletMatch[1].trim()
+      if (path) paths.push(path)
+      continue
+    }
+
+    // 格式2: "在目录 "C:\path" 中发现了..."
+    const dirMatch = trimmed.match(/在目录\s+"([^"]+)"/)
+    if (dirMatch) {
+      paths.push(dirMatch[1])
+    }
+  }
+
+  return paths
+})
+</script>
+
+<style scoped>
+.blocker-banner {
+  background: linear-gradient(135deg, #fff5f5 0%, #fff0e6 100%);
+  border: 1.5px solid #e74c3c;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.blocker-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px 6px;
+}
+
+.blocker-shield {
+  font-size: 22px;
+  flex-shrink: 0;
+}
+
+.blocker-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #c0392b;
+}
+
+.blocker-divider {
+  height: 1px;
+  background: linear-gradient(to right, #e74c3c44, transparent);
+  margin: 2px 16px;
+}
+
+.blocker-body {
+  padding: 8px 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.blocker-intro {
+  margin: 0;
+  font-size: 13px;
+  color: #7f8c8d;
+  line-height: 1.5;
+}
+
+.blocker-intro strong {
+  color: #c0392b;
+  font-weight: 700;
+}
+
+.blocker-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.blocker-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: #e67e22;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.blocker-path-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: rgba(231, 76, 60, 0.06);
+  border: 1px solid rgba(231, 76, 60, 0.15);
+  border-radius: 6px;
+}
+
+.blocker-path-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.blocker-path-text {
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 12px;
+  color: #c0392b;
+  word-break: break-all;
+  background: none;
+  padding: 0;
+}
+
+.blocker-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 12px;
+  color: #e67e22;
+  line-height: 1.5;
+  padding: 8px 10px;
+  background: rgba(230, 126, 34, 0.08);
+  border-radius: 6px;
+}
+
+.blocker-notice-icon {
+  flex-shrink: 0;
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+/* ── 普通错误（回退） ── */
+.bubble-error {
+  font-size: 13px;
+  color: #b91c1c;
+  padding: 4px 0;
+}
+</style>


### PR DESCRIPTION
## 变更内容

为 SonettoHere 新增双层本地文件安全防护系统：

### 🔒 SonettoBlocker（黑名单阻断）
- 基于目录标记文件的阻断机制，在目录放置 `SonettoBlocker` 文件即可阻断访问
- 逐级目录检查（从根到目标），不区分大小写和扩展名
- 前端配套特殊渲染阻断

### 📜 路径白名单（白名单允许）
- YAML 配置文件 (`api/data/path_whitelist.yaml`)，自动生成，不提交 git
- 默认仅开放 `anthropic_skills` 目录（最小权限）
- 工程移动时自动替换路径，保留用户条目
- Fail-secure：空/损坏的白名单全阻断

### 🔗 交叉集成
- 文件工具系列（`file_ops`/`file_edit`/`pdf_reader`/`doc_reader`）：显式调用 Blocker + 白名单
- exec 工具系列（`run_python`/`debugger`）：运行时 `open()` 拦截（`_whitelisted_open`）
- 开发工具（`unit_test_runner`/`syntax_checker`/`code_quality_analyzer`）：白名单检查
- 优先级：**Blocker > 白名单**，任一阻断即拒绝

### 📝 文档
- `dev_docs/security/local-file-security.md`：完整安全机制文档
- `dev_docs/path-whitelist.md`：白名单设计文档
- 更新动态新闻条目

Closes #124