### PR TITLE
fix: 调整输入框高度与菜单显示

### DIFF
--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -579,18 +579,20 @@ const isResizing = ref(false)
 const resizeStartY = ref(0)
 const resizeStartHeight = ref(0)
 const handleRef = ref<HTMLDivElement | null>(null)
-const initialHeight = ref(120)
+const DEFAULT_INPUT_HEIGHT = 117
+const initialHeight = ref(DEFAULT_INPUT_HEIGHT)
 
 const containerStyle = computed(() => {
-  if (customHeight.value === null) return {}
-  return { height: customHeight.value + 'px' }
+  const minHeight = initialHeight.value + 'px'
+  if (customHeight.value === null) return { minHeight }
+  return { height: customHeight.value + 'px', minHeight }
 })
 
 /** 组件挂载后捕获输入框的初始默认高度，作为拖拽下限 */
 onMounted(() => {
   nextTick(() => {
     const el = inputContainerRef.value
-    if (el) initialHeight.value = el.clientHeight
+    if (el) initialHeight.value = Math.max(DEFAULT_INPUT_HEIGHT, el.clientHeight)
   })
 })
 
@@ -893,7 +895,7 @@ function onResizeEnd(e: PointerEvent) {
   padding: 4px 14px 8px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
   transition: border-color 0.2s, box-shadow 0.2s;
-  overflow: hidden;
+  overflow: visible;
 }
 .chat-input.is-resizing {
   border-color: var(--accent);
@@ -908,6 +910,7 @@ function onResizeEnd(e: PointerEvent) {
 .btn-add-file-wrapper {
   position: relative;
   flex-shrink: 0;
+  z-index: 210;
 }
 .btn-add-file {
   width: 32px;


### PR DESCRIPTION
## 变更说明

修复聊天输入框底部区域的两个显示问题：

- 加号附件菜单弹出时被输入框外层 `overflow: hidden` 裁剪，导致菜单显示不完整
- 统一输入框初始高度与拖拽后的最低高度，使右侧输入框边界和左侧系统状态分隔线对齐

## 具体改动

- 将输入框外层容器改为允许弹出层溢出显示
- 提升加号菜单容器层级，避免被同一输入栏内其它控件遮挡
- 新增统一的默认输入框高度常量 `DEFAULT_INPUT_HEIGHT = 117`
- 让拖拽高度下限复用同一个默认高度，避免初始状态和拖回最低点不一致

## 验证

- 已执行 `npm.cmd run build`
- 构建通过