### PR TITLE
会话持久化 + 代码执行权限增强

### DIFF
--- a/api/code_permission_store.py
+++ b/api/code_permission_store.py
@@ -1,0 +1,106 @@
+"""代码执行权限 — YAML 持久化存储。
+
+管理"永久允许/拒绝"的代码执行权限。
+权限根据代码内容的 SHA256 哈希进行匹配。
+"""
+
+import hashlib
+from pathlib import Path
+
+import yaml
+
+_PERMISSION_PATH = (
+    Path(__file__).resolve().parent / "data" / "code_permissions.yaml"
+)
+
+
+def _ensure_file():
+    _PERMISSION_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if not _PERMISSION_PATH.exists():
+        _write([])
+
+
+def _write(entries: list[dict]):
+    with open(_PERMISSION_PATH, "w", encoding="utf-8") as f:
+        f.write("# 代码执行权限（永久允许/拒绝）\n")
+        f.write("# 编辑此文件以管理永久性权限规则。\n")
+        yaml.dump({"code_permissions": entries}, f, allow_unicode=True, default_flow_style=False)
+
+
+def _load() -> list[dict]:
+    _ensure_file()
+    try:
+        with open(_PERMISSION_PATH, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        entries = raw.get("code_permissions", [])
+        if not isinstance(entries, list):
+            return []
+        return entries
+    except Exception:
+        return []
+
+
+def code_hash(code: str) -> str:
+    """计算代码内容的 SHA256 哈希。"""
+    return hashlib.sha256(code.encode("utf-8")).hexdigest()
+
+
+def check_permission(code: str) -> str | None:
+    """检查代码是否有永久权限设置。
+
+    Returns:
+        "allow" — 永久允许
+        "deny"  — 永久拒绝
+        None    — 无永久设置，需用户确认
+    """
+    h = code_hash(code)
+    for entry in _load():
+        if entry.get("hash") == h:
+            return entry.get("action")
+    return None
+
+
+def add_permission(code: str, action: str, description: str = "") -> dict:
+    """添加一条永久权限记录。
+
+    Args:
+        code: 代码内容
+        action: "allow" 或 "deny"
+        description: 描述（可选）
+    """
+    _ensure_file()
+    entries = _load()
+    h = code_hash(code)
+
+    for entry in entries:
+        if entry.get("hash") == h:
+            entry["action"] = action
+            if description:
+                entry["description"] = description
+            _write(entries)
+            return entry
+
+    entry = {
+        "hash": h,
+        "code_preview": code[:200],
+        "action": action,
+        "description": description or "",
+    }
+    entries.append(entry)
+    _write(entries)
+    return entry
+
+
+def remove_permission(index: int) -> bool:
+    """按索引删除权限记录。"""
+    entries = _load()
+    if index < 0 or index >= len(entries):
+        return False
+    entries.pop(index)
+    _write(entries)
+    return True
+
+
+def list_permissions() -> list[dict]:
+    """列出所有永久权限记录。"""
+    return _load()

--- a/api/const_session_store.py
+++ b/api/const_session_store.py
@@ -1,4 +1,4 @@
-"""Const 固定会话 — YAML 持久化存储。
+"""会话 — YAML 持久化存储。
 
 提供将会话状态（元数据 + 对话消息）序列化为 YAML 文件并重新加载的能力。
 """
@@ -8,8 +8,10 @@ from pathlib import Path
 
 import yaml
 
-# api/const_session_store.py → api/data/const-sessions/
+# api/const_session_store.py → api/data/const-sessions/（固定会话）
 _CONST_DIR = Path(__file__).resolve().parent / "data" / "const-sessions"
+# api/data/sessions/（所有会话的自动持久化）
+_SESSION_DIR = Path(__file__).resolve().parent / "data" / "sessions"
 
 
 def _ensure_dir() -> Path:
@@ -121,6 +123,48 @@ def load_all_const_sessions() -> list[dict]:
 def delete_const_session(session_id: str) -> bool:
     """删除 const 会话文件。"""
     filepath = _CONST_DIR / f"{session_id}.yaml"
+    if filepath.exists():
+        filepath.unlink()
+        return True
+    return False
+
+
+# ── 通用会话持久化（所有会话自动保存/加载） ──────────────────
+
+
+def save_session(session_id: str, metadata: dict, messages: list[dict]) -> str:
+    """将会话持久化为 YAML 文件（通用版本，不限 const）。"""
+    _SESSION_DIR.mkdir(parents=True, exist_ok=True)
+    data = {
+        "session_id": session_id,
+        "saved_at": time.time(),
+        "metadata": metadata,
+        "messages": messages,
+    }
+    filepath = _SESSION_DIR / f"{session_id}.yaml"
+    with open(filepath, "w", encoding="utf-8") as f:
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+    return str(filepath)
+
+
+def load_all_sessions() -> list[dict]:
+    """扫描 sessions/ 目录，加载所有自动持久化的会话。"""
+    _SESSION_DIR.mkdir(parents=True, exist_ok=True)
+    sessions = []
+    for fpath in sorted(_SESSION_DIR.glob("*.yaml")):
+        try:
+            with open(fpath, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            if data and data.get("session_id"):
+                sessions.append(data)
+        except Exception:
+            continue
+    return sessions
+
+
+def delete_session_file(session_id: str) -> bool:
+    """删除指定会话的持久化文件（通用版本）。"""
+    filepath = _SESSION_DIR / f"{session_id}.yaml"
     if filepath.exists():
         filepath.unlink()
         return True

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -12,7 +12,7 @@ from agent.graph import build_agent
 from agent.prompts import build_system_prompt
 from api import interaction
 from api.callbacks.websocket_callback import WebSocketCallback
-from api.const_session_store import save_const_session, serialize_messages
+from api.const_session_store import save_const_session, save_session, serialize_messages
 from api.context_usage import estimate_context_usage
 from api.session_manager import SessionState
 from tools.base import format_error
@@ -305,8 +305,8 @@ async def _run_agent_turn(
             {"role": "assistant", "content": final_answer},
         ])
 
-    # 4. [Const 会话] 自动持久化到磁盘 YAML
-    if final_answer and session.is_const:
+    # 4. [自动持久化] 所有会话保存到磁盘 YAML
+    if final_answer and not session.is_subagent:
         try:
             cpt = await session.checkpointer.aget_tuple(
                 {"configurable": {"thread_id": session.session_id}}
@@ -316,11 +316,13 @@ async def _run_agent_turn(
                 "created_at": session.created_at,
                 "last_active": session.last_active,
                 "message_count": session.message_count,
+                "is_const": session.is_const,
+                "const_name": session.const_name,
             }
             serialized = serialize_messages(raw_messages)
-            save_const_session(session.session_id, session.const_name, metadata, serialized)
+            save_session(session.session_id, metadata, serialized)
         except Exception as e:
-            print(f"[const] 自动保存会话 {session.session_id[:8]} 失败: {e}", file=sys.stderr)
+            print(f"[save] 自动保存会话 {session.session_id[:8]} 失败: {e}", file=sys.stderr)
 
     # 5. [Sub-agent] 如果有待处理的 pending_result，resolve 它
     if session._pending_result is not None and not session._pending_result.done():

--- a/api/routes/code_permissions.py
+++ b/api/routes/code_permissions.py
@@ -1,0 +1,51 @@
+"""REST API — 代码执行权限 (code_permissions.yaml) CRUD。"""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from api.code_permission_store import (
+    add_permission,
+    list_permissions,
+    remove_permission,
+)
+
+router = APIRouter()
+
+
+class CodePermissionEntry(BaseModel):
+    hash: str = ""
+    code_preview: str = ""
+    action: str
+    description: str = ""
+
+
+class ListPermissionsResponse(BaseModel):
+    permissions: list[CodePermissionEntry]
+
+
+class AddPermissionRequest(BaseModel):
+    code: str
+    action: str
+    description: str = ""
+
+
+@router.get("/code-permissions", response_model=ListPermissionsResponse)
+async def get_permissions():
+    return ListPermissionsResponse(
+        permissions=[CodePermissionEntry(**e) for e in list_permissions()]
+    )
+
+
+@router.post("/code-permissions", response_model=CodePermissionEntry)
+async def create_permission(req: AddPermissionRequest):
+    if req.action not in ("allow", "deny"):
+        raise HTTPException(status_code=400, detail="action 必须是 allow 或 deny")
+    entry = add_permission(req.code, req.action, req.description)
+    return CodePermissionEntry(**entry)
+
+
+@router.delete("/code-permissions/{index}")
+async def delete_permission(index: int):
+    if not remove_permission(index):
+        raise HTTPException(status_code=404, detail=f"索引 {index} 超出范围")
+    return {"status": "ok"}

--- a/api/routes/path_whitelist.py
+++ b/api/routes/path_whitelist.py
@@ -1,5 +1,6 @@
 """REST API — 路径白名单 (path_whitelist.yaml) CRUD。"""
 
+import os
 from pathlib import Path
 
 import yaml
@@ -22,6 +23,7 @@ WHITELIST_PATH = (
 class WhitelistEntry(BaseModel):
     path: str
     description: str = ""
+    recursive: bool = True
 
 
 class WhitelistResponse(BaseModel):
@@ -50,9 +52,11 @@ async def list_whitelist():
 @router.post("/path-whitelist", response_model=WhitelistEntry)
 async def add_whitelist(entry: WhitelistEntry):
     entries = _load()
-    entries.append(entry.model_dump())
+    data = entry.model_dump()
+    data["path"] = os.path.normpath(data["path"])
+    entries.append(data)
     _save(entries)
-    return entry
+    return WhitelistEntry(**data)
 
 
 @router.put("/path-whitelist/{index}", response_model=WhitelistEntry)
@@ -60,9 +64,11 @@ async def update_whitelist(index: int, entry: WhitelistEntry):
     entries = _load()
     if index < 0 or index >= len(entries):
         raise HTTPException(status_code=404, detail=f"索引 {index} 超出范围")
-    entries[index] = entry.model_dump()
+    data = entry.model_dump()
+    data["path"] = os.path.normpath(data["path"])
+    entries[index] = data
     _save(entries)
-    return entry
+    return WhitelistEntry(**data)
 
 
 @router.delete("/path-whitelist/{index}")

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -113,9 +113,10 @@ async def delete_session(session_id: str, request: Request):
     sm = request.app.state.session_manager
     session = sm.get(session_id)
 
-    # 若为 const 会话，先清理磁盘文件
+    # 清理磁盘文件
+    from api.const_session_store import delete_const_session, delete_session_file
+    delete_session_file(session_id)
     if session is not None and session.is_const:
-        from api.const_session_store import delete_const_session
         delete_const_session(session_id)
 
     if not sm.delete(session_id):

--- a/api/server.py
+++ b/api/server.py
@@ -13,6 +13,7 @@ import time
 from api.const_session_store import (
     deserialize_messages,
     load_all_const_sessions,
+    load_all_sessions,
 )
 from api.dependencies import get_llm, get_system_prompt, get_tools
 from api.health import get_health_report
@@ -20,6 +21,7 @@ from api.providers.manager import ProviderManager
 from api.providers.store import ProviderConfigStore
 from api.routes import chat, files, memory, sessions, balance, providers
 from api.routes import path_whitelist as path_whitelist_router
+from api.routes import code_permissions as code_permissions_router
 from api.routes import persona as persona_router
 from api.routes import sonetto_blocker as sonetto_blocker_router
 from api.routes import skills as skills_router
@@ -90,6 +92,66 @@ async def _load_const_sessions(app: FastAPI):
     print(f"[const] 已加载 {loaded}/{len(const_list)} 个固定会话")
 
 
+async def _load_saved_sessions(app: FastAPI):
+    """从 YAML 重建所有自动持久化的非常量会话到内存 SessionManager。"""
+    sm = app.state.session_manager
+    session_list = load_all_sessions()
+    if not session_list:
+        return
+
+    from langgraph.checkpoint.memory import MemorySaver
+
+    loaded = 0
+    for data in session_list:
+        sid = data.get("session_id")
+        if not sid or sid in sm._sessions:
+            continue
+
+        metadata = data.get("metadata", {})
+        messages = data.get("messages", [])
+
+        if not messages:
+            continue
+
+        if app.state.llm is None:
+            continue
+
+        try:
+            reconstructed = deserialize_messages(messages)
+            checkpointer = MemorySaver()
+            if reconstructed:
+                agent = build_agent(
+                    model=app.state.llm,
+                    tools=app.state.tools,
+                    system_prompt=app.state.system_prompt,
+                    checkpointer=checkpointer,
+                )
+                await agent.aupdate_state(
+                    {"configurable": {"thread_id": sid}},
+                    {"messages": reconstructed},
+                )
+        except Exception as e:
+            print(f"[session] 重建会话 {sid} 失败: {e}")
+            continue
+
+        is_const = metadata.get("is_const", False)
+        const_name = metadata.get("const_name", "")
+
+        session = SessionState(
+            session_id=sid,
+            created_at=metadata.get("created_at", time.time()),
+            last_active=metadata.get("last_active", time.time()),
+            message_count=metadata.get("message_count", 0),
+            checkpointer=checkpointer,
+            is_const=is_const,
+            const_name=const_name,
+        )
+        sm._sessions[sid] = session
+        loaded += 1
+
+    print(f"[session] 已恢复 {loaded}/{len(session_list)} 个会话")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # 1. 初始化 Provider 管理器（优先从 YAML 加载）
@@ -125,6 +187,9 @@ async def lifespan(app: FastAPI):
 
     # 加载 const 固定会话（需要 tools 已就绪）
     await _load_const_sessions(app)
+
+    # 加载所有自动持久化的非常量会话
+    await _load_saved_sessions(app)
 
     yield
 
@@ -168,6 +233,9 @@ def create_app() -> FastAPI:
 
     # SonettoBlocker 拒止锚管理
     app.include_router(sonetto_blocker_router.router, prefix="/api")
+
+    # 代码执行权限管理
+    app.include_router(code_permissions_router.router, prefix="/api")
 
     # Anthropic Skills
     app.include_router(skills_router.router, prefix="/api")

--- a/api/session_manager.py
+++ b/api/session_manager.py
@@ -30,6 +30,10 @@ class SessionState:
     is_const: bool = False
     const_name: str = ""
 
+    # ── 代码执行权限（会话级） ──────────────────────────────
+    approved_code_hashes: set[str] = field(default_factory=set)
+    denied_code_hashes: set[str] = field(default_factory=set)
+
 
 class SessionManager:
     def __init__(self, ttl_seconds: int = 1800):

--- a/tools/base.py
+++ b/tools/base.py
@@ -208,8 +208,9 @@ def _ensure_whitelist() -> None:
 
 def _default_entry() -> dict:
     return {
-        "path": str(_DEFAULT_WHITELIST_PATH),
+        "path": os.path.normpath(str(_DEFAULT_WHITELIST_PATH)),
         "description": "技能目录（自动生成）",
+        "recursive": True,
     }
 
 
@@ -228,13 +229,18 @@ def _write_whitelist(entries: list) -> None:
 _ensure_whitelist()
 
 
-def _load_path_whitelist() -> list[str]:
-    """从 YAML 文件加载白名单路径前缀列表，按绝对路径规范化后返回。
+def _load_path_whitelist() -> list[tuple[str, bool]]:
+    """从 YAML 文件加载白名单条目列表。
+
+    每个条目返回 (normalized_path, recursive) 元组。
+    recursive=True 时该路径下所有子目录继承访问权限；
+    recursive=False 时仅允许访问该确切路径。
 
     文件格式:
         whitelist:
           - path: "/some/allowed/dir"
             description: ...
+            recursive: true
     读取失败时返回空列表（会触发 fail-secure 全阻断）。
     """
     try:
@@ -243,11 +249,15 @@ def _load_path_whitelist() -> list[str]:
         entries = raw.get("whitelist", [])
         if not isinstance(entries, list):
             return []
-        result: list[str] = []
+        result: list[tuple[str, bool]] = []
         for entry in entries:
             if isinstance(entry, dict) and "path" in entry:
                 normalized = os.path.normpath(os.path.abspath(entry["path"]))
-                result.append(normalized)
+                recursive = entry.get("recursive", True)
+                if isinstance(recursive, bool):
+                    result.append((normalized, recursive))
+                else:
+                    result.append((normalized, True))
         return result
     except (yaml.YAMLError, OSError, ValueError):
         return []
@@ -262,6 +272,10 @@ def check_path_whitelisted(target_path: str) -> str | None:
     返回:
         None      — 允许访问（路径在白名单内）。
         str       — 阻断原因描述，调用方应将其传给 format_error()。
+
+    白名单每个条目可设置 recursive 标志：
+        recursive=True  — 目标路径等于允许前缀或以"允许前缀 + 分隔符"开头时允许。
+        recursive=False — 仅当目标路径与允许前缀精确相等时才允许。
     """
     if not target_path:
         return None
@@ -272,12 +286,17 @@ def check_path_whitelisted(target_path: str) -> str | None:
     if not whitelist:
         return f"路径不在白名单中: {target_path}（白名单为空或未配置）"
 
-    for allowed_prefix in whitelist:
-        # 精确匹配或前缀 + 分隔符匹配，防止 "/home/proj" 误匹配 "/home/project-evil"
-        if abs_target == allowed_prefix or abs_target.startswith(
-            allowed_prefix + os.sep
-        ):
+    for allowed_prefix, recursive in whitelist:
+        # 去掉末尾分隔符，避免 root 路径（如 T:\）拼接 os.sep 产生双分隔符
+        prefix_stripped = allowed_prefix.rstrip(os.sep)
+
+        if abs_target == allowed_prefix or abs_target == prefix_stripped:
             return None
+
+        if recursive:
+            # 防止 "/home/proj" 误匹配 "/home/project-evil"
+            if abs_target.startswith(prefix_stripped + os.sep):
+                return None
 
     return f"路径不在白名单中: {target_path}"
 

--- a/tools/system/tool_python.py
+++ b/tools/system/tool_python.py
@@ -7,6 +7,8 @@ import sys
 from pydantic import BaseModel, Field
 
 from api import interaction
+from api.code_permission_store import add_permission, check_permission, code_hash
+from api.session_manager import SessionState
 from tools.base import ToolBase, format_error, format_success, get_safe_builtins
 
 # 模块级常量：安全 builtins 只构造一次
@@ -24,6 +26,16 @@ def _exec_code(code: str) -> str:
         raise RuntimeError(f"代码执行错误: {e}") from e
     finally:
         sys.stdout = old_stdout
+
+
+async def _get_session() -> SessionState | None:
+    """从当前 interaction 上下文获取 SessionState（通过 WebSocket 的 app.state）。"""
+    try:
+        ws = interaction.current_ws.get()
+        session_id = ws.scope["path"].rsplit("/", 1)[-1]
+        return ws.app.state.session_manager.get(session_id)
+    except Exception:
+        return None
 
 
 class RunPythonInput(BaseModel):
@@ -48,19 +60,42 @@ class RunPythonTool(ToolBase):
     def _run(self, get_doc: bool = False, code: str = "") -> str:
         raise NotImplementedError("run_python 仅支持异步模式，请使用 _arun")
 
+    async def _exec_with_approval(self, code: str) -> str:
+        try:
+            output = await asyncio.to_thread(_exec_code, code)
+            return format_success({"output": output, "code": code})
+        except Exception as e:
+            return format_error(str(e))
+
     async def _arun(self, get_doc: bool = False, code: str = "") -> str:
         if get_doc:
             return self._load_doc()
         if not code:
             return format_error("code 不能为空")
 
+        # ── 自动批准模式：跳过所有确认 ──
         if interaction.auto_approve.get():
-            try:
-                output = await asyncio.to_thread(_exec_code, code)
-                return format_success({"output": output, "code": code})
-            except Exception as e:
-                return format_error(str(e))
+            return await self._exec_with_approval(code)
 
+        # ── 权限检查 ──
+        h = code_hash(code)
+
+        # 1. 检查永久权限
+        permanent = check_permission(code)
+        if permanent == "allow":
+            return await self._exec_with_approval(code)
+        if permanent == "deny":
+            return format_error("该代码已被永久拒绝执行")
+
+        # 2. 检查会话级权限
+        session = await _get_session()
+        if session is not None:
+            if h in session.approved_code_hashes:
+                return await self._exec_with_approval(code)
+            if h in session.denied_code_hashes:
+                return format_error("该代码已在本会话中被拒绝执行")
+
+        # ── 用户交互确认 ──
         ws = interaction.current_ws.get()
         interaction_id, future = interaction.register()
 
@@ -68,9 +103,9 @@ class RunPythonTool(ToolBase):
             "type": "ask_user",
             "payload": {
                 "tool_name": self.name,
-                "question": "即将执行以下 Python 代码，是否确认执行？",
+                "question": "即将执行以下 Python 代码，请选择操作：",
                 "mode": "confirm",
-                "options": ["执行", "取消"],
+                "options": ["本次允许", "永久允许", "本次拒绝", "永久拒绝"],
                 "interaction_id": interaction_id,
                 "code": code,
             },
@@ -85,16 +120,30 @@ class RunPythonTool(ToolBase):
                 action = answer.get("action", "")
                 reason = answer.get("reason", "")
 
-            if action == "approve":
-                try:
-                    output = await asyncio.to_thread(_exec_code, code)
-                    return format_success({"output": output, "code": code})
-                except Exception as e:
-                    return format_error(str(e))
-            else:
-                if reason:
-                    return format_error(f"用户拒绝执行代码。原因：{reason}")
-                else:
+            match action:
+                case "approve_session":
+                    if session is not None:
+                        session.approved_code_hashes.add(h)
+                    return await self._exec_with_approval(code)
+
+                case "approve_permanent":
+                    add_permission(code, "allow", "用户永久允许")
+                    return await self._exec_with_approval(code)
+
+                case "reject_session":
+                    if session is not None:
+                        session.denied_code_hashes.add(h)
+                    if reason:
+                        return format_error(f"用户拒绝执行代码。原因：{reason}")
+                    return format_error("用户拒绝执行代码")
+
+                case "reject_permanent":
+                    add_permission(code, "deny", "用户永久拒绝")
+                    return format_error("该代码已被永久拒绝执行")
+
+                case _:
+                    if reason:
+                        return format_error(f"用户拒绝执行代码。原因：{reason}")
                     return format_error("用户拒绝执行代码")
 
         except asyncio.CancelledError:

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -29,6 +29,7 @@
           <router-link to="/user" class="popup-item" @click="closeSettingsMenu">用户 USER</router-link>
           <router-link to="/path-whitelist" class="popup-item" @click="closeSettingsMenu">路径白名单</router-link>
           <router-link to="/sonetto-blocker" class="popup-item" @click="closeSettingsMenu">拒止锚</router-link>
+          <router-link to="/code-permissions" class="popup-item" @click="closeSettingsMenu">代码权限</router-link>
         </div>
       </Transition>
       <SessionSidebar

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -18,6 +18,8 @@ import type {
   ConstifyResponse,
   WhitelistEntry,
   ListWhitelistResponse,
+  CodePermissionEntry,
+  ListCodePermissionsResponse,
   BlockerEntry,
   ListBlockerResponse,
 } from '@/types'
@@ -202,4 +204,18 @@ export const api = {
 
   deleteBlocker: (index: number) =>
     request<{ status: string }>(`/sonetto-blocker/${index}`, { method: 'DELETE' }),
+
+  // ── 代码执行权限 ──
+
+  listCodePermissions: () =>
+    request<ListCodePermissionsResponse>('/code-permissions'),
+
+  addCodePermission: (body: { code: string; action: string; description?: string }) =>
+    request<CodePermissionEntry>('/code-permissions', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  deleteCodePermission: (index: number) =>
+    request<{ status: string }>(`/code-permissions/${index}`, { method: 'DELETE' }),
 }

--- a/web/src/components/tools/PythonBubble.vue
+++ b/web/src/components/tools/PythonBubble.vue
@@ -33,16 +33,32 @@
       <!-- 确认按钮 -->
       <div class="py-confirm-actions">
         <button
-          class="btn-action btn-reject"
-          @click="submitRejection"
+          class="btn-action btn-reject-session"
+          @click="submitRejectSession"
+          title="仅本次对话拒绝此代码"
         >
-          拒绝执行
+          本次拒绝
         </button>
         <button
-          class="btn-action btn-approve"
-          @click="submitApproval"
+          class="btn-action btn-reject-permanent"
+          @click="submitRejectPermanent"
+          title="永久拒绝此代码"
         >
-          允许执行
+          永久拒绝
+        </button>
+        <button
+          class="btn-action btn-approve-session"
+          @click="submitApproveSession"
+          title="仅本次对话允许此代码"
+        >
+          本次允许
+        </button>
+        <button
+          class="btn-action btn-approve-permanent"
+          @click="submitApprovePermanent"
+          title="永久允许此代码（可在设置中管理）"
+        >
+          永久允许
         </button>
       </div>
     </template>
@@ -129,24 +145,48 @@ const stdoutLineCount = computed(() => {
   return stdout.value.split('\n').length
 })
 
-function submitApproval() {
+function submitApproveSession() {
   submitted.value = true
   emit('action', {
     action: 'user_response',
     data: {
       interactionId: props.toolCall.interaction?.interactionId,
-      response: { action: 'approve', reason: '' },
+      response: { action: 'approve_session', reason: '' },
     },
   })
 }
 
-function submitRejection() {
+function submitApprovePermanent() {
+  if (!window.confirm('永久允许此代码？之后执行相同代码时将自动跳过确认。可在设置中管理。')) return
   submitted.value = true
   emit('action', {
     action: 'user_response',
     data: {
       interactionId: props.toolCall.interaction?.interactionId,
-      response: { action: 'reject', reason: rejectionReason.value.trim() },
+      response: { action: 'approve_permanent', reason: '' },
+    },
+  })
+}
+
+function submitRejectSession() {
+  submitted.value = true
+  emit('action', {
+    action: 'user_response',
+    data: {
+      interactionId: props.toolCall.interaction?.interactionId,
+      response: { action: 'reject_session', reason: rejectionReason.value.trim() },
+    },
+  })
+}
+
+function submitRejectPermanent() {
+  if (!window.confirm('永久拒绝此代码？之后执行相同代码时将自动跳过。可在设置中管理。')) return
+  submitted.value = true
+  emit('action', {
+    action: 'user_response',
+    data: {
+      interactionId: props.toolCall.interaction?.interactionId,
+      response: { action: 'reject_permanent', reason: rejectionReason.value.trim() },
     },
   })
 }
@@ -351,15 +391,16 @@ function copyCode() {
 
 .py-confirm-actions {
   display: flex;
-  gap: 10px;
+  gap: 6px;
+  flex-wrap: wrap;
   justify-content: flex-end;
   margin-top: 8px;
 }
 
 .btn-action {
-  padding: 8px 20px;
+  padding: 6px 12px;
   border-radius: 8px;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
   cursor: pointer;
   font-family: inherit;
@@ -367,23 +408,43 @@ function copyCode() {
   border: 1px solid transparent;
 }
 
-.btn-reject {
+.btn-reject-session {
   background: var(--bg-secondary);
   border-color: var(--border);
   color: var(--text-primary);
 }
 
-.btn-reject:hover {
+.btn-reject-session:hover {
   border-color: var(--text-secondary);
   background: color-mix(in srgb, var(--border) 20%, transparent);
 }
 
-.btn-approve {
+.btn-reject-permanent {
+  background: #fef3c7;
+  border-color: #f59e0b;
+  color: #92400e;
+}
+
+.btn-reject-permanent:hover {
+  background: #fde68a;
+}
+
+.btn-approve-session {
   background: var(--accent);
   color: #fff;
 }
 
-.btn-approve:hover {
+.btn-approve-session:hover {
   background: color-mix(in srgb, var(--accent) 90%, #fff);
+}
+
+.btn-approve-permanent {
+  background: #22c55e;
+  color: #fff;
+  border-color: #16a34a;
+}
+
+.btn-approve-permanent:hover {
+  background: #16a34a;
 }
 </style>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -37,6 +37,11 @@ const router = createRouter({
       name: 'sonetto-blocker',
       component: () => import('@/views/SonettoBlockerView.vue'),
     },
+    {
+      path: '/code-permissions',
+      name: 'code-permissions',
+      component: () => import('@/views/CodePermissionView.vue'),
+    },
   ],
 })
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -352,6 +352,7 @@ export interface ListToolsResponse {
 export interface WhitelistEntry {
   path: string
   description: string
+  recursive: boolean
 }
 
 export interface ListWhitelistResponse {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -359,6 +359,19 @@ export interface ListWhitelistResponse {
   entries: WhitelistEntry[]
 }
 
+// === 代码执行权限 ===
+
+export interface CodePermissionEntry {
+  hash: string
+  code_preview: string
+  action: string
+  description: string
+}
+
+export interface ListCodePermissionsResponse {
+  permissions: CodePermissionEntry[]
+}
+
 // === SonettoBlocker 拒止锚 ===
 
 export interface BlockerEntry {

--- a/web/src/views/CodePermissionView.vue
+++ b/web/src/views/CodePermissionView.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="perm-view">
+    <div class="header">
+      <h2>代码执行权限</h2>
+      <span class="subtitle">管理永久允许/拒绝的代码规则</span>
+    </div>
+
+    <div v-if="loading" class="loading">加载中...</div>
+    <div v-else-if="permissions.length === 0" class="empty">
+      暂无永久权限规则。在执行代码时选择"永久允许"或"永久拒绝"即可添加。
+    </div>
+    <div v-else class="entry-list">
+      <div v-for="(perm, i) in permissions" :key="i" class="entry-card">
+        <div class="entry-body">
+          <div class="entry-action-tag" :class="perm.action === 'allow' ? 'tag-allow' : 'tag-deny'">
+            {{ perm.action === 'allow' ? '允许' : '拒绝' }}
+          </div>
+          <div class="entry-hash" :title="perm.hash">SHA256: {{ perm.hash.slice(0, 16) }}...</div>
+          <pre class="entry-preview">{{ perm.code_preview }}</pre>
+          <div v-if="perm.description" class="entry-desc">{{ perm.description }}</div>
+        </div>
+        <button class="btn btn-danger" @click="confirmDelete(i)">删除</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { api } from '@/api'
+import type { CodePermissionEntry } from '@/types'
+
+const loading = ref(true)
+const permissions = ref<CodePermissionEntry[]>([])
+
+async function load() {
+  loading.value = true
+  try {
+    const res = await api.listCodePermissions()
+    permissions.value = res.permissions
+  } catch (e: any) {
+    console.error('加载代码权限失败', e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function confirmDelete(i: number) {
+  const perm = permissions.value[i]
+  if (!window.confirm(`确定删除此${perm.action === 'allow' ? '允许' : '拒绝'}规则？`)) return
+  try {
+    await api.deleteCodePermission(i)
+    permissions.value.splice(i, 1)
+  } catch (e: any) {
+    console.error('删除失败', e)
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.perm-view {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+.header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+.header h2 {
+  font-size: 20px;
+  font-weight: 700;
+}
+.subtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.loading,
+.empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 40px 0;
+}
+.entry-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.entry-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+  transition: box-shadow 0.15s;
+}
+.entry-card:hover {
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+}
+.entry-body {
+  flex: 1;
+  min-width: 0;
+}
+.entry-action-tag {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-bottom: 6px;
+}
+.tag-allow {
+  background: #dcfce7;
+  color: #166534;
+}
+.tag-deny {
+  background: #fee2e2;
+  color: #991b1b;
+}
+.entry-hash {
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-bottom: 4px;
+}
+.entry-preview {
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 12px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  padding: 8px 10px;
+  border-radius: 6px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 80px;
+  overflow-y: auto;
+  margin: 0;
+}
+.entry-desc {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-top: 4px;
+}
+.btn {
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 13px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  margin-top: 2px;
+  transition: opacity 0.15s;
+}
+.btn:hover { opacity: 0.8; }
+.btn-danger {
+  color: var(--status-error);
+  border-color: var(--status-error);
+}
+</style>

--- a/web/src/views/PathWhitelistView.vue
+++ b/web/src/views/PathWhitelistView.vue
@@ -14,6 +14,9 @@
           <div class="entry-body">
             <div class="entry-path">{{ entry.path }}</div>
             <div v-if="entry.description" class="entry-desc">{{ entry.description }}</div>
+            <div class="entry-recursive-tag" :class="entry.recursive ? 'recursive-yes' : 'recursive-no'">
+              {{ entry.recursive ? '允许子目录' : '仅当前目录' }}
+            </div>
           </div>
           <div class="entry-actions">
             <button class="btn" @click="startEdit(i)">编辑</button>
@@ -49,6 +52,14 @@
             placeholder="用途说明"
           />
         </div>
+        <div class="form-section">
+          <label class="form-label">子目录继承</label>
+          <label class="toggle-row">
+            <input type="checkbox" v-model="formRecursive" class="toggle-input" />
+            <span class="toggle-slider"></span>
+            <span class="toggle-label">{{ formRecursive ? '允许访问所有子目录' : '仅允许访问此目录（不含子目录）' }}</span>
+          </label>
+        </div>
         <div v-if="formError" class="msg error">{{ formError }}</div>
         <div class="form-actions">
           <button class="btn" @click="cancelForm">取消</button>
@@ -74,6 +85,7 @@ const formError = ref('')
 const editingIndex = ref(-1)
 const formPath = ref('')
 const formDesc = ref('')
+const formRecursive = ref(true)
 
 async function loadEntries() {
   loading.value = true
@@ -103,6 +115,7 @@ function startAdd() {
   editingIndex.value = -1
   formPath.value = ''
   formDesc.value = ''
+  formRecursive.value = true
   formError.value = ''
   mode.value = 'form'
 }
@@ -111,6 +124,7 @@ function startEdit(i: number) {
   editingIndex.value = i
   formPath.value = entries.value[i].path
   formDesc.value = entries.value[i].description || ''
+  formRecursive.value = entries.value[i].recursive !== false
   formError.value = ''
   mode.value = 'form'
 }
@@ -124,7 +138,7 @@ async function handleSave() {
   saving.value = true
   formError.value = ''
   try {
-    const entry = { path: formPath.value.trim(), description: formDesc.value.trim() }
+    const entry = { path: formPath.value.trim(), description: formDesc.value.trim(), recursive: formRecursive.value }
     if (editingIndex.value >= 0) {
       await api.updateWhitelistEntry(editingIndex.value, entry)
     } else {
@@ -292,5 +306,64 @@ onMounted(loadEntries)
 .btn-danger {
   color: var(--status-error);
   border-color: var(--status-error);
+}
+
+/* ── 递归标签 ── */
+.entry-recursive-tag {
+  display: inline-block;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+.recursive-yes {
+  background: #dcfce7;
+  color: #166534;
+}
+.recursive-no {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+/* ── Toggle 开关 ── */
+.toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+.toggle-input {
+  display: none;
+}
+.toggle-slider {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: #d1d5db;
+  border-radius: 11px;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+.toggle-slider::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+.toggle-input:checked + .toggle-slider {
+  background: var(--accent, #3b82f6);
+}
+.toggle-input:checked + .toggle-slider::after {
+  transform: translateX(18px);
+}
+.toggle-label {
+  font-size: 13px;
+  color: var(--text-secondary);
 }
 </style>


### PR DESCRIPTION
## 改动内容

### 1. 会话持久化（修复重启后历史丢失）

**问题**：SessionManager._sessions 纯内存存储 + MemorySaver 纯内存，服务器重启后所有会话消失。

**修复**：
- pi/const_session_store.py：新增 save_session() / load_all_sessions() / delete_session_file() 通用会话持久化函数
- pi/routes/chat.py：每轮对话后自动保存所有非常量会话到 pi/data/sessions/
- pi/server.py：启动时从 sessions/ 恢复所有会话（含 checkpointer 重建）
- pi/routes/sessions.py：删除会话时同时清理磁盘文件

### 2. 代码执行权限增强

**问题**：之前只有「允许执行」和「拒绝执行」两个选项，缺少更细粒度的权限控制。

**新增**：
- **4 个选项**：本次允许 / 永久允许 / 本次拒绝 / 永久拒绝
- **永久权限存储**：pi/code_permission_store.py — 基于 SHA256 哈希的 YAML 持久化存储
- **会话级权限**：SessionState.approved_code_hashes / denied_code_hashes — 跟踪当前会话的临时权限
- **REST API**：pi/routes/code_permissions.py — CRUD 管理永久权限
- **管理页面**：CodePermissionView.vue — 查看/删除永久权限规则
- **前端导航**：设置菜单新增「代码权限」入口

### 修改的文件（14个）

**新文件**：
- pi/code_permission_store.py
- pi/routes/code_permissions.py
- web/src/views/CodePermissionView.vue

**修改文件**：
- pi/const_session_store.py — 通用会话持久化
- pi/session_manager.py — SessionState 加 session 级代码权限跟踪
- pi/server.py — 启动时恢复会话 + 注册代码权限路由
- pi/routes/sessions.py — 删除时清理文件
- pi/routes/chat.py — 每轮自动保存所有会话
- 	ools/system/tool_python.py — 4 选项权限流 + 永久/会话级检查
- web/src/types/index.ts — 代码权限类型
- web/src/api/index.ts — 代码权限 API
- web/src/components/tools/PythonBubble.vue — 4 按钮 UI
- web/src/router/index.ts — 管理页面路由
- web/src/App.vue — 导航入口