### PR TITLE
refactor(web): 分级阴影 token 体系

### DIFF
--- a/config/personas/AGENTS.md
+++ b/config/personas/AGENTS.md
@@ -88,14 +88,15 @@
 
 你可以直接输出原始的 HTML/CSS/JS 来创建交互式内容，前端会自动将其放入沙箱 iframe 中渲染。
 
-**关键规则**：HTML **不要包裹在围栏代码块内**（```` ```html ````），否则会被显示为代码文本而非渲染为页面元素。
+**关键规则**：HTML **应包裹在 ````html 围栏代码块内**，系统会自动将其渲染为页面元素而非源代码。直接输出的原始 HTML 同样兼容，但推荐使用 ````html` 代码块以获得更稳定的渲染效果。
 
 ### 正确 vs 错误示范
 
 ```
-✅ 正确：直接输出 HTML（无代码块包裹）
+✅ 推荐：使用 ```html 代码块包裹 HTML（优先选择）
 一个交互式计数器：
 
+```html
 <div id="counter">
   <style>
     .counter-wrap { text-align: center; padding: 20px; }
@@ -108,21 +109,25 @@
     <button class="counter-btn" onclick="document.getElementById('num').textContent=parseInt(document.getElementById('num').textContent)+1">+1</button>
   </div>
 </div>
+```
 
-❌ 错误：包裹在代码块中，只会显示代码
-```html
+✅ 也支持直接输出原始 HTML（无代码块包裹）
+<div>hello</div>
+
+❌ 错误：包裹在非 html 代码块中，会被渲染为源代码
+```js
 <div>hello</div>
 ```
 
-❌ 错误：包裹在代码块中的 script 不会被执行
-```html
+❌ 错误：包裹在非 html 代码块中的 script 不会被执行
+```js
 <script>alert('test')</script>
 ```
 ```
 
 ### 触发沙箱的条件
 
-内容中**在代码块之外**出现以下任何一种模式，就会进入 iframe 沙箱渲染：
+内容中出现以下任何一种模式（无论是否在代码块内），就会进入 iframe 沙箱渲染：
 
 | 模式 | 示例 |
 |------|------|

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -189,7 +189,8 @@ onMounted(() => {
   --status-error: #ef4444;
   --status-warn: #f59e0b;
   --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);       /* 兼容别名，同级 --shadow-md */
-  --shadow-xs: 0 1px 3px rgba(0, 0, 0, 0.04);   /* 输入框、极浅分割 */
+  --shadow-xs: 0 1px 3px rgba(0, 0, 0, 0.04);   /* 极浅分割 */
+  --shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.06); /* 大面积超浅阴影（输入框） */
   --shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.06);   /* 卡片、条目 hover */
   --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);   /* 气泡、通用卡片 */
   --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.12);  /* 下拉菜单、浮层 */

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -188,7 +188,12 @@ onMounted(() => {
   --status-ok: #000000;
   --status-error: #ef4444;
   --status-warn: #f59e0b;
-  --shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);       /* 兼容别名，同级 --shadow-md */
+  --shadow-xs: 0 1px 3px rgba(0, 0, 0, 0.04);   /* 输入框、极浅分割 */
+  --shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.06);   /* 卡片、条目 hover */
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);   /* 气泡、通用卡片 */
+  --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.12);  /* 下拉菜单、浮层 */
+  --shadow-xl: 0 6px 28px rgba(0, 0, 0, 0.18);  /* 模态弹窗、重型浮层 */
   --radius: 10px;
 }
 
@@ -345,7 +350,7 @@ html, body {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-lg);
   min-width: 170px;
   padding: 6px;
   overflow: hidden;

--- a/web/src/components/AutocompletePanel.vue
+++ b/web/src/components/AutocompletePanel.vue
@@ -90,7 +90,7 @@ const panelStyle = computed(() => ({
   background: #ffffff;
   border: 1px solid #e5e7eb;
   border-radius: 10px;
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-xl);
   padding: 4px;
 }
 .ac-item {

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -910,7 +910,7 @@ function onResizeEnd(e: PointerEvent) {
   border: 1px solid var(--border);
   border-radius: 20px;
   padding: 4px 14px 8px;
-  box-shadow: var(--shadow-xs);
+  box-shadow: var(--shadow-soft);
   transition: border-color 0.2s, box-shadow 0.2s;
   overflow: visible;
 }
@@ -920,7 +920,7 @@ function onResizeEnd(e: PointerEvent) {
 }
 .chat-input:focus-within {
   border-color: var(--accent);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 10%, transparent);
+  box-shadow: var(--shadow-soft), 0 0 0 1px color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 /* 添加文件按钮 */

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -701,7 +701,7 @@ function onResizeEnd(e: PointerEvent) {
   background: #ffffff;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-lg);
   min-width: 140px;
   max-height: 200px;
   overflow-y: auto;
@@ -910,7 +910,7 @@ function onResizeEnd(e: PointerEvent) {
   border: 1px solid var(--border);
   border-radius: 20px;
   padding: 4px 14px 8px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+  box-shadow: var(--shadow-xs);
   transition: border-color 0.2s, box-shadow 0.2s;
   overflow: visible;
 }
@@ -979,7 +979,7 @@ function onResizeEnd(e: PointerEvent) {
   border: 1px solid var(--border);
   border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   min-width: 140px;
 }
 .add-file-menu-item {

--- a/web/src/components/ContextMenu.vue
+++ b/web/src/components/ContextMenu.vue
@@ -95,7 +95,7 @@ onUnmounted(() => {
   border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   padding: 4px 0;
   transform-origin: top left;
 }

--- a/web/src/components/ContextUsageBadge.vue
+++ b/web/src/components/ContextUsageBadge.vue
@@ -221,7 +221,7 @@ async function onBalanceHover() {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   font-size: 12px;
   line-height: 1.6;
   white-space: nowrap;

--- a/web/src/components/HtmlSandbox.vue
+++ b/web/src/components/HtmlSandbox.vue
@@ -58,7 +58,7 @@ function getThemeCssVars(): string[] {
     '--accent', '--accent-light', '--border',
     '--user-bubble',
     '--status-ok', '--status-error', '--status-warn',
-    '--shadow', '--radius',
+    '--shadow', '--shadow-xs', '--shadow-sm', '--shadow-md', '--shadow-lg', '--shadow-xl', '--radius',
   ]
   return names.map(n => `${n}: ${style.getPropertyValue(n).trim()};`)
 }

--- a/web/src/components/NewsCard.vue
+++ b/web/src/components/NewsCard.vue
@@ -58,7 +58,7 @@ const paragraphs = computed(() => {
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 20px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -667,7 +667,7 @@ function closeContextMenu() {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   font-size: 12px;
   line-height: 1.6;
   white-space: nowrap;
@@ -770,7 +770,7 @@ function closeContextMenu() {
   -webkit-backdrop-filter: blur(16px) saturate(1.2);
   border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   border-radius: 10px;
-  box-shadow: 0 6px 28px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--shadow-xl);
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -515,6 +515,7 @@ function closeContextMenu() {
   gap: 4px;
   max-height: 400px;
   overflow-y: auto;
+  padding: 0 6px 8px;
 }
 
 /* ── Section label ── */

--- a/web/src/components/StatusBadge.vue
+++ b/web/src/components/StatusBadge.vue
@@ -119,7 +119,7 @@ function makeItem(name: string, c: ComponentHealth) {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   font-size: 12px;
   line-height: 1.6;
   white-space: nowrap;

--- a/web/src/components/TaskTrackerBar.vue
+++ b/web/src/components/TaskTrackerBar.vue
@@ -92,7 +92,7 @@ const statusLabel = computed(() => {
   border: 1.5px solid #0000001e;
   border-radius: 6px;
   padding: 4px 12px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.034);
+  box-shadow: var(--shadow-xs);
   transition: opacity 0.25s;
 }
 

--- a/web/src/components/tools/HolidayBubble.vue
+++ b/web/src/components/tools/HolidayBubble.vue
@@ -275,7 +275,7 @@ const displayOutput = computed(() => {
   background: linear-gradient(135deg, #d4145a, #fbb03b);
   border-radius: 12px;
   color: #fff;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.1);
+  box-shadow: var(--shadow-md);
 }
 
 .hero-date {

--- a/web/src/components/tools/TarotBubble.vue
+++ b/web/src/components/tools/TarotBubble.vue
@@ -220,12 +220,12 @@ const displayOutput = computed(() => {
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-md);
   transition: box-shadow 0.2s;
 }
 
 .tarot-card:hover .card-face {
-  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+  box-shadow: var(--shadow-lg);
 }
 
 .card-name {

--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -26,6 +26,26 @@ md.use(texmath, {
   },
 })
 
+// 自定义 fence 渲染器：```html 代码块渲染为实际 HTML，而非源代码显示
+const defaultFence = md.renderer.rules.fence
+
+md.renderer.rules.fence = function (tokens, idx, options, env, self) {
+  const token = tokens[idx]
+  const info = token.info ? token.info.trim() : ''
+  const lang = info.split(/\s+/)[0].toLowerCase()
+
+  // ```html 代码块：输出原始内容作为实际 HTML（不包裹 <pre><code>）
+  if (lang === 'html') {
+    return token.content
+  }
+
+  // 其他语言：使用默认渲染（转义后包裹 <pre><code>）
+  if (defaultFence) {
+    return defaultFence(tokens, idx, options, env, self)
+  }
+  return self.renderToken(tokens, idx, options)
+}
+
 export function renderMarkdown(content: string): string {
   if (!content) return ''
   return md.render(content)
@@ -33,7 +53,7 @@ export function renderMarkdown(content: string): string {
 
 /**
  * 检测 Markdown 原文是否包含需要沙箱隔离的原始 HTML/JS/CSS。
- * 跳过围栏代码块内的内容，避免误判示例代码。
+ * 跳过非 HTML 围栏代码块内的内容；HTML 代码块（```html）内的内容仍接受沙箱检测。
  *
  * 触发隔离的条件：
  * - `<script>` — JS 脚本（v-html 不执行，iframe 才执行）
@@ -45,15 +65,25 @@ export function renderMarkdown(content: string): string {
 export function contentNeedsIsolation(markdown: string): boolean {
   if (!markdown) return false
   let inCodeBlock = false
+  let codeBlockLang = ''
   const lines = markdown.split('\n')
   for (const line of lines) {
     const trimmed = line.trimStart()
-    // 切换围栏代码块状态
+    // 切换围栏代码块状态，同时记录语言标签
     if (trimmed.startsWith('```')) {
+      if (!inCodeBlock) {
+        // 进入代码块：提取语言标签（``` 后的第一个词）
+        codeBlockLang = trimmed.slice(3).trim().split(/\s+/)[0].toLowerCase()
+      } else {
+        // 退出代码块：重置语言标签
+        codeBlockLang = ''
+      }
       inCodeBlock = !inCodeBlock
       continue
     }
-    if (inCodeBlock) continue
+
+    // 跳过非 HTML 代码块内的内容
+    if (inCodeBlock && codeBlockLang !== 'html') continue
 
     // 检查原始 <script> 标签
     if (/<script[\s>/]/i.test(line) || /<\/script>/i.test(line)) return true

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -224,7 +224,7 @@ async function handleUndo() {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   font-size: 12px;
   line-height: 1.6;
 }
@@ -333,7 +333,7 @@ async function handleUndo() {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 16px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-sm);
 }
 .no-provider-icon {
   font-size: 48px;

--- a/web/src/views/PathWhitelistView.vue
+++ b/web/src/views/PathWhitelistView.vue
@@ -219,7 +219,7 @@ onMounted(loadEntries)
   transition: box-shadow 0.15s;
 }
 .entry-card:hover {
-  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  box-shadow: var(--shadow-sm);
 }
 .entry-body {
   flex: 1;

--- a/web/src/views/ProvidersView.vue
+++ b/web/src/views/ProvidersView.vue
@@ -413,7 +413,7 @@ onMounted(loadProviders)
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 20px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -464,7 +464,7 @@ onMounted(loadProviders)
   border-radius: 50%;
   background: #ffffff;
   transition: transform 0.2s;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+  box-shadow: var(--shadow-xs);
 }
 .toggle-btn.active {
   background: #1f2937;

--- a/web/src/views/SonettoBlockerView.vue
+++ b/web/src/views/SonettoBlockerView.vue
@@ -249,7 +249,7 @@ onMounted(loadEntries)
   transition: box-shadow 0.15s;
 }
 .entry-card:hover {
-  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  box-shadow: var(--shadow-sm);
 }
 .entry-body {
   flex: 1;


### PR DESCRIPTION
## 变更内容

将单一 `--shadow` 设计令牌扩展为 5 级 elevation 体系，替换 20+ 处硬编码 box-shadow 值。

### Token 层级

| Token | 值 | 用途 |
|-------|------|------|
| `--shadow-xs` | `0 1px 3px rgba(0,0,0,0.04)` | 极浅分割 |
| `--shadow-soft` | `0 8px 24px rgba(0,0,0,0.06)` | 大面积超浅阴影（输入框） |
| `--shadow-sm` | `0 1px 4px rgba(0,0,0,0.06)` | 卡片、条目 hover |
| `--shadow-md` | `0 2px 8px rgba(0,0,0,0.08)` | 气泡、通用卡片 |
| `--shadow-lg` | `0 4px 16px rgba(0,0,0,0.12)` | 下拉菜单、浮层 |
| `--shadow-xl` | `0 6px 28px rgba(0,0,0,0.18)` | 模态弹窗、重型浮层 |

### 主要改动

- **App.vue** — `--shadow` 扩展为 6 级 token
- **HtmlSandbox.vue** — 沙箱注入全部 shadow token
- **14 个组件** — 硬编码值替换为 `var(--shadow-*)`
- **ChatInput.vue** — 输入框使用 `--shadow-soft`，聚焦时阴影不变
- **SessionSidebar.vue** — 调整内边距防止阴影被容器截断

Closes #173