### PR TITLE
路径白名单改进：路径规范化 + 子目录继承开关 (recursive)

### DIFF
--- a/api/routes/path_whitelist.py
+++ b/api/routes/path_whitelist.py
@@ -1,5 +1,6 @@
 """REST API — 路径白名单 (path_whitelist.yaml) CRUD。"""
 
+import os
 from pathlib import Path
 
 import yaml
@@ -22,6 +23,7 @@ WHITELIST_PATH = (
 class WhitelistEntry(BaseModel):
     path: str
     description: str = ""
+    recursive: bool = True
 
 
 class WhitelistResponse(BaseModel):
@@ -50,9 +52,11 @@ async def list_whitelist():
 @router.post("/path-whitelist", response_model=WhitelistEntry)
 async def add_whitelist(entry: WhitelistEntry):
     entries = _load()
-    entries.append(entry.model_dump())
+    data = entry.model_dump()
+    data["path"] = os.path.normpath(data["path"])
+    entries.append(data)
     _save(entries)
-    return entry
+    return WhitelistEntry(**data)
 
 
 @router.put("/path-whitelist/{index}", response_model=WhitelistEntry)
@@ -60,9 +64,11 @@ async def update_whitelist(index: int, entry: WhitelistEntry):
     entries = _load()
     if index < 0 or index >= len(entries):
         raise HTTPException(status_code=404, detail=f"索引 {index} 超出范围")
-    entries[index] = entry.model_dump()
+    data = entry.model_dump()
+    data["path"] = os.path.normpath(data["path"])
+    entries[index] = data
     _save(entries)
-    return entry
+    return WhitelistEntry(**data)
 
 
 @router.delete("/path-whitelist/{index}")

--- a/tools/base.py
+++ b/tools/base.py
@@ -208,8 +208,9 @@ def _ensure_whitelist() -> None:
 
 def _default_entry() -> dict:
     return {
-        "path": str(_DEFAULT_WHITELIST_PATH),
+        "path": os.path.normpath(str(_DEFAULT_WHITELIST_PATH)),
         "description": "技能目录（自动生成）",
+        "recursive": True,
     }
 
 
@@ -228,13 +229,18 @@ def _write_whitelist(entries: list) -> None:
 _ensure_whitelist()
 
 
-def _load_path_whitelist() -> list[str]:
-    """从 YAML 文件加载白名单路径前缀列表，按绝对路径规范化后返回。
+def _load_path_whitelist() -> list[tuple[str, bool]]:
+    """从 YAML 文件加载白名单条目列表。
+
+    每个条目返回 (normalized_path, recursive) 元组。
+    recursive=True 时该路径下所有子目录继承访问权限；
+    recursive=False 时仅允许访问该确切路径。
 
     文件格式:
         whitelist:
           - path: "/some/allowed/dir"
             description: ...
+            recursive: true
     读取失败时返回空列表（会触发 fail-secure 全阻断）。
     """
     try:
@@ -243,11 +249,15 @@ def _load_path_whitelist() -> list[str]:
         entries = raw.get("whitelist", [])
         if not isinstance(entries, list):
             return []
-        result: list[str] = []
+        result: list[tuple[str, bool]] = []
         for entry in entries:
             if isinstance(entry, dict) and "path" in entry:
                 normalized = os.path.normpath(os.path.abspath(entry["path"]))
-                result.append(normalized)
+                recursive = entry.get("recursive", True)
+                if isinstance(recursive, bool):
+                    result.append((normalized, recursive))
+                else:
+                    result.append((normalized, True))
         return result
     except (yaml.YAMLError, OSError, ValueError):
         return []
@@ -262,6 +272,10 @@ def check_path_whitelisted(target_path: str) -> str | None:
     返回:
         None      — 允许访问（路径在白名单内）。
         str       — 阻断原因描述，调用方应将其传给 format_error()。
+
+    白名单每个条目可设置 recursive 标志：
+        recursive=True  — 目标路径等于允许前缀或以"允许前缀 + 分隔符"开头时允许。
+        recursive=False — 仅当目标路径与允许前缀精确相等时才允许。
     """
     if not target_path:
         return None
@@ -272,12 +286,17 @@ def check_path_whitelisted(target_path: str) -> str | None:
     if not whitelist:
         return f"路径不在白名单中: {target_path}（白名单为空或未配置）"
 
-    for allowed_prefix in whitelist:
-        # 精确匹配或前缀 + 分隔符匹配，防止 "/home/proj" 误匹配 "/home/project-evil"
-        if abs_target == allowed_prefix or abs_target.startswith(
-            allowed_prefix + os.sep
-        ):
+    for allowed_prefix, recursive in whitelist:
+        # 去掉末尾分隔符，避免 root 路径（如 T:\）拼接 os.sep 产生双分隔符
+        prefix_stripped = allowed_prefix.rstrip(os.sep)
+
+        if abs_target == allowed_prefix or abs_target == prefix_stripped:
             return None
+
+        if recursive:
+            # 防止 "/home/proj" 误匹配 "/home/project-evil"
+            if abs_target.startswith(prefix_stripped + os.sep):
+                return None
 
     return f"路径不在白名单中: {target_path}"
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -352,6 +352,7 @@ export interface ListToolsResponse {
 export interface WhitelistEntry {
   path: string
   description: string
+  recursive: boolean
 }
 
 export interface ListWhitelistResponse {

--- a/web/src/views/PathWhitelistView.vue
+++ b/web/src/views/PathWhitelistView.vue
@@ -14,6 +14,9 @@
           <div class="entry-body">
             <div class="entry-path">{{ entry.path }}</div>
             <div v-if="entry.description" class="entry-desc">{{ entry.description }}</div>
+            <div class="entry-recursive-tag" :class="entry.recursive ? 'recursive-yes' : 'recursive-no'">
+              {{ entry.recursive ? '允许子目录' : '仅当前目录' }}
+            </div>
           </div>
           <div class="entry-actions">
             <button class="btn" @click="startEdit(i)">编辑</button>
@@ -49,6 +52,14 @@
             placeholder="用途说明"
           />
         </div>
+        <div class="form-section">
+          <label class="form-label">子目录继承</label>
+          <label class="toggle-row">
+            <input type="checkbox" v-model="formRecursive" class="toggle-input" />
+            <span class="toggle-slider"></span>
+            <span class="toggle-label">{{ formRecursive ? '允许访问所有子目录' : '仅允许访问此目录（不含子目录）' }}</span>
+          </label>
+        </div>
         <div v-if="formError" class="msg error">{{ formError }}</div>
         <div class="form-actions">
           <button class="btn" @click="cancelForm">取消</button>
@@ -74,6 +85,7 @@ const formError = ref('')
 const editingIndex = ref(-1)
 const formPath = ref('')
 const formDesc = ref('')
+const formRecursive = ref(true)
 
 async function loadEntries() {
   loading.value = true
@@ -103,6 +115,7 @@ function startAdd() {
   editingIndex.value = -1
   formPath.value = ''
   formDesc.value = ''
+  formRecursive.value = true
   formError.value = ''
   mode.value = 'form'
 }
@@ -111,6 +124,7 @@ function startEdit(i: number) {
   editingIndex.value = i
   formPath.value = entries.value[i].path
   formDesc.value = entries.value[i].description || ''
+  formRecursive.value = entries.value[i].recursive !== false
   formError.value = ''
   mode.value = 'form'
 }
@@ -124,7 +138,7 @@ async function handleSave() {
   saving.value = true
   formError.value = ''
   try {
-    const entry = { path: formPath.value.trim(), description: formDesc.value.trim() }
+    const entry = { path: formPath.value.trim(), description: formDesc.value.trim(), recursive: formRecursive.value }
     if (editingIndex.value >= 0) {
       await api.updateWhitelistEntry(editingIndex.value, entry)
     } else {
@@ -292,5 +306,64 @@ onMounted(loadEntries)
 .btn-danger {
   color: var(--status-error);
   border-color: var(--status-error);
+}
+
+/* ── 递归标签 ── */
+.entry-recursive-tag {
+  display: inline-block;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+.recursive-yes {
+  background: #dcfce7;
+  color: #166534;
+}
+.recursive-no {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+/* ── Toggle 开关 ── */
+.toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+.toggle-input {
+  display: none;
+}
+.toggle-slider {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: #d1d5db;
+  border-radius: 11px;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+.toggle-slider::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+.toggle-input:checked + .toggle-slider {
+  background: var(--accent, #3b82f6);
+}
+.toggle-input:checked + .toggle-slider::after {
+  transform: translateX(18px);
+}
+.toggle-label {
+  font-size: 13px;
+  color: var(--text-secondary);
 }
 </style>


### PR DESCRIPTION
## 改动内容

### Issue 1：路径分隔符统一
保存路径时使用 os.path.normpath() 统一格式，YAML 文件中不再混用正斜杠/反斜杠。

### Issue 2：子目录继承开关 (recursive)

**Bug 修复**：check_path_whitelisted() 中 Windows 根路径（如 T:\）拼接 os.sep 产生双分隔符导致子目录匹配失败。改用 
strip(os.sep) 修复。

**新功能**：每个白名单条目增加 
ecursive: bool 开关（默认 	rue）：
- 	rue（默认）→ 允许此目录及所有子目录
- alse → 仅允许此确切路径

### 向后兼容
旧 YAML 条目无 
ecursive 字段 → 加载时默认 True。函数签名 check_path_whitelisted(target_path: str) -> str | None 不变。

### 修改的文件
- tools/base.py
- api/routes/path_whitelist.py
- web/src/types/index.ts
- web/src/views/PathWhitelistView.vue

Closes #130