### PR TITLE
fix: 修复选择文件/文件夹引用时 401 未授权错误

### DIFF
--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -194,6 +194,9 @@ export const api = {
 
   // ── 文件选择器 ──
 
+  selectFile: (type: 'file' | 'folder') =>
+    request<{ path: string | null }>(`/select-file?type=${type}`),
+
   selectFolder: () =>
     request<{ path: string | null }>('/select-file?type=folder'),
 

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -520,12 +520,11 @@ async function pickFolder() {
   await _pick('folder')
 }
 
-async function _pick(type: string) {
+async function _pick(type: 'file' | 'folder') {
   if (loading.value) return
   loading.value = true
   try {
-    const res = await fetch(`/api/select-file?type=${type}`)
-    const data = await res.json()
+    const data = await api.selectFile(type)
     if (data.path) {
       const refType = type === 'folder' ? 'folder' : 'file'
       const idx = refs.value.length


### PR DESCRIPTION
## 修复内容

前端点击添加文件/文件夹路径引用时返回 401 Unauthorized，其他需认证的功能不受影响。

## 根因

`ChatInput.vue` 的 `_pick()` 函数使用原始 `fetch()` 调用 `/api/select-file`，未携带 `X-Sonetto-Token` 请求头，被 `AuthMiddleware` 拦截返回 401。

## 改动

- **`web/src/api/index.ts`**：新增 `selectFile(type)` 方法，复用 `request()` 工具函数（自动附加 token）
- **`web/src/components/ChatInput.vue`**：`_pick()` 改用 `api.selectFile(type)` 替代原始 `fetch()`

## 类型

fix