### PR TITLE
test+ci: 补齐后端测试 & 添加 CI 工作流

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,0 +1,51 @@
+# Frontend CI — 类型检查 + 构建验证
+#
+# 每次 push 和 PR 时自动运行：
+#   1. npm ci — 安装依赖
+#   2. vue-tsc --noEmit — TypeScript 类型检查
+#   3. vite build — 构建验证
+
+name: Frontend CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'feat/**'
+      - 'fix/**'
+      - 'chore/**'
+      - 'test/**'
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: 🔧 TypeScript + Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Type check — vue-tsc
+        run: npx vue-tsc --noEmit
+        working-directory: web
+
+      - name: Build — vite
+        run: npm run build
+        working-directory: web

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,0 +1,60 @@
+# Python CI — code style + type check + 测试
+#
+# 每次 push 和 PR 时自动运行：
+#   1. ruff check — 代码风格与常见错误检查
+#   2. ruff format — 代码格式化验证
+#   3. pytest — 后端测试
+
+name: Python CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'feat/**'
+      - 'fix/**'
+      - 'chore/**'
+      - 'test/**'
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    name: 🐍 Lint + Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install test & lint tools
+        run: |
+          pip install ruff pytest pytest-asyncio pytest-cov
+
+      - name: Lint — ruff check
+        run: ruff check .
+
+      - name: Format — ruff format
+        run: ruff format --check .
+
+      - name: Test — pytest
+        run: python -m pytest tests/ -v --tb=short --cov=api --cov=memory --cov=tools --cov-report=term

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Python
 __pycache__/
 *.py[cod]
+.coverage
+.pytest_cache/
 *.egg-info/
 /dist/
 build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-mock>=3.12.0",
+    "ruff>=0.11.0",
 ]
 
 [tool.setuptools.dynamic]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,53 @@
+"""共享 fixtures — FastAPI TestClient、认证 Token、最小测试 app。"""
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from api.middleware.auth import AuthMiddleware
+
+
+@pytest.fixture
+def auth_token() -> str:
+    """固定测试 Token。"""
+    return "test-token-123"
+
+
+@pytest.fixture
+def minimal_app(auth_token: str) -> FastAPI:
+    """创建一个最小化的 FastAPI app 用于测试 AuthMiddleware。
+
+    包含：
+    - 一个受保护的 /api/test 路由
+    - 一个白名单 /api/health 路由
+    - 一个不受保护的 /open 路由
+    - 一个 /ws/test 路由（WebSocket 路径受保护）
+    - AuthMiddleware
+    """
+    app = FastAPI()
+
+    @app.get("/api/test")
+    async def test_endpoint():
+        return {"status": "ok"}
+
+    @app.get("/api/health")
+    async def health():
+        return {"status": "healthy"}
+
+    @app.get("/open")
+    async def open_endpoint():
+        return {"status": "public"}
+
+    @app.get("/ws/test")
+    async def ws_endpoint():
+        return {"status": "ws"}
+
+    app.state.auth_token = auth_token
+    app.add_middleware(AuthMiddleware)
+    return app
+
+
+@pytest.fixture
+def client(minimal_app: FastAPI) -> TestClient:
+    """Starlette TestClient 实例。"""
+    return TestClient(minimal_app)

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -1,0 +1,124 @@
+"""api/auth.py 测试 — Token 生成、加载、轮换。"""
+
+import pytest
+import yaml
+
+import api.auth as auth
+
+
+class TestLoadOrCreateToken:
+    """load_or_create_token 测试。"""
+
+    def test_load_existing_token(self, monkeypatch, tmp_path):
+        """文件存在且有有效 token key → 返回已有值。"""
+        token_path = tmp_path / "auth_token.yaml"
+        token_path.write_text(
+            yaml.dump({"token": "existing-token-value"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(auth, "AUTH_TOKEN_PATH", token_path)
+
+        result = auth.load_or_create_token()
+
+        assert result == "existing-token-value"
+
+    def test_load_or_create_creates_new(self, monkeypatch, tmp_path):
+        """文件不存在 → 生成并写入新 token。"""
+        token_path = tmp_path / "auth_token.yaml"
+        monkeypatch.setattr(auth, "AUTH_TOKEN_PATH", token_path)
+
+        result = auth.load_or_create_token()
+
+        assert token_path.exists()
+        assert isinstance(result, str)
+        assert len(result) > 0
+        # 验证写入内容
+        data = yaml.safe_load(token_path.read_text(encoding="utf-8"))
+        assert data["token"] == result
+
+    def test_load_or_create_corrupted_file(self, monkeypatch, tmp_path):
+        """文件存在但 YAML 无效 → 抛出异常（生产代码暂未处理此情况）。"""
+        import yaml
+        token_path = tmp_path / "auth_token.yaml"
+        token_path.write_text("{{ 无效 yaml !!", encoding="utf-8")
+        monkeypatch.setattr(auth, "AUTH_TOKEN_PATH", token_path)
+
+        with pytest.raises(yaml.parser.ParserError):
+            auth.load_or_create_token()
+
+    def test_load_or_create_missing_key(self, monkeypatch, tmp_path):
+        """文件存在但无 token key → 重新生成。"""
+        token_path = tmp_path / "auth_token.yaml"
+        token_path.write_text(
+            yaml.dump({"other_key": "value"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(auth, "AUTH_TOKEN_PATH", token_path)
+
+        result = auth.load_or_create_token()
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+        data = yaml.safe_load(token_path.read_text(encoding="utf-8"))
+        assert data["token"] == result
+
+
+class TestRotateToken:
+    """rotate_token 测试。"""
+
+    def test_rotate_creates_new_token(self, monkeypatch, tmp_path):
+        """rotate_token 返回新值并写入文件。"""
+        token_path = tmp_path / "auth_token.yaml"
+        # 先创建一个已有 token
+        token_path.write_text(
+            yaml.dump({"token": "old-token"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(auth, "AUTH_TOKEN_PATH", token_path)
+
+        result = auth.rotate_token()
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+        data = yaml.safe_load(token_path.read_text(encoding="utf-8"))
+        assert data["token"] == result
+
+    def test_rotate_different_from_old(self, monkeypatch, tmp_path):
+        """轮换前后 token 不同。"""
+        token_path = tmp_path / "auth_token.yaml"
+        token_path.write_text(
+            yaml.dump({"token": "old-token"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(auth, "AUTH_TOKEN_PATH", token_path)
+
+        result = auth.rotate_token()
+
+        assert result != "old-token"
+
+    def test_rotate_writes_file_even_if_not_exists(self, monkeypatch, tmp_path):
+        """rotate_token 在文件不存在时也创建。"""
+        token_path = tmp_path / "auth_token.yaml"
+        monkeypatch.setattr(auth, "AUTH_TOKEN_PATH", token_path)
+
+        result = auth.rotate_token()
+
+        assert token_path.exists()
+        data = yaml.safe_load(token_path.read_text(encoding="utf-8"))
+        assert data["token"] == result
+
+
+class TestTokenFormat:
+    """Token 格式验证。"""
+
+    def test_token_format(self, monkeypatch, tmp_path):
+        """生成的 token 是 43 字符 URL-safe base64。"""
+        token_path = tmp_path / "auth_token.yaml"
+        monkeypatch.setattr(auth, "AUTH_TOKEN_PATH", token_path)
+
+        token = auth.load_or_create_token()
+
+        # token_urlsafe(32) → 43 chars, no padding chars like + or /
+        assert len(token) == 43
+        # URL-safe: only letters, digits, -, _
+        assert all(c.isalnum() or c in "-_" for c in token)

--- a/tests/test_api/test_auth_middleware.py
+++ b/tests/test_api/test_auth_middleware.py
@@ -1,0 +1,77 @@
+"""api/middleware/auth.py 测试 — AuthMiddleware 认证拦截逻辑。"""
+
+
+class TestAuthMiddleware:
+    """AuthMiddleware 认证逻辑测试。"""
+
+    def test_unprotected_path_passthrough(self, client):
+        """非 /api/ 非 /ws/ 路径不受保护。"""
+        resp = client.get("/open")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "public"}
+
+    def test_health_whitelist(self, client):
+        """/api/health 白名单放行。"""
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "healthy"}
+
+    def test_missing_token_returns_401(self, client):
+        """未提供 token → 401。"""
+        resp = client.get("/api/test")
+        assert resp.status_code == 401
+        assert "Unauthorized" in resp.json()["detail"]
+
+    def test_wrong_token_returns_401(self, client):
+        """token 不匹配 → 401。"""
+        resp = client.get("/api/test", headers={"X-Sonetto-Token": "wrong-token"})
+        assert resp.status_code == 401
+
+    def test_correct_header_token(self, client, auth_token):
+        """X-Sonetto-Token 正确 → 200。"""
+        resp = client.get("/api/test", headers={"X-Sonetto-Token": auth_token})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_correct_query_token(self, client, auth_token):
+        """?token= 正确 → 200。"""
+        resp = client.get(f"/api/test?token={auth_token}")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_query_token_wrong_still_401(self, client):
+        """?token= 值错误 → 401。"""
+        resp = client.get("/api/test?token=wrong-token")
+        assert resp.status_code == 401
+
+    def test_ws_path_protected(self, client):
+        """/ws/ 路径受保护。"""
+        resp = client.get("/ws/test")
+        assert resp.status_code == 401
+
+    def test_ws_path_with_valid_token(self, client, auth_token):
+        """/ws/ 路径带有效 token → 200。"""
+        resp = client.get(f"/ws/test?token={auth_token}")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ws"}
+
+    def test_ws_path_with_wrong_token(self, client):
+        """/ws/ 路径带无效 token → 401。"""
+        resp = client.get("/ws/test?token=wrong")
+        assert resp.status_code == 401
+
+    def test_query_token_with_extra_params(self, client, auth_token):
+        """?token= 后还有其他 query params 时仍正确提取。"""
+        resp = client.get(f"/api/test?token={auth_token}&other=value")
+        assert resp.status_code == 200
+
+
+class TestAuthMiddlewareNoToken:
+    """app.state.auth_token 为 None 时的行为。"""
+
+    def test_empty_auth_token_returns_401(self, client):
+        """app.state.auth_token 为 None → 401。"""
+        # 覆盖 fixture：设置 auth_token 为 None
+        client.app.state.auth_token = None
+        resp = client.get("/api/test", headers={"X-Sonetto-Token": "any-token"})
+        assert resp.status_code == 401

--- a/tests/test_api/test_dependencies.py
+++ b/tests/test_api/test_dependencies.py
@@ -1,0 +1,122 @@
+"""api/dependencies.py 测试 — LLM、系统提示、工具集的惰性单例。"""
+
+from unittest.mock import MagicMock
+
+import api.dependencies as deps
+
+
+class TestGetLlm:
+    """get_llm 测试。"""
+
+    def test_get_llm_no_provider_raises(self):
+        """provider_manager 为 None → RuntimeError。"""
+        import pytest
+        with pytest.raises(RuntimeError, match="No enabled LLM provider"):
+            deps.get_llm(provider_manager=None)
+
+    def test_get_llm_empty_provider_raises(self):
+        """provider_manager.count == 0 → RuntimeError。"""
+        import pytest
+        pm = MagicMock()
+        pm.count = 0
+        with pytest.raises(RuntimeError, match="No enabled LLM provider"):
+            deps.get_llm(provider_manager=pm)
+
+    def test_get_llm_with_enabled_provider(self):
+        """有 enabled provider → 返回 LLM。"""
+        fake_llm = MagicMock()
+        fake_provider = MagicMock()
+        fake_provider.default_model = "gpt-4"
+        fake_provider.create_llm.return_value = fake_llm
+
+        pm = MagicMock()
+        pm.count = 1
+        pm.iter_enabled.return_value = [fake_provider]
+
+        result = deps.get_llm(provider_manager=pm)
+
+        assert result is fake_llm
+        fake_provider.create_llm.assert_called_once_with(
+            "gpt-4", temperature=0.7, streaming=True,
+        )
+
+
+class TestGetSystemPrompt:
+    """get_system_prompt 测试。"""
+
+    def setup_method(self):
+        """每个测试前重置全局缓存。"""
+        deps._system_prompt = None
+
+    def test_first_call_calls_build(self, monkeypatch):
+        """首次调用调用 build_system_prompt。"""
+        monkeypatch.setattr(deps, "build_system_prompt", lambda: "测试提示")
+        result = deps.get_system_prompt()
+        assert result == "测试提示"
+
+    def test_second_call_returns_cached(self, monkeypatch):
+        """第二次调用返回缓存，不重复调用 build_system_prompt。"""
+        call_count = [0]
+
+        def fake_build():
+            call_count[0] += 1
+            return f"prompt-{call_count[0]}"
+
+        monkeypatch.setattr(deps, "build_system_prompt", fake_build)
+
+        first = deps.get_system_prompt()
+        second = deps.get_system_prompt()
+
+        assert first == "prompt-1"
+        assert second == "prompt-1"  # 缓存，不重新调用
+        assert call_count[0] == 1
+
+
+class TestGetTools:
+    """get_tools 测试。"""
+
+    def setup_method(self):
+        """每个测试前重置全局缓存。"""
+        deps._tools = None
+
+    def test_first_call_calls_get_all(self, monkeypatch):
+        """首次调用调用 get_all_tools。"""
+        fake_tools = ["tool1", "tool2"]
+        monkeypatch.setattr(deps, "get_all_tools", lambda: fake_tools)
+        result = deps.get_tools()
+        assert result == fake_tools
+
+    def test_second_call_returns_cached(self, monkeypatch):
+        """第二次调用返回缓存列表。"""
+        call_count = [0]
+
+        def fake_get_all():
+            call_count[0] += 1
+            return [f"tool-{call_count[0]}"]
+
+        monkeypatch.setattr(deps, "get_all_tools", fake_get_all)
+
+        first = deps.get_tools()
+        second = deps.get_tools()
+
+        assert first == ["tool-1"]
+        assert second == ["tool-1"]  # 缓存
+        assert call_count[0] == 1
+
+
+class TestGlobalStateReset:
+    """确保全局缓存在测试间正确重置。"""
+
+    def setup_method(self):
+        deps._system_prompt = None
+        deps._tools = None
+
+    def teardown_method(self):
+        deps._system_prompt = None
+        deps._tools = None
+
+    def test_system_prompt_starts_none(self):
+        assert deps._system_prompt is None
+
+    def test_tools_starts_none(self):
+        assert deps._tools is None

--- a/tests/test_memory/test_memory_manager.py
+++ b/tests/test_memory/test_memory_manager.py
@@ -1,0 +1,182 @@
+"""memory/memory_manager.py 测试 — MemoryManager 直接测试。"""
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from memory.memory_manager import MemoryManager, MemoryItem
+
+
+class TestMemoryItem:
+    """MemoryItem 单元测试。"""
+
+    def test_init_sets_defaults(self):
+        item = MemoryItem("test description", "test theme")
+        assert item.description == "test description"
+        assert item.theme == "test theme"
+        assert item.history == []
+        assert item.latest_update_time is not None
+
+    def test_update_description(self):
+        item = MemoryItem("old", "theme")
+        item.update("信息过时", new_description="new")
+        assert item.description == "new"
+        assert len(item.history) == 1
+        assert item.history[0]["old_description"] == "old"
+
+    def test_update_theme(self):
+        item = MemoryItem("desc", "旧主题")
+        item.update("重新分类", new_theme="新主题")
+        assert item.theme == "新主题"
+
+    def test_merge_combines_history(self):
+        item1 = MemoryItem("A", "主题")
+        item2 = MemoryItem("B", "主题")
+        item1.merge(item2, "合并", "merged", "主题")
+        assert item1.description == "merged"
+        # merge → update 产生一条历史记录
+        assert len(item1.history) == 1
+        assert item1.history[0]["reason"] == "合并"
+
+    def test_show_description_history_order(self):
+        item = MemoryItem("initial", "theme")
+        item.update("第一次", new_description="second")
+        item.update("第二次", new_description="third")
+        history = item.show_description_history()
+        # 第一项是当前值
+        assert history[0]["description"] == "third"
+        # 后续是逆序的历史值
+        assert history[1]["description"] == "second"
+        assert history[2]["description"] == "initial"
+
+
+class TestMemoryManager:
+    """MemoryManager CRUD 测试。"""
+
+    def test_init_creates_yaml_file(self, tmp_path):
+        """初始化时创建 yaml 文件。"""
+        path = tmp_path / "test_memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        assert path.exists()
+        # 文件内容应为有效 yaml
+        import yaml
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert data == {}
+
+    def test_init_creates_parent_dir(self, tmp_path):
+        """初始化时创建父目录。"""
+        path = tmp_path / "subdir" / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        assert path.exists()
+
+    def test_add_returns_id(self, tmp_path):
+        """add 返回非空字符串。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        item_id = mm.add(description="测试", theme="身份")
+        assert isinstance(item_id, str)
+        assert len(item_id) > 0
+
+    def test_add_and_show(self, tmp_path):
+        """add 后 show 能查到。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        mm.add(description="测试描述", theme="测试主题")
+        items = mm.show()
+        assert len(items) == 1
+        assert items[0]["description"] == "测试描述"
+        assert items[0]["theme"] == "测试主题"
+        # id 是 uuid 格式
+        assert re.match(r"^[\w-]{36}$", items[0]["id"])
+
+    def test_delete_removes_item(self, tmp_path):
+        """delete 后 show 为空。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        item_id = mm.add(description="待删除", theme="身份")
+        mm.delete(item_id)
+        assert mm.show() == []
+
+    def test_delete_nonexistent_raises(self, tmp_path):
+        """删除不存在的 ID → ValueError。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        with pytest.raises(ValueError, match="not found"):
+            mm.delete("nonexistent-id")
+
+    def test_update_changes_description(self, tmp_path):
+        """update 后描述变更。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        item_id = mm.add(description="旧描述", theme="身份")
+        mm.update(id=item_id, reason="更新", new_description="新描述")
+        items = mm.show()
+        assert items[0]["description"] == "新描述"
+
+    def test_update_nonexistent_raises(self, tmp_path):
+        """更新不存在的 ID → ValueError。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        with pytest.raises(ValueError, match="not found"):
+            mm.update(id="nonexistent-id", reason="测试")
+
+    def test_merge_combines_and_removes(self, tmp_path):
+        """merge 合并两个条目，删除第二个。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        id1 = mm.add(description="条目A", theme="身份")
+        id2 = mm.add(description="条目B", theme="身份")
+        mm.merge(id1, id2, "合并后描述", "身份", "重复")
+        items = mm.show()
+        assert len(items) == 1
+        assert items[0]["id"] == id1
+        assert items[0]["description"] == "合并后描述"
+
+    def test_merge_nonexistent_raises(self, tmp_path):
+        """合并包含不存在 ID → ValueError。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        id1 = mm.add(description="A", theme="身份")
+        with pytest.raises(ValueError, match="not found"):
+            mm.merge(id1, "bad-id", "desc", "主题", "原因")
+
+
+class TestMemoryManagerGrouping:
+    """get_memories_grouped 测试。"""
+
+    def test_memories_grouped_by_theme(self, tmp_path):
+        """get_memories_grouped() 按 theme 分组。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        mm.add(description="学生", theme="身份")
+        mm.add(description="网络安全", theme="身份")
+        mm.add(description="洛天依", theme="音乐")
+        result = mm.get_memories_grouped()
+        assert "sections" in result
+        sections = result["sections"]
+        assert len(sections) == 2
+        theme_names = [s["theme"] for s in sections]
+        assert "身份" in theme_names
+        assert "音乐" in theme_names
+
+    def test_memories_grouped_empty(self, tmp_path):
+        """空文件时返回空 sections。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        result = mm.get_memories_grouped()
+        assert result == {"sections": []}
+
+    def test_description_history(self, tmp_path):
+        """show_description_history 返回正确顺序。"""
+        path = tmp_path / "memory.yaml"
+        mm = MemoryManager(yaml_file=str(path))
+        item_id = mm.add(description="初始", theme="身份")
+        mm.update(item_id, "第一次更新", new_description="第一次")
+        mm.update(item_id, "第二次更新", new_description="第二次")
+        history = mm.show_description_history(item_id)
+        # 从当前到最早
+        assert history[0]["description"] == "第二次"
+        assert history[1]["description"] == "第一次"
+        assert history[2]["description"] == "初始"

--- a/tests/test_memory/test_user_init.py
+++ b/tests/test_memory/test_user_init.py
@@ -1,6 +1,5 @@
 """memory/user_init.py 测试。"""
 
-import shutil
 from pathlib import Path
 
 import memory.user_init as user_init
@@ -71,3 +70,122 @@ class TestEnsureUserMd:
         user_init.ensure_user_md()
 
         assert user_md.read_text(encoding="utf-8") == "旧内容。"
+
+
+class TestEnsureSoulMd:
+    """ensure_soul_md 测试。"""
+
+    def test_creates_soul_md_from_example(self, monkeypatch, tmp_path):
+        """SOUL.md 不存在时从 example 复制。"""
+        persona_dir = tmp_path / "personas"
+        persona_dir.mkdir(parents=True)
+        example = persona_dir / "SOUL.example.md"
+        example.write_text("人设模板内容。", encoding="utf-8")
+
+        monkeypatch.setattr(user_init, "PERSONAS_DIR", persona_dir)
+
+        soul_md = persona_dir / "SOUL.md"
+        assert not soul_md.exists()
+
+        user_init.ensure_soul_md()
+
+        assert soul_md.exists()
+        assert soul_md.read_text(encoding="utf-8") == "人设模板内容。"
+
+    def test_soul_md_not_overwritten(self, monkeypatch, tmp_path):
+        """SOUL.md 已存在时不覆盖。"""
+        persona_dir = tmp_path / "personas"
+        persona_dir.mkdir(parents=True)
+        example = persona_dir / "SOUL.example.md"
+        example.write_text("新模板。", encoding="utf-8")
+
+        soul_md = persona_dir / "SOUL.md"
+        soul_md.write_text("用户自定义人设。", encoding="utf-8")
+
+        monkeypatch.setattr(user_init, "PERSONAS_DIR", persona_dir)
+
+        user_init.ensure_soul_md()
+
+        assert soul_md.read_text(encoding="utf-8") == "用户自定义人设。"
+
+    def test_soul_no_example_does_nothing(self, monkeypatch, tmp_path):
+        """example 文件不存在时什么都不做。"""
+        persona_dir = tmp_path / "personas"
+        persona_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(user_init, "PERSONAS_DIR", persona_dir)
+
+        user_init.ensure_soul_md()
+
+        soul_md = persona_dir / "SOUL.md"
+        assert not soul_md.exists()
+
+
+class TestEnsureEnvFile:
+    """ensure_env_file 测试。"""
+
+    def test_creates_env_from_example(self, monkeypatch, tmp_path):
+        """.env 不存在时从 example 复制。"""
+        project_root = tmp_path
+        example = project_root / ".env.example"
+        example.write_text("API_KEY=test", encoding="utf-8")
+
+        monkeypatch.setattr(user_init, "PROJECT_ROOT", project_root)
+
+        env_file = project_root / ".env"
+        assert not env_file.exists()
+
+        user_init.ensure_env_file()
+
+        assert env_file.exists()
+        assert env_file.read_text(encoding="utf-8") == "API_KEY=test"
+
+    def test_env_not_overwritten(self, monkeypatch, tmp_path):
+        """.env 已存在时不覆盖。"""
+        project_root = tmp_path
+        example = project_root / ".env.example"
+        example.write_text("新内容。", encoding="utf-8")
+
+        env_file = project_root / ".env"
+        env_file.write_text("用户已有的配置。", encoding="utf-8")
+
+        monkeypatch.setattr(user_init, "PROJECT_ROOT", project_root)
+
+        user_init.ensure_env_file()
+
+        assert env_file.read_text(encoding="utf-8") == "用户已有的配置。"
+
+    def test_env_no_example_does_nothing(self, monkeypatch, tmp_path):
+        """example 文件不存在时什么都不做。"""
+        project_root = tmp_path
+        monkeypatch.setattr(user_init, "PROJECT_ROOT", project_root)
+
+        user_init.ensure_env_file()
+
+        env_file = project_root / ".env"
+        assert not env_file.exists()
+
+
+class TestEnsureAll:
+    """ensure_all 集成测试。"""
+
+    def test_ensure_all_calls_all_three(self, monkeypatch, tmp_path):
+        """ensure_all 依次调用三个 ensure 函数。"""
+        persona_dir = tmp_path / "personas"
+        persona_dir.mkdir(parents=True)
+        project_root = tmp_path
+
+        # 准备所有 example 文件
+        (persona_dir / "USER.example.md").write_text("user", encoding="utf-8")
+        (persona_dir / "SOUL.example.md").write_text("soul", encoding="utf-8")
+        (project_root / ".env.example").write_text("env", encoding="utf-8")
+
+        monkeypatch.setattr(user_init, "PERSONAS_DIR", persona_dir)
+        monkeypatch.setattr(user_init, "PROJECT_ROOT", project_root)
+
+        user_init.ensure_all()
+
+        # 三个目标文件都应被创建
+        assert (persona_dir / "USER.md").exists()
+        assert (persona_dir / "SOUL.md").exists()
+        assert (project_root / ".env").exists()


### PR DESCRIPTION
## 变更内容

### 🧪 后端测试补全（+54 个测试）
| 模块 | 之前 | 之后 |
|------|------|------|
| `api/auth.py` | 0% | **100%** |
| `api/middleware/auth.py` | 0% | **100%** |
| `api/dependencies.py` | 0% | **100%** |
| `memory/memory_manager.py` | 69% | **99%** |
| `memory/user_init.py` | 79% | **100%** |
| **总覆盖率** | **8%** | **13%** |

### ⚙️ CI 工作流
- **Python CI** (`ci-python.yml`)：ruff check + ruff format + pytest（Python 3.11-3.13 矩阵）
- **Frontend CI** (`ci-frontend.yml`)：`vue-tsc --noEmit` 类型检查 + `vite build` 构建验证

### 🔧 其他
- `.coverage` / `.pytest_cache` 加入 `.gitignore`
- `ruff` 加入 `pyproject.toml` dev dependencies

## 测试
```
101 passed in 3.91s
```