### PR TITLE
feat: 后台记忆 consumer 实时事件推送到前端

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import sys
 import traceback
+import uuid
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -344,10 +345,12 @@ async def _run_agent_turn(
             max_tokens=current_max_tokens,
             model_name=current_model_name or "",
         )
+        turn_id = uuid.uuid4().hex
         await ws.send_json(
-            {  # [向前端通信] 3. 推送 turn 结束 + 上下文用量
+            {  # [向前端通信] 3. 推送 turn 结束 + 上下文用量 + turn_id（用于记忆事件关联）
                 "type": "done",
                 "payload": {
+                    "turn_id": turn_id,
                     "context_usage": context_usage,
                 },
             }
@@ -361,8 +364,11 @@ async def _run_agent_turn(
             [
                 {"role": "user", "content": user_message},
                 {"role": "assistant", "content": final_answer},
-            ]
+            ],
+            session_id=session.session_id,
+            turn_id=turn_id,
         )
+        print(f"[ltm] send_history enqueued session={session.session_id[:8]} turn_id={turn_id[:8]}")
 
     # 4. [Const 会话] 自动持久化到磁盘 YAML
     if final_answer and session.is_const:
@@ -448,6 +454,9 @@ async def websocket_chat(ws: WebSocket, session_id: str):
     app_state = ws.app.state
     session = app_state.session_manager.get_or_create(session_id)
 
+    # 注册 WebSocket 到注册表，供后台记忆 consumer 推送事件
+    app_state.ws_registry.register(session_id, ws)
+
     # ── 推送初始上下文用量 ─────────────────────────────────
     default_max_tokens, default_model = _get_provider_context(app_state)
     initial_usage = await _calculate_context_usage(
@@ -512,6 +521,7 @@ async def websocket_chat(ws: WebSocket, session_id: str):
     except WebSocketDisconnect:
         pass  # 客户端断开是正常行为
     finally:
+        app_state.ws_registry.unregister(session_id)
         if agent_task and not agent_task.done():
             agent_task.cancel()
         session._active_task = None

--- a/api/server.py
+++ b/api/server.py
@@ -25,6 +25,7 @@ from api.routes import skills as skills_router
 from api.routes import news as news_router
 from api.routes import restart as restart_router
 from api.session_manager import SessionManager, SessionState
+from api.ws_registry import WebSocketRegistry
 from agent.graph import build_agent
 from memory.narrative import MEMORY_PATH, LongTermMemoryInterface
 from tools.mcp import init_mcp_tools, close_mcp
@@ -115,9 +116,10 @@ async def lifespan(app: FastAPI):
     app.state.system_prompt = get_system_prompt()
     app.state.native_tools = get_tools()
     app.state.session_manager = SessionManager()
+    app.state.ws_registry = WebSocketRegistry()
     app.state.ltm = LongTermMemoryInterface(MEMORY_PATH)
     if app.state.llm is not None:
-        app.state.ltm.start_listening(app.state.llm)
+        app.state.ltm.start_listening(app.state.llm, ws_registry=app.state.ws_registry)
     else:
         print("[ltm] Skipped (no LLM available)")
 

--- a/api/ws_registry.py
+++ b/api/ws_registry.py
@@ -1,0 +1,26 @@
+"""WebSocket 注册表 — 为后台任务提供推送事件到指定会话的能力。"""
+
+from fastapi import WebSocket
+
+
+class WebSocketRegistry:
+    """协程安全的 WebSocket 注册表。
+
+    在 websocket_chat() accept 后 register，断开时 unregister。
+    所有操作在单线程事件循环中执行，无需加锁。
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, WebSocket] = {}
+
+    def register(self, session_id: str, ws: WebSocket) -> None:
+        """注册 session_id → WebSocket 映射。"""
+        self._sessions[session_id] = ws
+
+    def unregister(self, session_id: str) -> None:
+        """移除 session_id 的映射。"""
+        self._sessions.pop(session_id, None)
+
+    def get(self, session_id: str) -> WebSocket | None:
+        """获取指定 session_id 的 WebSocket，不存在时返回 None。"""
+        return self._sessions.get(session_id)

--- a/memory/memory_callback.py
+++ b/memory/memory_callback.py
@@ -1,0 +1,79 @@
+"""记忆消费者专属回调 — 将 CRUD 工具调用事件推到目标会话 WebSocket。"""
+
+import time
+from typing import Any
+
+from langchain_core.callbacks import BaseCallbackHandler
+
+from api.ws_registry import WebSocketRegistry
+
+
+class MemoryToolCallback(BaseCallbackHandler):
+    """将 CRUD agent 的工具调用以 memory_tool_* 事件推送到前端。"""
+
+    def __init__(
+        self,
+        ws_registry: WebSocketRegistry,
+        session_id: str,
+        turn_id: str,
+    ) -> None:
+        super().__init__()
+        self._ws_registry = ws_registry
+        self._session_id = session_id
+        self._turn_id = turn_id
+        self._tool_start_time: dict[str, float] = {}
+        self._tool_names: dict[str, str] = {}
+
+    async def _send(self, event_type: str, payload: dict) -> None:
+        ws = self._ws_registry.get(self._session_id)
+        if ws is None:
+            print(f"[ltm-cb] _send skipped: no WS for session={self._session_id[:8]}")
+            return  # WebSocket 已断开，静默跳过
+        try:
+            await ws.send_json({"type": event_type, "payload": payload})
+            print(f"[ltm-cb] {event_type} sent to session={self._session_id[:8]} tool={payload.get('tool_name','?')}")
+        except Exception as e:
+            print(f"[ltm-cb] _send error: {e}")
+
+    async def on_tool_start(
+        self, serialized: dict[str, Any], input_str: str, **kwargs: Any
+    ) -> None:
+        tool_name = serialized.get("name", "unknown")
+        run_id = str(kwargs.get("run_id", ""))
+        self._tool_start_time[run_id] = time.time()
+        self._tool_names[run_id] = tool_name
+
+        # 截断过长输入
+        truncated = input_str[:300] if len(input_str) > 300 else input_str
+        await self._send("memory_tool_start", {
+            "turn_id": self._turn_id,
+            "tool_name": tool_name,
+            "input": truncated,
+        })
+
+    async def on_tool_end(self, output: str, **kwargs: Any) -> None:
+        run_id = str(kwargs.get("run_id", ""))
+        elapsed = time.time() - self._tool_start_time.pop(run_id, time.time())
+        tool_name = self._tool_names.pop(run_id, "unknown")
+
+        # 提取字符串内容
+        out_str = str(output.content) if hasattr(output, "content") else str(output)
+        if len(out_str) > 300:
+            out_str = out_str[:300] + f"... (共 {len(out_str)} 字符)"
+
+        await self._send("memory_tool_end", {
+            "turn_id": self._turn_id,
+            "tool_name": tool_name,
+            "output": out_str,
+            "elapsed": round(elapsed, 2),
+        })
+
+    async def on_tool_error(self, error: BaseException, **kwargs: Any) -> None:
+        run_id = str(kwargs.get("run_id", ""))
+        self._tool_start_time.pop(run_id, None)
+        tool_name = self._tool_names.pop(run_id, "unknown")
+        await self._send("memory_tool_error", {
+            "turn_id": self._turn_id,
+            "tool_name": tool_name,
+            "error": str(error),
+        })

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -307,6 +307,20 @@ class LongTermMemoryInterface:
             session_id, turn_id, turn_messages = item
             print(f"[ltm] consumer got session={session_id} turn_id={turn_id} msgs={len(turn_messages)}")
 
+            # 无论后续成功与否，先通知前端「开始处理」
+            _sent_done = False
+            if self._ws_registry is not None and session_id:
+                ws = self._ws_registry.get(session_id)
+                if ws is not None:
+                    try:
+                        await ws.send_json({
+                            "type": "memory_start",
+                            "payload": {"turn_id": turn_id or ""},
+                        })
+                        print(f"[ltm] memory_start sent session={session_id[:8]} turn_id={turn_id[:8]}")
+                    except Exception:
+                        pass
+
             try:
                 _set_current_mm(self._mm)
                 items = self._mm.show()
@@ -372,7 +386,10 @@ class LongTermMemoryInterface:
                 )
                 print(f"[ltm] CRUD agent done")
 
-                # 无论是否有工具调用，都通知前端本轮记忆处理完成
+            except Exception as e:
+                print(f"[ltm] CRUD agent error: {e}")
+            finally:
+                # 无论异常与否，都通知前端本轮记忆处理完成
                 if self._ws_registry is not None and session_id:
                     ws = self._ws_registry.get(session_id)
                     if ws is not None:
@@ -388,6 +405,3 @@ class LongTermMemoryInterface:
                         print(f"[ltm] ws_registry.get returned None for session={session_id[:8]}")
                 else:
                     print(f"[ltm] NO ws_registry or session_id — skip memory_done")
-
-            except Exception:
-                pass

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -12,6 +12,7 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 
 from memory.memory_manager import MemoryManager
+from memory.memory_callback import MemoryToolCallback
 
 
 def _sanitize(text: str) -> str:
@@ -247,6 +248,7 @@ class LongTermMemoryInterface:
         self._mm = MemoryManager(yaml_file=str(self._memory_path))
         self._queue: asyncio.Queue | None = None
         self._consumer_task: asyncio.Task | None = None
+        self._ws_registry = None
 
     @property
     def is_listening(self) -> bool:
@@ -260,20 +262,32 @@ class LongTermMemoryInterface:
         mm = MemoryManager(yaml_file=str(self._memory_path))
         return _format_narrative(mm.show())
 
-    def start_listening(self, llm) -> None:
+    def start_listening(self, llm, ws_registry=None) -> None:
         """创建 asyncio.Queue 并启动后台消费者协程。
 
         必须在运行中的事件循环内调用。
         """
+        self._ws_registry = ws_registry
         self._queue = asyncio.Queue()
         self._consumer_task = asyncio.create_task(self._consumer(llm))
 
-    async def send_history(self, turn_messages: list[dict]) -> None:
-        """生产者：将本轮对话消息放入队列（非阻塞）。"""
+    async def send_history(
+        self,
+        turn_messages: list[dict],
+        session_id: str | None = None,
+        turn_id: str | None = None,
+    ) -> None:
+        """生产者：将本轮对话消息放入队列（非阻塞）。
+
+        可附带 session_id 和 turn_id，供后台消费者关联到前端对话轮次。
+        """
         if not turn_messages:
             return
         if self._queue is not None:
-            await self._queue.put(list(turn_messages))
+            await self._queue.put((session_id, turn_id, list(turn_messages)))
+            print(f"[ltm] queue.put session={session_id} turn_id={turn_id} queue_size≈{self._queue.qsize()}")
+        else:
+            print(f"[ltm] queue is None, dropping history")
 
     async def stop_listening(self) -> None:
         """发送 None 哨兵并等待消费者排空队列。"""
@@ -287,9 +301,11 @@ class LongTermMemoryInterface:
         """后台消费者协程：从队列取消息，调用 CRUD Agent，写入 memory.yaml。"""
 
         while True:
-            turn_messages = await self._queue.get()
-            if turn_messages is None:
+            item = await self._queue.get()
+            if item is None:
                 break
+            session_id, turn_id, turn_messages = item
+            print(f"[ltm] consumer got session={session_id} turn_id={turn_id} msgs={len(turn_messages)}")
 
             try:
                 _set_current_mm(self._mm)
@@ -335,10 +351,43 @@ class LongTermMemoryInterface:
                     checkpointer=MemorySaver(),
                 )
 
+                # 创建回调：推送 CRUD 工具调用到前端对应轮次
+                callbacks = []
+                if self._ws_registry is not None and session_id:
+                    print(f"[ltm] creating MemoryToolCallback session={session_id[:8]} turn_id={turn_id[:8]}")
+                    memory_cb = MemoryToolCallback(
+                        self._ws_registry, session_id, turn_id or "",
+                    )
+                    callbacks.append(memory_cb)
+                else:
+                    print(f"[ltm] NO ws_registry or session_id — skip callbacks")
+
+                print(f"[ltm] invoking CRUD agent...")
                 await agent.ainvoke(
                     {"messages": [HumanMessage(content=user_prompt)]},
-                    config={"configurable": {"thread_id": "ltm-consumer"}},
+                    config={
+                        "configurable": {"thread_id": "ltm-consumer"},
+                        "callbacks": callbacks,
+                    },
                 )
+                print(f"[ltm] CRUD agent done")
+
+                # 无论是否有工具调用，都通知前端本轮记忆处理完成
+                if self._ws_registry is not None and session_id:
+                    ws = self._ws_registry.get(session_id)
+                    if ws is not None:
+                        try:
+                            await ws.send_json({
+                                "type": "memory_done",
+                                "payload": {"turn_id": turn_id or ""},
+                            })
+                            print(f"[ltm] memory_done sent session={session_id[:8]} turn_id={turn_id[:8]}")
+                        except Exception as e:
+                            print(f"[ltm] memory_done send error: {e}")
+                    else:
+                        print(f"[ltm] ws_registry.get returned None for session={session_id[:8]}")
+                else:
+                    print(f"[ltm] NO ws_registry or session_id — skip memory_done")
 
             except Exception:
                 pass

--- a/tools/memory/tool_create_memory.py
+++ b/tools/memory/tool_create_memory.py
@@ -30,7 +30,7 @@ class CreateMemoryTool(ToolBase):
     name: str = "create_memory"
     description: str = (
         "添加一条新的长期记忆条目到指定分区。返回该条目的唯一 ID。"
-        "[调用积极性: 仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
+        "[调用积极性: 绝对不要在用户没有提及该工具名时使用|仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
     )
     args_schema: type[BaseModel] = CreateMemoryInput
 

--- a/tools/memory/tool_delete_memory.py
+++ b/tools/memory/tool_delete_memory.py
@@ -27,7 +27,7 @@ class DeleteMemoryTool(ToolBase):
     name: str = "delete_memory"
     description: str = (
         "根据 ID 删除一条长期记忆。"
-        "[调用积极性: 仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
+        "[调用积极性: 绝对不要在用户没有提及该工具名时使用|仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
     )
     args_schema: type[BaseModel] = DeleteMemoryInput
 

--- a/tools/memory/tool_list_memories.py
+++ b/tools/memory/tool_list_memories.py
@@ -56,7 +56,7 @@ class ListMemoriesTool(ToolBase):
     description: str = (
         "查看所有长期记忆条目的概览列表（每条描述已截断以节省上下文）。"
         "如需读取某条记忆的完整内容，再调用 read_memories 传入其 ID。"
-        "[调用积极性: 仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
+        "[调用积极性: 绝对不要在用户没有提及该工具名时使用|仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
     )
     args_schema: type[BaseModel] = ListMemoriesInput
 

--- a/tools/memory/tool_merge_memories.py
+++ b/tools/memory/tool_merge_memories.py
@@ -33,7 +33,7 @@ class MergeMemoriesTool(ToolBase):
     description: str = (
         "将两条相似记忆合并为一条，id1 保留、id2 被删除，同时保留两者的修改历史。"
         "当两条记忆描述同一事物（如分散的身份信息、同一首歌在不同分区的重复条目）时使用，避免碎片化。"
-        "[调用积极性: 仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
+        "[调用积极性: 绝对不要在用户没有提及该工具名时使用|仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
     )
     args_schema: type[BaseModel] = MergeMemoriesInput
 

--- a/tools/memory/tool_read_memories.py
+++ b/tools/memory/tool_read_memories.py
@@ -27,7 +27,7 @@ class ReadMemoriesTool(ToolBase):
     description: str = (
         "根据 ID 读取一条长期记忆的完整内容（含变更历史）。"
         "先用 list_memories 获取概览和 ID，再用此工具查看全文。"
-        "[调用积极性: 仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
+        "[调用积极性: 绝对不要在用户没有提及该工具名时使用|仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
     )
     args_schema: type[BaseModel] = ReadMemoriesInput
 

--- a/tools/memory/tool_update_memory.py
+++ b/tools/memory/tool_update_memory.py
@@ -28,7 +28,7 @@ class UpdateMemoryTool(ToolBase):
     name: str = "update_memory"
     description: str = (
         "根据 ID 更新一条已有长期记忆的内容。"
-        "[调用积极性: 仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
+        "[调用积极性: 绝对不要在用户没有提及该工具名时使用|仅在用户引用或提及时调用] [get_doc: 仅在发生错误时 get_doc]"
     )
     args_schema: type[BaseModel] = UpdateMemoryInput
 

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -42,6 +42,33 @@
         >
           <MessageBubble role="assistant" :content="turn.finalAnswer" />
         </div>
+        <!-- 后台记忆更新日志（小字，轮次底部） -->
+        <div v-if="turn.memoryEvents?.length" class="memory-tool-log">
+          <div
+            v-for="(me, i) in turn.memoryEvents"
+            :key="i"
+            class="memory-tool-entry"
+            :class="{ 'is-running': me.status === 'running' }"
+          >
+            <span class="memory-tool-icon">
+              <span v-if="me.status === 'running'" class="memory-spinner"></span>
+              <span v-else-if="me.status === 'done'" class="memory-check">&#10003;</span>
+              <span v-else class="memory-cross">&#10007;</span>
+            </span>
+            <!-- memory_review = 未触发任何修改，显示简洁文字 -->
+            <template v-if="me.name === 'memory_review'">
+              <span class="memory-tool-name">记忆检查</span>
+              <span class="memory-tool-status">无需修改</span>
+            </template>
+            <template v-else>
+              <span class="memory-tool-name">{{ toolDisplayName(me.name) }}</span>
+              <span v-if="me.status === 'running'" class="memory-tool-status">处理中...</span>
+              <span v-else-if="me.status === 'done' && me.output" class="memory-tool-output">{{ me.output }}</span>
+              <span v-else-if="me.status === 'error'" class="memory-tool-status is-error">失败</span>
+              <span v-if="me.elapsed !== null" class="memory-tool-elapsed">{{ me.elapsed.toFixed(1) }}s</span>
+            </template>
+          </div>
+        </div>
       </template>
 
       <!-- 错误提示 -->
@@ -104,6 +131,7 @@ import ContextMenu from './ContextMenu.vue'
 import MessageBubble from './MessageBubble.vue'
 import ThinkingBlock from './ThinkingBlock.vue'
 import ToolBubbleRouter from './ToolBubbleRouter.vue'
+import { toolDisplayName } from './tools/_shared/displayNames'
 
 const props = defineProps<{
   turns: ChatTurn[]
@@ -511,5 +539,89 @@ function closeContextMenu() {
 
 .scroll-mark:active {
   background: var(--accent-light);
+}
+
+/* ── 后台记忆更新日志 ── */
+.memory-tool-log {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 2px 0 4px 0;
+  margin-top: 0;
+}
+
+.memory-tool-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+
+.memory-tool-entry:hover {
+  opacity: 1;
+}
+
+.memory-tool-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  font-size: 9px;
+}
+
+.memory-spinner {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border: 1.5px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: memory-spin 0.6s linear infinite;
+}
+
+@keyframes memory-spin {
+  to { transform: rotate(360deg); }
+}
+
+.memory-check {
+  color: #22c55e;
+}
+
+.memory-cross {
+  color: #b91c1c;
+}
+
+.memory-tool-name {
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.memory-tool-status {
+  font-style: italic;
+  color: var(--text-tertiary);
+}
+
+.memory-tool-status.is-error {
+  color: #b91c1c;
+}
+
+.memory-tool-output {
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-tertiary);
+}
+
+.memory-tool-elapsed {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.6;
+  font-size: 10px;
 }
 </style>

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -63,7 +63,7 @@
             <template v-else>
               <span class="memory-tool-name">{{ toolDisplayName(me.name) }}</span>
               <span v-if="me.status === 'running'" class="memory-tool-status">处理中...</span>
-              <span v-else-if="me.status === 'done' && me.output" class="memory-tool-output" :title="me.output">{{ me.output }}</span>
+              <span v-else-if="me.status === 'done' && me.output" class="memory-tool-output" :title="me.output">{{ shortenMemoryIds(me.output) }}</span>
               <span v-else-if="me.status === 'error'" class="memory-tool-status is-error">失败</span>
               <span v-if="me.elapsed !== null" class="memory-tool-elapsed">{{ me.elapsed.toFixed(1) }}s</span>
             </template>
@@ -156,6 +156,12 @@ function isNearBottom(): boolean {
   const el = windowRef.value
   if (!el) return true
   return el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_BOTTOM_THRESHOLD
+}
+
+/** 将输出文本中的完整 UUID（如 [550e8400-e29b-41d4-a716-446655440000]）
+ *  缩短为仅显示第一个分段 [550e8400]。 */
+function shortenMemoryIds(text: string): string {
+  return text.replace(/\[([a-f0-9]{8})-[^\]]+\]/gi, '[$1]')
 }
 
 function hasAnswerBlock(turn: ChatTurn): boolean {

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -60,6 +60,11 @@
               <span class="memory-tool-name">记忆检查</span>
               <span class="memory-tool-status">无需修改</span>
             </template>
+            <!-- memory_processing = 后台 consumer 正在处理中 -->
+            <template v-else-if="me.name === 'memory_processing'">
+              <span class="memory-tool-name">记忆处理</span>
+              <span class="memory-tool-status">处理中...</span>
+            </template>
             <template v-else>
               <span class="memory-tool-name">{{ toolDisplayName(me.name) }}</span>
               <span v-if="me.status === 'running'" class="memory-tool-status">处理中...</span>

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -63,7 +63,7 @@
             <template v-else>
               <span class="memory-tool-name">{{ toolDisplayName(me.name) }}</span>
               <span v-if="me.status === 'running'" class="memory-tool-status">处理中...</span>
-              <span v-else-if="me.status === 'done' && me.output" class="memory-tool-output">{{ me.output }}</span>
+              <span v-else-if="me.status === 'done' && me.output" class="memory-tool-output" :title="me.output">{{ me.output }}</span>
               <span v-else-if="me.status === 'error'" class="memory-tool-status is-error">失败</span>
               <span v-if="me.elapsed !== null" class="memory-tool-elapsed">{{ me.elapsed.toFixed(1) }}s</span>
             </template>
@@ -612,11 +612,12 @@ function closeContextMenu() {
 }
 
 .memory-tool-output {
-  max-width: 280px;
+  max-width: 180px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-tertiary);
+  cursor: default;
 }
 
 .memory-tool-elapsed {

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -1,5 +1,5 @@
 import { reactive, computed, watch, nextTick, type Ref } from 'vue'
-import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, AskUserEvent, MemoryToolEvent, MemoryToolStartEvent, MemoryToolEndEvent, MemoryToolErrorEvent, MemoryDoneEvent } from '@/types'
+import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, AskUserEvent, MemoryToolEvent, MemoryToolStartEvent, MemoryToolEndEvent, MemoryToolErrorEvent, MemoryStartEvent, MemoryDoneEvent } from '@/types'
 import { refreshSessions, switchSession } from '@/composables/useSession'
 import { buildFlatMessage, buildTimestamp, parseReferences } from '@/utils/references'
 import type { ParsedRef } from '@/utils/references'
@@ -248,9 +248,9 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
     return
   }
 
-  // memory_tool_* / memory_done 可能在 done 事件之后到达（currentTurn 已清空），
+  // memory_tool_* / memory_start / memory_done 可能在 done 事件之后到达（currentTurn 已清空），
   // 必须在 const turn = ch.currentTurn 守卫之前处理，通过 turn_id 自行查找目标。
-  if (event.type === 'memory_tool_start' || event.type === 'memory_tool_end'
+  if (event.type === 'memory_start' || event.type === 'memory_tool_start' || event.type === 'memory_tool_end'
     || event.type === 'memory_tool_error' || event.type === 'memory_done') {
     handleMemoryToolEvent(ch, sid, event)
     return
@@ -431,6 +431,17 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
 
 /** 后台记忆 consumer 事件处理（在 done 后 currentTurn=null 时也能通过 turn_id 找到目标）。 */
 function handleMemoryToolEvent(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  if (event.type === 'memory_start') {
+    const me = event as MemoryStartEvent
+    console.log(`[ltm-fe] memory_start session=${sid} turn_id=${me.payload.turn_id}`)
+    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+    if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
+    if (!targetTurn.memoryEvents) targetTurn.memoryEvents = []
+    targetTurn.memoryEvents.push({
+      kind: 'memory_tool', name: 'memory_processing', input: '', output: null, elapsed: null, status: 'running',
+    })
+    return
+  }
   if (event.type === 'memory_tool_start') {
     const me = event as MemoryToolStartEvent
     if (me.payload.tool_name === 'read_memories') return  // 纯读取不显示
@@ -469,12 +480,17 @@ function handleMemoryToolEvent(ch: SessionChannel, sid: string, event: ServerEve
     console.log(`[ltm-fe] memory_done session=${sid} turn_id=${me.payload.turn_id}`)
     const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
     if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
-    if (!targetTurn.memoryEvents || targetTurn.memoryEvents.length === 0) {
+    // 移除「处理中」占位条目
+    const realEvents = (targetTurn.memoryEvents ?? []).filter(e => e.name !== 'memory_processing')
+    targetTurn.memoryEvents = realEvents
+    if (realEvents.length === 0) {
       targetTurn.memoryEvents = [{
         kind: 'memory_tool', name: 'memory_review', input: '', output: '', elapsed: null, status: 'done',
       }]
       console.log(`[ltm-fe] added memory_review`)
     }
+    if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
+    return
   }
 }
 

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -1,5 +1,5 @@
 import { reactive, computed, watch, nextTick, type Ref } from 'vue'
-import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, AskUserEvent } from '@/types'
+import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, AskUserEvent, MemoryToolEvent, MemoryToolStartEvent, MemoryToolEndEvent, MemoryToolErrorEvent, MemoryDoneEvent } from '@/types'
 import { refreshSessions, switchSession } from '@/composables/useSession'
 import { buildFlatMessage, buildTimestamp, parseReferences } from '@/utils/references'
 import type { ParsedRef } from '@/utils/references'
@@ -12,13 +12,13 @@ export const TURNS_KEY_PREFIX = 'sonetto_turns_'
 /** 将旧格式 turn（userMessage 含 __refs__ 和时间尾缀）迁移为新格式 */
 function migrateLegacyTurn(turn: any): ChatTurn {
   if (Array.isArray(turn.refs)) {
-    return turn as ChatTurn  // 已经是新格式
+    return { memoryEvents: [], ...turn } as ChatTurn
   }
   // 旧格式：从 userMessage 中提取 refs 和时间尾缀
   const prevMsg = (turn.userMessage ?? '') as string
   const { cleanText, refs } = parseReferences(prevMsg || '')
   const text = refs.length > 0 ? cleanText : prevMsg.replace(TIME_SUFFIX_RE, '')
-  return { ...turn, userMessage: text, refs }
+  return { ...turn, userMessage: text, refs, memoryEvents: [] }
 }
 
 // 从 localStorage 恢复所有会话的消息缓存（页面刷新后仍保留）
@@ -240,10 +240,19 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
       userMessage: event.payload.task || '(子 Agent 任务)',
       refs: [],
       events: [],
+      memoryEvents: [],
       finalAnswer: null,
     }
 
     void switchSession(subId)
+    return
+  }
+
+  // memory_tool_* / memory_done 可能在 done 事件之后到达（currentTurn 已清空），
+  // 必须在 const turn = ch.currentTurn 守卫之前处理，通过 turn_id 自行查找目标。
+  if (event.type === 'memory_tool_start' || event.type === 'memory_tool_end'
+    || event.type === 'memory_tool_error' || event.type === 'memory_done') {
+    handleMemoryToolEvent(ch, sid, event)
     return
   }
 
@@ -335,6 +344,11 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
       if (event.payload.context_usage) {
         ch.contextUsage = event.payload.context_usage
       }
+      // 存储后端 turn_id，用于关联后台记忆 consumer 的事件
+      if (ch.currentTurn && (event.payload as Record<string, unknown>).turn_id) {
+        ch.currentTurn.turnId = (event.payload as Record<string, unknown>).turn_id as string
+        console.log(`[ltm-fe] turnId set on turn.id=${ch.currentTurn.id}: ${ch.currentTurn.turnId}`)
+      }
       if (ch.currentTurn) {
         const lastThink = findLastThinking(ch.currentTurn.events)
         const trackBecame = lastThink?.becameAnswer
@@ -410,6 +424,53 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
         }
       }
       break
+    }
+
+  }
+}
+
+/** 后台记忆 consumer 事件处理（在 done 后 currentTurn=null 时也能通过 turn_id 找到目标）。 */
+function handleMemoryToolEvent(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  if (event.type === 'memory_tool_start') {
+    const me = event as MemoryToolStartEvent
+    console.log(`[ltm-fe] memory_tool_start session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
+    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+    if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
+    targetTurn.memoryEvents?.push({
+      kind: 'memory_tool', name: me.payload.tool_name, input: me.payload.input,
+      output: null, elapsed: null, status: 'running',
+    })
+    return
+  }
+  if (event.type === 'memory_tool_end') {
+    const me = event as MemoryToolEndEvent
+    console.log(`[ltm-fe] memory_tool_end session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
+    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+    if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
+    const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
+    if (mt) { mt.output = me.payload.output; mt.elapsed = me.payload.elapsed; mt.status = 'done' }
+    if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
+    return
+  }
+  if (event.type === 'memory_tool_error') {
+    const me = event as MemoryToolErrorEvent
+    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+    if (!targetTurn) return
+    const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
+    if (mt) mt.status = 'error'
+    if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
+    return
+  }
+  if (event.type === 'memory_done') {
+    const me = event as MemoryDoneEvent
+    console.log(`[ltm-fe] memory_done session=${sid} turn_id=${me.payload.turn_id}`)
+    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+    if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
+    if (!targetTurn.memoryEvents || targetTurn.memoryEvents.length === 0) {
+      targetTurn.memoryEvents = [{
+        kind: 'memory_tool', name: 'memory_review', input: '', output: '', elapsed: null, status: 'done',
+      }]
+      console.log(`[ltm-fe] added memory_review`)
     }
   }
 }
@@ -488,6 +549,7 @@ export function useChat(sessionId: Ref<string>) {
       userMessage: text,
       refs,
       events: [],
+      memoryEvents: [],
       finalAnswer: null,
     }
     ch.currentTurn = turn
@@ -553,6 +615,21 @@ function findRunningTool(events: TurnEvent[], toolName: string): ToolCall | unde
     if (e.kind === 'tool' && e.name === toolName && e.status === 'running') {
       return e as ToolCall
     }
+  }
+  return undefined
+}
+
+/** 通过后端 turn_id 查找 turn（先在 currentTurn 中找，再在 turns 中找）。 */
+function findTurnByBackendId(ch: SessionChannel, turnId: string): ChatTurn | undefined {
+  if (ch.currentTurn?.turnId === turnId) return ch.currentTurn
+  return ch.turns.find(t => t.turnId === turnId)
+}
+
+/** 在 memoryEvents 中查找指定工具名的 running 状态事件。 */
+function findRunningMemoryTool(events: MemoryToolEvent[], toolName: string): MemoryToolEvent | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i]
+    if (e.name === toolName && e.status === 'running') return e
   }
   return undefined
 }

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -433,6 +433,7 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
 function handleMemoryToolEvent(ch: SessionChannel, sid: string, event: ServerEvent): void {
   if (event.type === 'memory_tool_start') {
     const me = event as MemoryToolStartEvent
+    if (me.payload.tool_name === 'read_memories') return  // 纯读取不显示
     console.log(`[ltm-fe] memory_tool_start session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
     const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
     if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
@@ -444,6 +445,7 @@ function handleMemoryToolEvent(ch: SessionChannel, sid: string, event: ServerEve
   }
   if (event.type === 'memory_tool_end') {
     const me = event as MemoryToolEndEvent
+    if (me.payload.tool_name === 'read_memories') return  // 纯读取不显示
     console.log(`[ltm-fe] memory_tool_end session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
     const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
     if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
@@ -454,6 +456,7 @@ function handleMemoryToolEvent(ch: SessionChannel, sid: string, event: ServerEve
   }
   if (event.type === 'memory_tool_error') {
     const me = event as MemoryToolErrorEvent
+    if (me.payload.tool_name === 'read_memories') return  // 纯读取不显示
     const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
     if (!targetTurn) return
     const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -112,6 +112,14 @@ export interface MemoryToolErrorEvent {
   }
 }
 
+/** memory_start — 后台记忆 consumer 开始处理本轮对话 */
+export interface MemoryStartEvent {
+  type: 'memory_start'
+  payload: {
+    turn_id: string
+  }
+}
+
 /** memory_done — 后台记忆 consumer 处理完毕（无论是否有修改） */
 export interface MemoryDoneEvent {
   type: 'memory_done'
@@ -134,6 +142,7 @@ export type ServerEvent =
   | ContextUsageEvent
   | AskUserEvent
   | SubSessionCreatedEvent
+  | MemoryStartEvent
   | MemoryToolStartEvent
   | MemoryToolEndEvent
   | MemoryToolErrorEvent

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -39,7 +39,7 @@ export interface AnswerEvent {
 
 export interface DoneEvent {
   type: 'done'
-  payload: { context_usage?: ContextUsage }
+  payload: { turn_id?: string; context_usage?: ContextUsage }
 }
 
 export interface ErrorEvent {
@@ -81,6 +81,45 @@ export interface SubSessionCreatedEvent {
   }
 }
 
+/** memory_tool_start — 后台记忆 consumer 开始调用 CRUD 工具 */
+export interface MemoryToolStartEvent {
+  type: 'memory_tool_start'
+  payload: {
+    turn_id: string
+    tool_name: string
+    input: string
+  }
+}
+
+/** memory_tool_end — 后台记忆 consumer 的 CRUD 工具执行完毕 */
+export interface MemoryToolEndEvent {
+  type: 'memory_tool_end'
+  payload: {
+    turn_id: string
+    tool_name: string
+    output: string
+    elapsed: number
+  }
+}
+
+/** memory_tool_error — 后台记忆 consumer 的 CRUD 工具执行出错 */
+export interface MemoryToolErrorEvent {
+  type: 'memory_tool_error'
+  payload: {
+    turn_id: string
+    tool_name: string
+    error: string
+  }
+}
+
+/** memory_done — 后台记忆 consumer 处理完毕（无论是否有修改） */
+export interface MemoryDoneEvent {
+  type: 'memory_done'
+  payload: {
+    turn_id: string
+  }
+}
+
 export type ServerEvent =
   | ThinkingStartEvent
   | TokenEvent
@@ -95,6 +134,10 @@ export type ServerEvent =
   | ContextUsageEvent
   | AskUserEvent
   | SubSessionCreatedEvent
+  | MemoryToolStartEvent
+  | MemoryToolEndEvent
+  | MemoryToolErrorEvent
+  | MemoryDoneEvent
 
 // === WebSocket 客户端 → 服务端消息 ===
 
@@ -161,14 +204,27 @@ export interface ToolCall {
   interaction?: AskUserInteraction
 }
 
-export type TurnEvent = ThinkingBlock | ToolCall
+/** 后台记忆 consumer 的 CRUD 工具调用（渲染在轮次底部小字区） */
+export interface MemoryToolEvent {
+  kind: 'memory_tool'
+  name: string
+  input: string
+  output: string | null
+  elapsed: number | null
+  status: 'running' | 'done' | 'error'
+}
+
+export type TurnEvent = ThinkingBlock | ToolCall | MemoryToolEvent
 
 export interface ChatTurn {
   id: string
   userMessage: string
   refs: ParsedRef[]
   events: TurnEvent[]
+  memoryEvents?: MemoryToolEvent[]
   finalAnswer: string | null
+  /** 后端生成的 turn_id，用于关联后台记忆 consumer 的事件 */
+  turnId?: string
 }
 
 // === 会话与 API 类型 ===


### PR DESCRIPTION
## Summary

后台记忆 consumer 实时事件推送到前端，每轮对话后用户能感知记忆正在被处理。

## 变更内容

- **feat**: 记忆 consumer 实时事件推送 — 新增 `WebSocketRegistry` + `MemoryToolCallback`，后台 CRUD Agent 的工具调用通过 `memory_tool_start/end/error` 推送到前端对应轮次底部
- **enhance**: 纯读取（`read_memories`）不显示工具调用，仅实际修改才展示；若仅读取则显示"记忆检查 - 无需修改"
- **enhance**: 收紧记忆工具输出显示宽度，添加 hover 查看完整文本
- **enhance**: UUID 仅显示第一个 `-` 分段（如 `550e8400-e29b-...` → `550e8400`）
- **feat**: consumer 开始处理时发送 `memory_start` 事件，前端显示"记忆处理 处理中..."

## 相关文件

- `api/ws_registry.py` (new)
- `memory/memory_callback.py` (new)
- `memory/narrative.py`
- `api/routes/chat.py`
- `api/server.py`
- `web/src/types/index.ts`
- `web/src/composables/useChat.ts`
- `web/src/components/ChatWindow.vue`
- `tools/memory/tool_*.py` (5 files)
