### PR TITLE
feat: 配置备份导出/导入功能（WebUI）

### DIFF
--- a/api/routes/backup.py
+++ b/api/routes/backup.py
@@ -1,0 +1,119 @@
+"""REST API — 配置导出/导入备份。"""
+
+import base64
+import json
+import time
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import Response
+
+router = APIRouter()
+
+BACKUP_VERSION = "1.0"
+
+# 项目根目录（由本文件位置向上推 2 级）
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# 需要备份的文件/目录（相对 _PROJECT_ROOT 的路径）
+_BACKUP_PATHS = [
+    ".env",
+    "providers.yaml",
+    "config/personas/USER.md",
+    "config/personas/SOUL.md",
+    "config/personas/AGENTS.md",
+    "config/personas/memory.yaml",
+    "api/data/path_whitelist.yaml",
+    "api/data/sonetto_blocker.yaml",
+    "api/data/const-sessions/",
+    "anthropic_skills/",
+    "tools/bilibili/cookie.txt",
+]
+
+
+def _collect_files() -> dict[str, str]:
+    """扫描所有备份路径，返回 {相对路径: base64 内容}。"""
+    files: dict[str, str] = {}
+    for rel in _BACKUP_PATHS:
+        full = _PROJECT_ROOT / rel
+        if not full.exists():
+            continue
+        if full.is_dir():
+            for fpath in sorted(full.rglob("*")):
+                if fpath.is_file():
+                    _add_file(files, fpath)
+        else:
+            _add_file(files, full)
+    return files
+
+
+def _add_file(files: dict[str, str], fpath: Path):
+    """将单个文件 base64 编码后加入 dict。"""
+    try:
+        rel = str(fpath.relative_to(_PROJECT_ROOT))
+        raw = fpath.read_bytes()
+        files[rel] = base64.b64encode(raw).decode("ascii")
+    except Exception:
+        pass
+
+
+def _restore_files(files: dict[str, str]) -> list[str]:
+    """将 base64 编码的文件内容写回磁盘。返回恢复的文件路径列表。"""
+    restored: list[str] = []
+    for rel_path, b64_content in files.items():
+        try:
+            full = _PROJECT_ROOT / rel_path
+            full.parent.mkdir(parents=True, exist_ok=True)
+            raw = base64.b64decode(b64_content)
+            full.write_bytes(raw)
+            restored.append(rel_path)
+        except Exception as e:
+            raise HTTPException(
+                status_code=500,
+                detail=f"还原文件失败 {rel_path}: {e}",
+            )
+    return restored
+
+
+@router.get("/backup/export")
+async def export_backup(request: Request):
+    """导出全部配置为 JSON 文件下载。"""
+    files = _collect_files()
+    data = {
+        "backup_version": BACKUP_VERSION,
+        "exported_at": time.time(),
+        "files": files,
+    }
+    body = json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
+    return Response(
+        content=body,
+        media_type="application/json",
+        headers={
+            "Content-Disposition": f'attachment; filename="sonetto-backup-{int(time.time())}.json"',
+        },
+    )
+
+
+@router.post("/backup/import")
+async def import_backup(request: Request):
+    """上传 JSON 备份文件并还原配置。"""
+    try:
+        body = await request.body()
+        data = json.loads(body)
+    except Exception:
+        raise HTTPException(
+            status_code=400, detail="无法解析备份文件，请确保上传的是有效的 JSON"
+        )
+
+    version = data.get("backup_version", "")
+    files = data.get("files")
+    if not isinstance(files, dict):
+        raise HTTPException(status_code=400, detail="备份文件格式错误：缺少 files 字段")
+
+    restored = _restore_files(files)
+    return {
+        "status": "ok",
+        "restored_count": len(restored),
+        "restored_files": restored,
+        "backup_version": version,
+    }

--- a/api/server.py
+++ b/api/server.py
@@ -23,6 +23,7 @@ from api.routes import persona as persona_router
 from api.routes import sonetto_blocker as sonetto_blocker_router
 from api.routes import skills as skills_router
 from api.routes import news as news_router
+from api.routes import backup as backup_router
 from api.routes import restart as restart_router
 from api.session_manager import SessionManager, SessionState
 from agent.graph import build_agent
@@ -190,6 +191,9 @@ def create_app() -> FastAPI:
 
     # 系统更新动态
     app.include_router(news_router.router, prefix="/api")
+
+    # 配置备份
+    app.include_router(backup_router.router, prefix="/api")
 
     # 重启后端
     app.include_router(restart_router.router, prefix="/api")

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -29,6 +29,7 @@
           <router-link to="/user" class="popup-item" @click="closeSettingsMenu">用户 USER</router-link>
           <router-link to="/path-whitelist" class="popup-item" @click="closeSettingsMenu">路径白名单</router-link>
           <router-link to="/sonetto-blocker" class="popup-item" @click="closeSettingsMenu">拒止锚</router-link>
+          <router-link to="/backup" class="popup-item" @click="closeSettingsMenu">配置备份</router-link>
           <div class="popup-divider"></div>
           <button class="popup-item popup-action" :class="{ restarting }" :disabled="restarting" @click="handleRestart">
             {{ restarting ? '重启中...' : '重启服务' }}

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -20,6 +20,7 @@ import type {
   ListWhitelistResponse,
   BlockerEntry,
   ListBlockerResponse,
+  ImportBackupResponse,
 } from '@/types'
 
 declare const __API_TOKEN__: string
@@ -206,6 +207,27 @@ export const api = {
     request<{ blocked: boolean; reason: string | null; blocker_path: string | null }>(
       `/check-path-blocked?path=${encodeURIComponent(path)}`
     ),
+
+  // ── 配置备份 ──
+
+  exportBackup: async () => {
+    const res = await fetch(`${BASE}/backup/export`)
+    if (!res.ok) throw new Error(`导出失败: ${res.status}`)
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `sonetto-backup-${Date.now()}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  },
+
+  importBackup: (jsonContent: string) =>
+    request<ImportBackupResponse>('/backup/import', {
+      method: 'POST',
+      body: jsonContent,
+      headers: { 'Content-Type': 'application/json' },
+    }),
 
   // ── SonettoBlocker 拒止锚 ──
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -37,6 +37,11 @@ const router = createRouter({
       name: 'sonetto-blocker',
       component: () => import('@/views/SonettoBlockerView.vue'),
     },
+    {
+      path: '/backup',
+      name: 'backup',
+      component: () => import('@/views/BackupView.vue'),
+    },
   ],
 })
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -359,6 +359,15 @@ export interface ListWhitelistResponse {
   entries: WhitelistEntry[]
 }
 
+// === 配置备份 ===
+
+export interface ImportBackupResponse {
+  status: string
+  restored_count: number
+  restored_files: string[]
+  backup_version: string
+}
+
 // === SonettoBlocker 拒止锚 ===
 
 export interface BlockerEntry {

--- a/web/src/views/BackupView.vue
+++ b/web/src/views/BackupView.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="backup-view">
+    <div class="header">
+      <h2>配置备份</h2>
+    </div>
+
+    <div class="card">
+      <h3>导出配置</h3>
+      <p>将所有配置（API Key、人设、记忆、白名单、固定会话、Skills 等）导出为 JSON 文件。</p>
+      <button class="btn btn-primary" :disabled="exporting" @click="handleExport">
+        {{ exporting ? '导出中...' : '导出配置' }}
+      </button>
+    </div>
+
+    <div class="card">
+      <h3>导入配置</h3>
+      <p>从之前导出的 JSON 文件还原配置。会覆盖当前所有配置。</p>
+      <input
+        ref="fileInputRef"
+        type="file"
+        accept=".json"
+        style="display:none"
+        @change="handleFileSelected"
+      />
+      <button class="btn btn-warning" :disabled="importing" @click="triggerFilePicker">
+        {{ importing ? '导入中...' : '选择备份文件导入' }}
+      </button>
+      <div v-if="importResult" class="import-result" :class="importResult.success ? 'success' : 'error'">
+        {{ importResult.message }}
+      </div>
+    </div>
+
+    <div class="card hint">
+      <h3>版本兼容</h3>
+      <p>备份文件包含版本号。导入时会按原始内容写入文件，不依赖特定版本格式，因此旧版备份在新版中亦可还原。</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { api } from '@/api'
+
+const exporting = ref(false)
+const importing = ref(false)
+const fileInputRef = ref<HTMLInputElement | null>(null)
+const importResult = ref<{ success: boolean; message: string } | null>(null)
+
+async function handleExport() {
+  exporting.value = true
+  importResult.value = null
+  try {
+    await api.exportBackup()
+  } catch (e: any) {
+    importResult.value = { success: false, message: `导出失败: ${e.message}` }
+  } finally {
+    exporting.value = false
+  }
+}
+
+function triggerFilePicker() {
+  importResult.value = null
+  fileInputRef.value?.click()
+}
+
+async function handleFileSelected(e: Event) {
+  const input = e.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+
+  importing.value = true
+  importResult.value = null
+  try {
+    const text = await file.text()
+    const result = await api.importBackup(text)
+    importResult.value = {
+      success: true,
+      message: `成功还原 ${result.restored_count} 个文件`,
+    }
+  } catch (e: any) {
+    importResult.value = { success: false, message: `导入失败: ${e.message}` }
+  } finally {
+    importing.value = false
+    input.value = ''
+  }
+}
+</script>
+
+<style scoped>
+.backup-view {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+  max-width: 640px;
+}
+.header {
+  margin-bottom: 24px;
+}
+.header h2 {
+  font-size: 20px;
+  font-weight: 700;
+}
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px;
+  margin-bottom: 16px;
+}
+.card h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.card p {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 14px;
+  line-height: 1.5;
+}
+.card.hint {
+  background: var(--bg-secondary);
+}
+.btn {
+  padding: 8px 20px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  border: none;
+  transition: opacity 0.15s;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+.btn-primary:hover:not(:disabled) {
+  opacity: 0.85;
+}
+.btn-warning {
+  background: #f59e0b;
+  color: #fff;
+}
+.btn-warning:hover:not(:disabled) {
+  opacity: 0.85;
+}
+.import-result {
+  margin-top: 12px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+}
+.import-result.success {
+  background: #dcfce7;
+  color: #166534;
+}
+.import-result.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+</style>


### PR DESCRIPTION
Closes #159

## 功能

在 WebUI 设置页新增「配置备份」页面，支持一键导出全部配置为 JSON 文件，以及从备份文件还原。

## 特点

- 独立于 setup.py 初始化流程，运行时随时可用
- 覆盖 .env、providers.yaml、人设、白名单、拒止锚、固定会话、Skills、MCP 等
- 备份文件含版本号，新旧版互通
- 纯前端操作，无需命令行

详细说明见 Issue。