### PR TITLE
fix: Python CI 缩减为单版本 + 分离 lint/test

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,4 +1,4 @@
-# Python CI — code style + type check + 测试
+# Python CI — code style + 测试
 #
 # 每次 push 和 PR 时自动运行：
 #   1. ruff check — 代码风格与常见错误检查
@@ -23,21 +23,38 @@ permissions:
   contents: read
 
 jobs:
-  lint-and-test:
-    name: 🐍 Lint + Test
+  lint:
+    name: 🧹 Lint (ruff)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Python ${{ matrix.python-version }}
+      - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Lint — ruff check
+        run: ruff check .
+
+      - name: Format — ruff format
+        run: ruff format --check .
+
+  test:
+    name: 🧪 Test (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
           cache: "pip"
           cache-dependency-path: requirements.txt
 
@@ -46,15 +63,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Install test & lint tools
-        run: |
-          pip install ruff pytest pytest-asyncio pytest-cov
-
-      - name: Lint — ruff check
-        run: ruff check .
-
-      - name: Format — ruff format
-        run: ruff format --check .
+      - name: Install test tools
+        run: pip install pytest pytest-asyncio pytest-cov
 
       - name: Test — pytest
         run: python -m pytest tests/ -v --tb=short --cov=api --cov=memory --cov=tools --cov-report=term


### PR DESCRIPTION
## 问题

Python CI 在 #149 合入 main 后运行失败（"The operation was canceled"），3 个 Python 版本矩阵并行安装 langchain/langgraph 等大量依赖耗时过高，被 GitHub Actions 基础设施取消。

## 变更

- 取消 3 版本矩阵（3.11/3.12/3.13），固定 Python 3.11
- 分离为两个独立 job：`lint`（仅 ruff，~10s）和 `test`（pytest，含 pip cache）
- 总运行时间从 ~3× 降到 ~1x，lint 更快反馈