### PR TITLE
安全加固：host 绑定 127.0.0.1 + API Token 认证 + api/data 拒止锚

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ api/data/path_whitelist.yaml
 
 # SonettoBlocker 拒止锚数据（自动生成，每用户本地配置）
 api/data/sonetto_blocker.yaml
+api/data/SonettoBlocker
 
 # 认证 Token（自动生成，每用户本地配置）
 api/data/auth_token.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,8 @@ api/data/path_whitelist.yaml
 # SonettoBlocker 拒止锚数据（自动生成，每用户本地配置）
 api/data/sonetto_blocker.yaml
 
+# 认证 Token（自动生成，每用户本地配置）
+api/data/auth_token.yaml
+
 # Anthropic Skills（忽略 skill 子目录，保留目录本身用于 .gitkeep）
 anthropic_skills/*/

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,33 @@
+"""Token 认证管理 — 生成、加载、轮换。"""
+
+import secrets
+from pathlib import Path
+
+import yaml
+
+AUTH_TOKEN_PATH = Path(__file__).resolve().parent / "data" / "auth_token.yaml"
+
+
+def load_or_create_token() -> str:
+    """从 auth_token.yaml 加载 Token，不存在则生成并持久化。"""
+    if AUTH_TOKEN_PATH.exists():
+        data = yaml.safe_load(AUTH_TOKEN_PATH.read_text(encoding="utf-8"))
+        if data and "token" in data:
+            return data["token"]
+
+    token = secrets.token_urlsafe(32)
+    AUTH_TOKEN_PATH.write_text(
+        yaml.dump({"token": token}, encoding="utf-8").decode("utf-8"),
+        encoding="utf-8",
+    )
+    return token
+
+
+def rotate_token() -> str:
+    """轮换 Token，覆盖写入文件并返回新值。"""
+    token = secrets.token_urlsafe(32)
+    AUTH_TOKEN_PATH.write_text(
+        yaml.dump({"token": token}, encoding="utf-8").decode("utf-8"),
+        encoding="utf-8",
+    )
+    return token

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,0 +1,31 @@
+"""
+认证中间件 — 对 API 和 WebSocket 路径校验 X-Sonetto-Token。
+非 API 路径（/docs、/openapi.json 等）一律放行。
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """拦截 /api/* 和 /ws/* 路径，校验 X-Sonetto-Token 请求头。"""
+
+    async def dispatch(self, request, call_next):
+        path = request.url.path
+
+        # 仅保护 API 和 WebSocket 路径
+        if not path.startswith("/api/") and not path.startswith("/ws/"):
+            return await call_next(request)
+
+        # 白名单：健康检查
+        if path == "/api/health":
+            return await call_next(request)
+
+        token = request.headers.get("x-sonetto-token", "")
+        expected = request.app.state.auth_token
+        if not expected or token != expected:
+            return JSONResponse(
+                {"detail": "Unauthorized — 请在请求头中提供有效的 X-Sonetto-Token"},
+                status_code=401,
+            )
+        return await call_next(request)

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,6 +1,9 @@
 """
-认证中间件 — 对 API 和 WebSocket 路径校验 X-Sonetto-Token。
-非 API 路径（/docs、/openapi.json 等）一律放行。
+认证中间件 — 对 API 和 WebSocket 路径校验 Token。
+
+Token 来源（按优先级）：
+1. X-Sonetto-Token 请求头（REST API 使用）
+2. ?token= 查询参数（WebSocket 使用，因其无法设置自定义头）
 """
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -8,7 +11,7 @@ from starlette.responses import JSONResponse
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
-    """拦截 /api/* 和 /ws/* 路径，校验 X-Sonetto-Token 请求头。"""
+    """拦截 /api/* 和 /ws/* 路径，校验认证 Token。"""
 
     async def dispatch(self, request, call_next):
         path = request.url.path
@@ -21,11 +24,15 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if path == "/api/health":
             return await call_next(request)
 
+        # 尝试从请求头或查询参数获取 Token
         token = request.headers.get("x-sonetto-token", "")
+        if not token:
+            token = request.url.query.split("token=")[-1].split("&")[0] if "token=" in request.url.query else ""
+
         expected = request.app.state.auth_token
         if not expected or token != expected:
             return JSONResponse(
-                {"detail": "Unauthorized — 请在请求头中提供有效的 X-Sonetto-Token"},
+                {"detail": "Unauthorized — X-Sonetto-Token 缺失或不匹配"},
                 status_code=401,
             )
         return await call_next(request)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -358,14 +358,14 @@ def _resume_sub_agent(ws: WebSocket, session: SessionState) -> asyncio.Task | No
 @router.websocket("/ws/chat/{session_id}")
 async def websocket_chat(ws: WebSocket, session_id: str):
     """WebSocket 聊天端点 — 接收用户消息、驱动 Agent、处理取消和用户交互。"""
-    # 校验 Token
+    await ws.accept()
+
+    # 校验 Token（accept 之后检查，避免 403 日志噪声）
     token = ws.query_params.get("token", "")
     expected = ws.app.state.auth_token
     if not expected or token != expected:
         await ws.close(code=4001)
         return
-
-    await ws.accept()
 
     # ── 初始化会话 ────────────────────────────────────────
     app_state = ws.app.state

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -358,6 +358,13 @@ def _resume_sub_agent(ws: WebSocket, session: SessionState) -> asyncio.Task | No
 @router.websocket("/ws/chat/{session_id}")
 async def websocket_chat(ws: WebSocket, session_id: str):
     """WebSocket 聊天端点 — 接收用户消息、驱动 Agent、处理取消和用户交互。"""
+    # 校验 Token
+    token = ws.query_params.get("token", "")
+    expected = ws.app.state.auth_token
+    if not expected or token != expected:
+        await ws.close(code=4001)
+        return
+
     await ws.accept()
 
     # ── 初始化会话 ────────────────────────────────────────

--- a/api/server.py
+++ b/api/server.py
@@ -1,12 +1,9 @@
-"""FastAPI 应用工厂 — 生命周期管理、CORS、路由挂载、静态文件服务。"""
+"""FastAPI 应用工厂 — 生命周期管理、CORS、路由挂载。"""
 
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-from starlette.responses import FileResponse
 
 import time
 
@@ -29,8 +26,6 @@ from agent.graph import build_agent
 from memory.narrative import MEMORY_PATH, LongTermMemoryInterface
 from tools.mcp import init_mcp_tools, close_mcp
 from version import __version__
-
-WEB_DIR = Path(__file__).resolve().parent.parent / "web" / "dist"
 
 
 async def _load_const_sessions(app: FastAPI):
@@ -179,13 +174,5 @@ def create_app() -> FastAPI:
     @app.get("/api/health")
     async def health():
         return await get_health_report(app)
-
-    # 生产模式：serve 前端静态文件（用 /assets 前缀避免拦截 WebSocket）
-    if WEB_DIR.exists():
-        app.mount("/assets", StaticFiles(directory=str(WEB_DIR / "assets")), name="assets")
-
-        @app.exception_handler(404)
-        async def spa_fallback(request, exc):
-            return FileResponse(WEB_DIR / "index.html")
 
     return app

--- a/api/server.py
+++ b/api/server.py
@@ -1,5 +1,6 @@
 """FastAPI 应用工厂 — 生命周期管理、CORS、路由挂载。"""
 
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -7,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 import time
 
+from api.auth import load_or_create_token
 from api.const_session_store import (
     deserialize_messages,
     load_all_const_sessions,
@@ -26,6 +28,8 @@ from agent.graph import build_agent
 from memory.narrative import MEMORY_PATH, LongTermMemoryInterface
 from tools.mcp import init_mcp_tools, close_mcp
 from version import __version__
+
+from api.middleware.auth import AuthMiddleware
 
 
 async def _load_const_sessions(app: FastAPI):
@@ -121,6 +125,10 @@ async def lifespan(app: FastAPI):
     # 加载 const 固定会话（需要 tools 已就绪）
     await _load_const_sessions(app)
 
+    # 3. 初始化认证 Token
+    app.state.auth_token = load_or_create_token()
+    print(f"[auth] token: {app.state.auth_token}")
+
     yield
 
     # 关闭：清理资源
@@ -135,9 +143,19 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
+    # CORS：开发环境仅放行 Vite（5173），生产可加 localhost:8000
+    cors_origins = [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+    if os.environ.get("SONETTO_ENV") == "production":
+        cors_origins += [
+            "http://localhost:8000",
+            "http://127.0.0.1:8000",
+        ]
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=cors_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -174,5 +192,8 @@ def create_app() -> FastAPI:
     @app.get("/api/health")
     async def health():
         return await get_health_report(app)
+
+    # 认证中间件（在路由之后添加，确保只拦截 API/WS 路径）
+    app.add_middleware(AuthMiddleware)
 
     return app

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ def main():
     ensure_all()
 
     app = create_app()
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="127.0.0.1", port=8000)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 """SonettoHere v2.0.0 — LangGraph ReAct AI Agent Web 入口。"""
 
+import sys
+
 import uvicorn
 
 from api.server import create_app
@@ -7,6 +9,13 @@ from memory.user_init import ensure_all
 
 
 def main():
+    # CLI：轮换 Token
+    if "--rotate-token" in sys.argv:
+        from api.auth import rotate_token
+        rotated = rotate_token()
+        print(f"[auth] Token rotated: {rotated}")
+        return
+
     print("SonettoHere v2.0.0")
     print()
 

--- a/tools/base.py
+++ b/tools/base.py
@@ -224,8 +224,58 @@ def _write_whitelist(entries: list) -> None:
         yaml.dump(content, f, allow_unicode=True, default_flow_style=False)
 
 
-# 模块加载时自动执行：确保白名单存在（首次 import 时运行一次）
+_BLOCKER_YAML_PATH = (
+    Path(__file__).resolve().parent.parent / "api" / "data" / "sonetto_blocker.yaml"
+)
+
+_BLOCKER_FILENAME = "SonettoBlocker"
+_AUTO_BLOCKER_PATH = os.path.join(_PROJECT_ROOT, "api", "data")
+
+
+def _ensure_blocker() -> None:
+    """确保 api/data/ 目录受 SonettoBlocker 保护。
+
+    在模块导入时自动运行：
+    - 如果 api/data/ 下没有 SonettoBlocker 标记文件 → 创建
+    - 如果 sonetto_blocker.yaml 中没有对应条目 → 添加
+    """
+    marker = Path(_AUTO_BLOCKER_PATH) / _BLOCKER_FILENAME
+    if not marker.exists():
+        try:
+            marker.write_text("", encoding="utf-8")
+        except OSError:
+            return
+
+    if not _BLOCKER_YAML_PATH.exists():
+        return
+
+    try:
+        with open(_BLOCKER_YAML_PATH, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        entries = raw.get("blockers", [])
+        if not isinstance(entries, list):
+            return
+
+        normalized = os.path.normpath(_AUTO_BLOCKER_PATH)
+        has_entry = any(
+            isinstance(e, dict)
+            and os.path.normpath(os.path.abspath(e.get("path", ""))) == normalized
+            for e in entries
+        )
+        if not has_entry:
+            entries.insert(0, {
+                "path": _AUTO_BLOCKER_PATH,
+                "description": "API 数据目录（自动生成）",
+            })
+            with open(_BLOCKER_YAML_PATH, "w", encoding="utf-8") as f:
+                yaml.dump({"blockers": entries}, f, allow_unicode=True, default_flow_style=False)
+    except (yaml.YAMLError, OSError):
+        pass
+
+
+# 模块加载时自动执行：确保白名单存在 + api/data/ 拒止锚存在（首次 import 时运行一次）
 _ensure_whitelist()
+_ensure_blocker()
 
 
 def _load_path_whitelist() -> list[str]:

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -22,11 +22,26 @@ import type {
   ListBlockerResponse,
 } from '@/types'
 
+declare const __API_TOKEN__: string
+
 const BASE = '/api'
 
+/** 从 Vite 编译期注入的 Token */
+let token: string = typeof __API_TOKEN__ !== 'undefined' ? __API_TOKEN__ : ''
+
+export function getToken(): string {
+  return token
+}
+
 async function request<T>(url: string, options?: RequestInit): Promise<T> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (token) {
+    headers['X-Sonetto-Token'] = token
+  }
   const res = await fetch(`${BASE}${url}`, {
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     ...options,
   })
   if (!res.ok) {

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -3,6 +3,7 @@ import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, Tur
 import { refreshSessions, switchSession } from '@/composables/useSession'
 import { buildFlatMessage, buildTimestamp, parseReferences } from '@/utils/references'
 import type { ParsedRef } from '@/utils/references'
+import { getToken } from '@/api'
 /** 匹配旧格式尾缀（用于 localStorage 迁移） */
 const TIME_SUFFIX_RE = /（\d{4}-\d{2}-\d{2} \w{3} \d{2}:\d{2}）$/
 
@@ -165,7 +166,8 @@ function connectSession(sid: string) {
   if (ch.ws?.readyState === WebSocket.OPEN) return
 
   const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-  const url = `${protocol}//${location.host}/ws/chat/${sid}`
+  const token = getToken()
+  const url = `${protocol}//${location.host}/ws/chat/${sid}?token=${encodeURIComponent(token)}`
   ch.ws = new WebSocket(url)
 
   ch.ws.onopen = () => {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,23 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { fileURLToPath, URL } from 'node:url'
+import fs from 'node:fs'
+import path from 'node:path'
+
+function loadApiToken(): string {
+  try {
+    const yamlPath = path.resolve(__dirname, '..', 'api', 'data', 'auth_token.yaml')
+    const raw = fs.readFileSync(yamlPath, 'utf-8')
+    const match = raw.match(/^token:\s*(.+)$/m)
+    const token = match?.[1]?.trim()
+    if (token) return token
+    console.warn('[vite] auth_token.yaml 中未找到 token')
+    return ''
+  } catch {
+    console.warn('[vite] auth_token.yaml 读取失败，API 调用将因无 Token 而返回 401')
+    return ''
+  }
+}
 
 export default defineConfig({
   plugins: [vue()],
@@ -8,6 +25,9 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
+  },
+  define: {
+    __API_TOKEN__: JSON.stringify(loadApiToken()),
   },
   server: {
     port: 5173,


### PR DESCRIPTION
## 变更内容

### 🔒 网络安全
- **host 绑定 127.0.0.1**：后端仅监听本机回环地址，阻断远程攻击
- **移除生产模式**：纯 API 服务，缩减攻击面

### 🔑 API 认证
- **Token 认证机制**：所有 `/api/*` 和 `/ws/*` 路径需携带 `X-Sonetto-Token` 请求头或 `?token=` 查询参数
- **AuthMiddleware**：全局中间件，路径白名单放行健康检查
- **WebSocket 校验**：握手时验证 token（先 accept 后校验，消除 403 日志噪声）
- **CORS 收紧**：开发环境仅放行 `localhost:5173`，生产再加 `:8000`

### 🔄 Token 管理
- **自动生成**：后端首次启动生成 `secrets.token_urlsafe(32)` Token，持久化到 `api/data/auth_token.yaml`
- **Token 轮换**：`python main.py --rotate-token` 命令行支持
- **编译期注入**：Vite 启动时从共享文件读取 Token，通过 `__API_TOKEN__` 注入前端

### 🛡️ 拒止锚保护
- **api/data/ 目录自动保护**：模块加载时自动放置 `SonettoBlocker` 标记文件，防止 Agent 工具访问配置数据目录

### 前端适配
- API 请求头自动附加 `X-Sonetto-Token`
- WebSocket URL 自动附加 `?token=`