### PR TITLE
feat(todo): 完整封堵 Todoist 工具 SDK 字段缺口并新增 3 个工具

### DIFF
--- a/tests/test_todo/conftest.py
+++ b/tests/test_todo/conftest.py
@@ -1,0 +1,117 @@
+"""Todo 工具测试 — 共享 fixtures。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from tools.base import SharedAPIClient
+from tools.todo.todo_base import TodoAPIHelper
+
+
+@pytest.fixture
+def mock_api():
+    """Mocked TodoistAPI instance."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_client():
+    """Mocked SharedAPIClient with fake todoist token."""
+    client = MagicMock(spec=SharedAPIClient)
+    client._todoist_token = "fake-token"
+    return client
+
+
+@pytest.fixture
+def helper(mock_api):
+    """TodoAPIHelper with mocked api property."""
+    h = TodoAPIHelper("fake-token")
+    type(h).api = PropertyMock(return_value=mock_api)
+    return h
+
+
+@pytest.fixture
+def mock_project():
+    """Standard mock Project object."""
+    p = MagicMock()
+    p.id = "proj123"
+    p.name = "Work"
+    p.description = "Work tasks"
+    p.color = "blue"
+    p.order = 1
+    p.is_favorite = True
+    p.is_archived = False
+    p.is_shared = False
+    p.is_collapsed = False
+    p.parent_id = None
+    p.view_style = "list"
+    p.can_assign_tasks = True
+    p.is_inbox_project = False
+    p.workspace_id = "ws1"
+    p.folder_id = None
+    return p
+
+
+@pytest.fixture
+def mock_section():
+    """Standard mock Section object."""
+    s = MagicMock()
+    s.id = "sec789"
+    s.name = "Backlog"
+    s.project_id = "proj123"
+    s.order = 1
+    s.is_collapsed = False
+    return s
+
+
+@pytest.fixture
+def mock_label():
+    """Standard mock Label object."""
+    l = MagicMock()
+    l.id = "lab456"
+    l.name = "urgent"
+    l.color = "red"
+    l.order = 1
+    l.is_favorite = False
+    return l
+
+
+@pytest.fixture
+def mock_task():
+    """Standard mock Task object with all fields populated."""
+    t = MagicMock()
+    t.id = "task999"
+    t.content = "Test task"
+    t.description = "Test description"
+    t.project_id = "proj123"
+    t.section_id = "sec789"
+    t.parent_id = None
+    t.labels = ["urgent", "work"]
+    t.priority = 2
+    t.order = 1
+    t.is_collapsed = False
+    t.assignee_id = None
+    t.assigner_id = None
+    t.creator_id = "user1"
+    t.is_completed = False
+    t.url = None
+
+    due = MagicMock()
+    due.date = "2026-07-01"
+    due.string = "next Monday"
+    due.lang = "en"
+    due.is_recurring = False
+    due.timezone = None
+    t.due = due
+
+    deadline = MagicMock()
+    deadline.date = "2026-07-05"
+    deadline.lang = "en"
+    t.deadline = deadline
+
+    duration = MagicMock()
+    duration.amount = 30
+    duration.unit = "minute"
+    t.duration = duration
+
+    return t

--- a/tests/test_todo/test_complete_uncomplete_delete.py
+++ b/tests/test_todo/test_complete_uncomplete_delete.py
@@ -1,0 +1,58 @@
+"""todo_complete / todo_uncomplete / todo_delete 工具测试。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+from tools.todo.tool_complete import TodoCompleteTool
+from tools.todo.tool_uncomplete import TodoUncompleteTool
+from tools.todo.tool_delete import TodoDeleteTool
+
+
+class _BaseTest:
+    def _make_tool(self, tool_cls, mock_api, mock_client):
+        tool = tool_cls(client=mock_client)
+        helper = tool.helper
+        type(helper).api = PropertyMock(return_value=mock_api)
+        return tool
+
+
+class TestComplete(_BaseTest):
+    def test_empty_id_returns_error(self, mock_api, mock_client):
+        tool = self._make_tool(TodoCompleteTool, mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="")
+        assert "不能为空" in result
+
+    def test_complete_success(self, mock_api, mock_client):
+        t = MagicMock()
+        t.id = "t1"
+        t.content = "Task"
+        mock_api.get_task.return_value = t
+        mock_api.complete_task.return_value = True
+
+        tool = self._make_tool(TodoCompleteTool, mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="t1")
+        assert "success" in result
+        mock_api.complete_task.assert_called_once_with("t1")
+
+
+class TestUncomplete(_BaseTest):
+    def test_uncomplete_success(self, mock_api, mock_client):
+        t = MagicMock()
+        t.id = "t1"
+        t.content = "Task"
+        mock_api.get_task.return_value = t
+        mock_api.uncomplete_task.return_value = True
+
+        tool = self._make_tool(TodoUncompleteTool, mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="t1")
+        assert "success" in result
+        mock_api.uncomplete_task.assert_called_once_with("t1")
+
+
+class TestDelete(_BaseTest):
+    def test_delete_success(self, mock_api, mock_client):
+        mock_api.delete_task.return_value = True
+
+        tool = self._make_tool(TodoDeleteTool, mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="t1")
+        assert "success" in result
+        mock_api.delete_task.assert_called_once_with("t1")

--- a/tests/test_todo/test_todo_base.py
+++ b/tests/test_todo/test_todo_base.py
@@ -1,0 +1,221 @@
+"""TodoAPIHelper 单元测试。"""
+
+from datetime import date, datetime
+
+from tools.todo.todo_base import TodoAPIHelper
+
+
+class TestParseDate:
+    def test_ymd(self):
+        result = TodoAPIHelper.parse_date("2026-07-01")
+        assert result == datetime(2026, 7, 1)
+
+    def test_ymd_hms(self):
+        result = TodoAPIHelper.parse_date("2026-07-01 15:30")
+        assert result == datetime(2026, 7, 1, 15, 30)
+
+    def test_ymd_thms(self):
+        result = TodoAPIHelper.parse_date("2026-07-01T15:30")
+        assert result == datetime(2026, 7, 1, 15, 30)
+
+    def test_invalid_returns_none(self):
+        result = TodoAPIHelper.parse_date("not-a-date")
+        assert result is None
+
+    def test_empty_returns_none(self):
+        result = TodoAPIHelper.parse_date("")
+        assert result is None
+
+
+class TestParseDeadline:
+    def test_valid(self):
+        result = TodoAPIHelper.parse_deadline("2026-07-01")
+        assert result == date(2026, 7, 1)
+        assert isinstance(result, date)
+
+    def test_invalid_returns_none(self):
+        result = TodoAPIHelper.parse_deadline("not-a-date")
+        assert result is None
+
+
+class TestParseDatetime:
+    def test_ymd_hms(self):
+        result = TodoAPIHelper.parse_datetime("2026-07-01 15:30")
+        assert result == datetime(2026, 7, 1, 15, 30)
+
+    def test_ymd_thms(self):
+        result = TodoAPIHelper.parse_datetime("2026-07-01T15:30")
+        assert result == datetime(2026, 7, 1, 15, 30)
+
+    def test_ymd(self):
+        """parse_datetime also accepts bare date."""
+        result = TodoAPIHelper.parse_datetime("2026-07-01")
+        assert result == datetime(2026, 7, 1)
+
+    def test_invalid_returns_none(self):
+        result = TodoAPIHelper.parse_datetime("")
+        assert result is None
+
+
+class TestGetProjectId:
+    def test_found(self, helper, mock_api):
+        p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+
+        result = helper.get_project_id("Work")
+        assert result == "p1"
+
+    def test_case_insensitive(self, helper, mock_api):
+        p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+
+        result = helper.get_project_id("work")
+        assert result == "p1"
+
+    def test_not_found(self, helper, mock_api):
+        p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+
+        result = helper.get_project_id("Nope")
+        assert result is None
+
+
+class TestGetProjectName:
+    def test_found(self, helper, mock_api):
+        p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+
+        result = helper.get_project_name("p1")
+        assert result == "Work"
+
+    def test_not_found_returns_inbox(self, helper, mock_api):
+        mock_api.get_projects.return_value = [[]]
+        result = helper.get_project_name("nope")
+        assert result == "Inbox"
+
+
+class TestGetSectionId:
+    def test_found(self, helper, mock_api):
+        s = type("FakeSection", (), {"id": "s1", "name": "Backlog", "project_id": "p1"})()
+        mock_api.get_sections.return_value = [[s]]
+
+        result = helper.get_section_id("Backlog", "p1")
+        assert result == "s1"
+
+    def test_case_insensitive(self, helper, mock_api):
+        s = type("FakeSection", (), {"id": "s1", "name": "Backlog", "project_id": "p1"})()
+        mock_api.get_sections.return_value = [[s]]
+
+        result = helper.get_section_id("backlog", "p1")
+        assert result == "s1"
+
+    def test_not_found(self, helper, mock_api):
+        mock_api.get_sections.return_value = [[]]
+        result = helper.get_section_id("Nope", "p1")
+        assert result is None
+
+
+class TestGetSectionName:
+    def test_found(self, helper, mock_api):
+        s = type("FakeSection", (), {"id": "s1", "name": "Backlog", "project_id": "p1"})()
+        mock_api.get_sections.return_value = [[s]]
+
+        result = helper.get_section_name("s1")
+        assert result == "Backlog"
+
+    def test_not_found(self, helper, mock_api):
+        mock_api.get_sections.return_value = [[]]
+        result = helper.get_section_name("nope")
+        assert result is None
+
+
+class TestFindSectionGlobal:
+    def test_found(self, helper, mock_api):
+        s = type("FakeSection", (), {"id": "s1", "name": "Backlog", "project_id": "p1"})()
+        mock_api.get_sections.return_value = [[s]]
+
+        result = helper.find_section_global("Backlog")
+        assert result == ("p1", "s1")
+
+    def test_not_found(self, helper, mock_api):
+        mock_api.get_sections.return_value = [[]]
+        result = helper.find_section_global("Nope")
+        assert result is None
+
+
+class TestGetAllLabels:
+    def test_returns_flat_list(self, helper, mock_api):
+        l1 = type("FakeLabel", (), {"id": "l1", "name": "urgent", "color": "red",
+                                     "order": 1, "is_favorite": False})()
+        l2 = type("FakeLabel", (), {"id": "l2", "name": "work", "color": "blue",
+                                     "order": 2, "is_favorite": False})()
+        mock_api.get_labels.return_value = [[l1], [l2]]
+
+        result = helper.get_all_labels()
+        assert len(result) == 2
+        assert result[0].name == "urgent"
+        assert result[1].name == "work"
+
+
+class TestTaskToDict:
+    def test_all_fields_present(self, helper, mock_task, mock_api):
+        mock_api.get_projects.return_value = [
+            [type("FakeProject", (), {"id": "proj123", "name": "Work"})()]
+        ]
+        mock_api.get_sections.return_value = [
+            [type("FakeSection", (), {"id": "sec789", "name": "Backlog", "project_id": "proj123"})()]
+        ]
+
+        result = helper.task_to_dict(mock_task)
+
+        assert result["task_id"] == "task999"
+        assert result["content"] == "Test task"
+        assert result["description"] == "Test description"
+        assert result["project_id"] == "proj123"
+        assert result["project_name"] == "Work"
+        assert result["section_id"] == "sec789"
+        assert result["section_name"] == "Backlog"
+        assert result["parent_id"] is None
+        assert result["labels"] == ["urgent", "work"]
+        assert result["priority"] == 2
+        assert result["order"] == 1
+        assert result["is_collapsed"] is False
+        assert result["is_completed"] is False
+
+        # Sub-models
+        assert result["due"]["date"] == "2026-07-01"
+        assert result["due"]["string"] == "next Monday"
+        assert result["deadline"]["date"] == "2026-07-05"
+        assert result["duration"]["amount"] == 30
+        assert result["duration"]["unit"] == "minute"
+
+
+class TestProjectToDict:
+    def test_all_fields_present(self, helper, mock_project):
+        result = helper.project_to_dict(mock_project)
+        assert result["project_id"] == "proj123"
+        assert result["name"] == "Work"
+        assert result["description"] == "Work tasks"
+        assert result["color"] == "blue"
+        assert result["is_favorite"] is True
+        assert result["is_archived"] is False
+        assert result["view_style"] == "list"
+
+
+class TestSectionToDict:
+    def test_all_fields_present(self, helper, mock_section, mock_api):
+        mock_api.get_projects.return_value = [
+            [type("FakeProject", (), {"id": "proj123", "name": "Work"})()]
+        ]
+        result = helper.section_to_dict(mock_section)
+        assert result["section_id"] == "sec789"
+        assert result["name"] == "Backlog"
+        assert result["project_name"] == "Work"
+
+
+class TestLabelToDict:
+    def test_all_fields_present(self, helper, mock_label):
+        result = helper.label_to_dict(mock_label)
+        assert result["label_id"] == "lab456"
+        assert result["name"] == "urgent"
+        assert result["color"] == "red"

--- a/tests/test_todo/test_tool_add.py
+++ b/tests/test_todo/test_tool_add.py
@@ -1,0 +1,201 @@
+"""todo_add 工具测试。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+from tools.todo.tool_add import TodoAddTool
+
+
+def _make_tool(mock_api, mock_client):
+    """Helper: create TodoAddTool with mocked api."""
+    tool = TodoAddTool(client=mock_client)
+    helper = tool.helper
+    type(helper).api = PropertyMock(return_value=mock_api)
+    return tool
+
+
+class TestValidation:
+    def test_get_doc_returns_doc(self, mock_client):
+        """get_doc=True → 不调 API，返回文档。"""
+        tool = TodoAddTool(client=mock_client)
+        result = tool._run(get_doc=True)
+        assert "本 Tool 暂无文档" in result or "Todoist" in result
+
+    def test_empty_content_returns_error(self, mock_client):
+        tool = TodoAddTool(client=mock_client)
+        result = tool._run(get_doc=False, content="")
+        assert "不能为空" in result
+
+    def test_invalid_priority_returns_error(self, mock_client):
+        tool = TodoAddTool(client=mock_client)
+        result = tool._run(get_doc=False, content="test", priority=5)
+        assert "无效" in result
+
+
+class TestCreateTask:
+    def test_basic_create(self, mock_api, mock_client):
+        """最基本创建：仅传 content。"""
+        mock_task = MagicMock()
+        mock_task.id = "new123"
+        mock_task.content = "Hello"
+        mock_task.description = ""
+        mock_task.project_id = "inbox_id"
+        mock_task.section_id = None
+        mock_task.parent_id = None
+        mock_task.labels = []
+        mock_task.priority = 1
+        mock_task.due = None
+        mock_task.deadline = None
+        mock_task.duration = None
+        mock_task.order = 1
+        mock_task.is_collapsed = False
+        mock_task.assignee_id = None
+        mock_task.assigner_id = None
+        mock_task.creator_id = "u1"
+        mock_task.is_completed = False
+        mock_task.url = None
+        mock_api.add_task.return_value = mock_task
+
+        # Mock project + section lookups
+        p = type("FakeProject", (), {"id": "inbox_id", "name": "Inbox"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, content="Hello")
+
+        assert '"success": true' in result or "success" in result
+        mock_api.add_task.assert_called_once()
+        kwargs = mock_api.add_task.call_args[1]
+        assert kwargs["content"] == "Hello"
+
+    def test_create_with_all_basic_fields(self, mock_api, mock_client):
+        """创建时传所有基本字段。"""
+        mock_task = MagicMock()
+        mock_task.id = "new456"
+        mock_task.content = "Test task"
+        mock_task.description = "A description"
+        mock_task.project_id = "proj123"
+        mock_task.section_id = "sec789"
+        mock_task.parent_id = None
+        mock_task.labels = ["urgent"]
+        mock_task.priority = 3
+        mock_task.due = None
+        mock_task.deadline = None
+        mock_task.duration = None
+        mock_task.order = 1
+        mock_task.is_collapsed = False
+        mock_task.assignee_id = "user2"
+        mock_task.assigner_id = None
+        mock_task.creator_id = "u1"
+        mock_task.is_completed = False
+        mock_task.url = None
+        mock_api.add_task.return_value = mock_task
+
+        p1 = type("FakeProject", (), {"id": "proj123", "name": "My Project"})()
+        s1 = type("FakeSection", (), {"id": "sec789", "name": "Backlog", "project_id": "proj123"})()
+        mock_api.get_projects.return_value = [[p1]]
+        mock_api.get_sections.return_value = [[s1]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(
+            get_doc=False,
+            content="Test task",
+            description="A description",
+            due_string="next Monday",
+            due_lang="en",
+            priority=3,
+            project_name="My Project",
+            section_name="Backlog",
+            labels=["urgent"],
+            parent_id=None,
+            assignee_id="user2",
+            order=5,
+        )
+
+        assert "success" in result
+        kwargs = mock_api.add_task.call_args[1]
+        assert kwargs["content"] == "Test task"
+        assert kwargs["description"] == "A description"
+        assert kwargs["due_string"] == "next Monday"
+        assert kwargs["due_lang"] == "en"
+        assert kwargs["priority"] == 3
+        assert kwargs["labels"] == ["urgent"]
+        assert kwargs["assignee_id"] == "user2"
+        assert kwargs["order"] == 5
+
+    def test_create_with_due_date(self, mock_api, mock_client):
+        """due_date 被正确解析为 date 对象。"""
+        mock_task = MagicMock()
+        mock_task.id = "t1"
+        mock_api.add_task.return_value = mock_task
+        p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, content="Test", due_date="2026-07-15")
+
+        kwargs = mock_api.add_task.call_args[1]
+        from datetime import date
+        assert kwargs["due_date"] == date(2026, 7, 15)
+
+    def test_create_with_labels(self, mock_api, mock_client):
+        """labels 列表被正确传递。"""
+        mock_task = MagicMock()
+        mock_task.id = "t1"
+        mock_api.add_task.return_value = mock_task
+        p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, content="Test", labels=["urgent", "work"])
+
+        kwargs = mock_api.add_task.call_args[1]
+        assert kwargs["labels"] == ["urgent", "work"]
+
+    def test_create_with_duration(self, mock_api, mock_client):
+        """duration / duration_unit 被传入。"""
+        mock_task = MagicMock()
+        mock_task.id = "t1"
+        mock_api.add_task.return_value = mock_task
+        p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, content="Test", duration=30, duration_unit="minute")
+
+        kwargs = mock_api.add_task.call_args[1]
+        assert kwargs["duration"] == 30
+        assert kwargs["duration_unit"] == "minute"
+
+    def test_create_with_deadline(self, mock_api, mock_client):
+        """deadline_date 被解析为 date 对象。"""
+        mock_task = MagicMock()
+        mock_task.id = "t1"
+        mock_api.add_task.return_value = mock_task
+        p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, content="Test", deadline_date="2026-08-01")
+
+        from datetime import date
+        kwargs = mock_api.add_task.call_args[1]
+        assert kwargs["deadline_date"] == date(2026, 8, 1)
+
+    def test_nonexistent_project_returns_error(self, mock_api, mock_client):
+        mock_api.get_projects.return_value = [[]]
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, content="Test", project_name="Nope")
+        assert "不存在" in result
+
+    def test_nonexistent_section_returns_error(self, mock_api, mock_client):
+        p = type("FakeProject", (), {"id": "p1", "name": "MyProject"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, content="Test", project_name="MyProject", section_name="Nope")
+        assert "不存在" in result

--- a/tests/test_todo/test_tool_add_quick.py
+++ b/tests/test_todo/test_tool_add_quick.py
@@ -1,0 +1,82 @@
+"""todo_add_quick 工具测试。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+from tools.todo.tool_add_quick import TodoAddQuickTool
+
+
+def _make_tool(mock_api, mock_client):
+    tool = TodoAddQuickTool(client=mock_client)
+    helper = tool.helper
+    type(helper).api = PropertyMock(return_value=mock_api)
+    return tool
+
+
+class TestAddQuick:
+    def test_empty_text_returns_error(self, mock_api, mock_client):
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, text="")
+        assert "不能为空" in result
+
+    def test_add_quick_with_text_only(self, mock_api, mock_client):
+        t = MagicMock()
+        t.id = "new1"
+        t.content = "Buy milk"
+        t.description = ""
+        t.project_id = "p1"
+        t.section_id = None
+        t.parent_id = None
+        t.labels = []
+        t.priority = 1
+        t.due = None
+        t.deadline = None
+        t.duration = None
+        t.order = 1
+        t.is_collapsed = False
+        t.assignee_id = None
+        t.assigner_id = None
+        t.creator_id = "u1"
+        t.is_completed = False
+        t.url = None
+        mock_api.add_task_quick.return_value = t
+        p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, text="Buy milk")
+        assert "success" in result
+        mock_api.add_task_quick.assert_called_once_with(
+            text="Buy milk", note=None, reminder=None, auto_reminder=True
+        )
+
+    def test_add_quick_with_note(self, mock_api, mock_client):
+        t = MagicMock()
+        t.id = "new1"
+        t.content = "Task"
+        t.project_id = "p1"
+        t.section_id = None
+        t.description = ""
+        t.parent_id = None
+        t.labels = []
+        t.priority = 1
+        t.due = None
+        t.deadline = None
+        t.duration = None
+        t.order = 1
+        t.is_collapsed = False
+        t.assignee_id = None
+        t.assigner_id = None
+        t.creator_id = "u1"
+        t.is_completed = False
+        t.url = None
+        mock_api.add_task_quick.return_value = t
+        p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, text="Task", note="A note")
+        mock_api.add_task_quick.assert_called_once_with(
+            text="Task", note="A note", reminder=None, auto_reminder=True
+        )

--- a/tests/test_todo/test_tool_list.py
+++ b/tests/test_todo/test_tool_list.py
@@ -1,0 +1,89 @@
+"""todo_list 工具测试 — 过滤参数 + 增强回显。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+from tools.todo.tool_list import TodoListTool
+
+
+def _make_tool(mock_api, mock_client):
+    tool = TodoListTool(client=mock_client)
+    helper = tool.helper
+    type(helper).api = PropertyMock(return_value=mock_api)
+    return tool
+
+
+def _fake_task(tid="t1", project_id="proj1", **kw):
+    t = MagicMock()
+    t.id = tid
+    t.content = "Task"
+    t.description = ""
+    t.project_id = project_id
+    t.section_id = None
+    t.parent_id = None
+    t.labels = []
+    t.priority = 1
+    t.due = None
+    t.deadline = None
+    t.duration = None
+    t.order = 1
+    t.is_collapsed = False
+    t.assignee_id = None
+    t.assigner_id = None
+    t.creator_id = "u1"
+    t.is_completed = False
+    t.url = None
+    for k, v in kw.items():
+        setattr(t, k, v)
+    return t
+
+
+class TestFilters:
+    def test_no_filter_returns_all(self, mock_api, mock_client):
+        mock_api.get_tasks.return_value = [[_fake_task(), _fake_task("t2")]]
+        p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False)
+        assert "success" in result
+        mock_api.get_tasks.assert_called_once_with()
+
+    def test_filter_by_project_name(self, mock_api, mock_client):
+        mock_api.get_tasks.return_value = [[_fake_task()]]
+        p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, project_name="Work")
+        mock_api.get_tasks.assert_called_once_with(project_id="proj1")
+
+    def test_filter_by_label(self, mock_api, mock_client):
+        mock_api.get_tasks.return_value = [[]]
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, label="urgent")
+        mock_api.get_tasks.assert_called_once_with(label="urgent")
+
+    def test_filter_by_parent_id(self, mock_api, mock_client):
+        mock_api.get_tasks.return_value = [[]]
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, parent_id="parent1")
+        mock_api.get_tasks.assert_called_once_with(parent_id="parent1")
+
+    def test_filter_by_ids(self, mock_api, mock_client):
+        mock_api.get_tasks.return_value = [[]]
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, ids=["t1", "t2"])
+        mock_api.get_tasks.assert_called_once_with(ids=["t1", "t2"])
+
+    def test_filter_by_limit(self, mock_api, mock_client):
+        mock_api.get_tasks.return_value = [[]]
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, limit=50)
+        mock_api.get_tasks.assert_called_once_with(limit=50)
+
+    def test_nonexistent_project_returns_empty(self, mock_api, mock_client):
+        mock_api.get_projects.return_value = [[]]
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, project_name="Nope")
+        assert '"total": 0' in result

--- a/tests/test_todo/test_tool_list_labels.py
+++ b/tests/test_todo/test_tool_list_labels.py
@@ -1,0 +1,28 @@
+"""todo_list_labels 工具测试。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+from tools.todo.tool_list_labels import TodoListLabelsTool
+
+
+def _make_tool(mock_api, mock_client):
+    tool = TodoListLabelsTool(client=mock_client)
+    helper = tool.helper
+    type(helper).api = PropertyMock(return_value=mock_api)
+    return tool
+
+
+class TestListLabels:
+    def test_returns_labels(self, mock_api, mock_client):
+        l = MagicMock()
+        l.id = "l1"
+        l.name = "urgent"
+        l.color = "red"
+        l.order = 1
+        l.is_favorite = False
+        mock_api.get_labels.return_value = [[l]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False)
+        assert "success" in result
+        assert "labels" in result

--- a/tests/test_todo/test_tool_list_projects.py
+++ b/tests/test_todo/test_tool_list_projects.py
@@ -1,0 +1,42 @@
+"""todo_list_projects 工具测试。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+from tools.todo.tool_list_projects import TodoListProjectsTool
+
+
+def _make_tool(mock_api, mock_client):
+    tool = TodoListProjectsTool(client=mock_client)
+    helper = tool.helper
+    type(helper).api = PropertyMock(return_value=mock_api)
+    return tool
+
+
+class TestListProjects:
+    def test_returns_all_fields(self, mock_api, mock_client):
+        p = MagicMock()
+        p.id = "p1"
+        p.name = "Work"
+        p.description = "Work tasks"
+        p.color = "blue"
+        p.order = 1
+        p.is_favorite = True
+        p.is_archived = False
+        p.is_shared = False
+        p.is_collapsed = False
+        p.parent_id = None
+        p.view_style = "list"
+        p.can_assign_tasks = True
+        p.is_inbox_project = False
+        p.workspace_id = "ws1"
+        p.folder_id = None
+        mock_api.get_projects.return_value = [[p]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False)
+
+        assert "success" in result
+        assert "project_id" in result
+        assert "description" in result
+        assert "color" in result
+        assert "is_favorite" in result

--- a/tests/test_todo/test_tool_list_sections.py
+++ b/tests/test_todo/test_tool_list_sections.py
@@ -1,0 +1,50 @@
+"""todo_list_sections 工具测试。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+from tools.todo.tool_list_sections import TodoListSectionsTool
+
+
+def _make_tool(mock_api, mock_client):
+    tool = TodoListSectionsTool(client=mock_client)
+    helper = tool.helper
+    type(helper).api = PropertyMock(return_value=mock_api)
+    return tool
+
+
+class TestListSections:
+    def test_list_all_sections(self, mock_api, mock_client):
+        s = MagicMock()
+        s.id = "s1"
+        s.name = "Backlog"
+        s.project_id = "p1"
+        s.order = 1
+        s.is_collapsed = False
+        mock_api.get_sections.return_value = [[s]]
+        p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False)
+        assert "success" in result
+
+    def test_filter_by_project(self, mock_api, mock_client):
+        s = MagicMock()
+        s.id = "s1"
+        s.name = "Backlog"
+        s.project_id = "p1"
+        s.order = 1
+        s.is_collapsed = False
+        mock_api.get_sections.return_value = [[s]]
+        p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, project_name="Work")
+        assert "success" in result
+
+    def test_nonexistent_project_returns_error(self, mock_api, mock_client):
+        mock_api.get_projects.return_value = [[]]
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, project_name="Nope")
+        assert "不存在" in result

--- a/tests/test_todo/test_tool_query.py
+++ b/tests/test_todo/test_tool_query.py
@@ -1,0 +1,55 @@
+"""todo_query 工具测试。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+from tools.todo.tool_query import TodoQueryTool
+
+
+def _make_tool(mock_api, mock_client):
+    tool = TodoQueryTool(client=mock_client)
+    helper = tool.helper
+    type(helper).api = PropertyMock(return_value=mock_api)
+    return tool
+
+
+class TestQuery:
+    def test_empty_task_id_returns_error(self, mock_api, mock_client):
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="")
+        assert "不能为空" in result
+
+    def test_nonexistent_task_returns_error(self, mock_api, mock_client):
+        mock_api.get_task.side_effect = Exception("not found")
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="nope")
+        assert "不存在" in result
+
+    def test_successful_query_returns_dict(self, mock_api, mock_client):
+        t = MagicMock()
+        t.id = "t1"
+        t.content = "Task"
+        t.description = "Desc"
+        t.project_id = "p1"
+        t.section_id = None
+        t.parent_id = None
+        t.labels = []
+        t.priority = 1
+        t.due = None
+        t.deadline = None
+        t.duration = None
+        t.order = 1
+        t.is_collapsed = False
+        t.assignee_id = None
+        t.assigner_id = None
+        t.creator_id = "u1"
+        t.is_completed = False
+        t.url = None
+        mock_api.get_task.return_value = t
+        p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="t1")
+        assert "success" in result
+        assert "task_id" in result

--- a/tests/test_todo/test_tool_update.py
+++ b/tests/test_todo/test_tool_update.py
@@ -1,0 +1,140 @@
+"""todo_update 工具测试。"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+from tools.todo.tool_update import TodoUpdateTool
+
+
+def _make_tool(mock_api, mock_client):
+    tool = TodoUpdateTool(client=mock_client)
+    helper = tool.helper
+    type(helper).api = PropertyMock(return_value=mock_api)
+    return tool
+
+
+def _fake_task(overrides=None):
+    """Create a fake task with sensible defaults."""
+    t = MagicMock()
+    t.id = "task1"
+    t.content = "Old content"
+    t.description = "Old desc"
+    t.project_id = "proj1"
+    t.section_id = None
+    t.parent_id = None
+    t.labels = []
+    t.priority = 1
+    t.due = None
+    t.deadline = None
+    t.duration = None
+    t.order = 1
+    t.is_collapsed = False
+    t.assignee_id = None
+    t.assigner_id = None
+    t.creator_id = "u1"
+    t.is_completed = False
+    t.url = None
+    if overrides:
+        for k, v in overrides.items():
+            setattr(t, k, v)
+    return t
+
+
+class TestValidation:
+    def test_empty_task_id_returns_error(self, mock_api, mock_client):
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="")
+        assert "不能为空" in result
+
+    def test_invalid_priority_returns_error(self, mock_api, mock_client):
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="t1", priority=5)
+        assert "无效" in result
+
+
+class TestUpdateFields:
+    def test_update_content_only(self, mock_api, mock_client):
+        mock_api.get_task.return_value = _fake_task()
+        mock_api.update_task.return_value = _fake_task({"content": "New content"})
+        p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="task1", content="New content")
+        assert "success" in result
+        mock_api.update_task.assert_called_once()
+        assert mock_api.update_task.call_args[1]["content"] == "New content"
+
+    def test_update_description(self, mock_api, mock_client):
+        mock_api.get_task.return_value = _fake_task()
+        mock_api.update_task.return_value = _fake_task({"description": "New desc"})
+        p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        result = tool._run(get_doc=False, task_id="task1", description="New desc")
+        assert "success" in result
+        assert mock_api.update_task.call_args[1]["description"] == "New desc"
+
+    def test_update_labels(self, mock_api, mock_client):
+        mock_api.get_task.return_value = _fake_task()
+        mock_api.update_task.return_value = _fake_task({"labels": ["urgent"]})
+        p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, task_id="task1", labels=["urgent"])
+        assert mock_api.update_task.call_args[1]["labels"] == ["urgent"]
+
+    def test_update_due_string(self, mock_api, mock_client):
+        mock_api.get_task.return_value = _fake_task()
+        mock_api.update_task.return_value = _fake_task()
+        p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, task_id="task1", due_string="next Friday")
+        assert mock_api.update_task.call_args[1]["due_string"] == "next Friday"
+
+
+class TestMoveTask:
+    def test_move_project(self, mock_api, mock_client):
+        current = _fake_task()
+        mock_api.get_task.return_value = current
+        mock_api.update_task.return_value = current
+        p1 = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
+        p2 = type("FakeProject", (), {"id": "proj2", "name": "Personal"})()
+        mock_api.get_projects.return_value = [[p1, p2]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, task_id="task1", project_name="Personal")
+        mock_api.move_task.assert_called_once_with(task_id="task1", project_id="proj2")
+
+    def test_move_section_within_project(self, mock_api, mock_client):
+        current = _fake_task({"project_id": "proj1", "section_id": None})
+        mock_api.get_task.return_value = current
+        mock_api.update_task.return_value = current
+        p1 = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
+        s1 = type("FakeSection", (), {"id": "sec1", "name": "Backlog", "project_id": "proj1"})()
+        mock_api.get_projects.return_value = [[p1]]
+        mock_api.get_sections.return_value = [[s1]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, task_id="task1", section_name="Backlog")
+        mock_api.move_task.assert_called_once_with(task_id="task1", section_id="sec1")
+
+    def test_no_move_when_same_project(self, mock_api, mock_client):
+        current = _fake_task({"project_id": "proj1"})
+        mock_api.get_task.return_value = current
+        mock_api.update_task.return_value = current
+        p1 = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
+        mock_api.get_projects.return_value = [[p1]]
+        mock_api.get_sections.return_value = [[]]
+
+        tool = _make_tool(mock_api, mock_client)
+        tool._run(get_doc=False, task_id="task1", project_name="Work")
+        mock_api.move_task.assert_not_called()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -32,6 +32,9 @@ def get_all_tools() -> list[BaseTool]:
     from tools.todo.tool_update import TodoUpdateTool
     from tools.todo.tool_query import TodoQueryTool
     from tools.todo.tool_list_projects import TodoListProjectsTool
+    from tools.todo.tool_list_sections import TodoListSectionsTool
+    from tools.todo.tool_list_labels import TodoListLabelsTool
+    from tools.todo.tool_add_quick import TodoAddQuickTool
 
     # Map
     from tools.map.tool_nearby import NearbySearchTool
@@ -94,6 +97,9 @@ def get_all_tools() -> list[BaseTool]:
         TodoUpdateTool(client=client),
         TodoQueryTool(client=client),
         TodoListProjectsTool(client=client),
+        TodoListSectionsTool(client=client),
+        TodoListLabelsTool(client=client),
+        TodoAddQuickTool(client=client),
         # Map
         NearbySearchTool(client=client),
         GeocodeTool(client=client),

--- a/tools/todo/TOOL.md
+++ b/tools/todo/TOOL.md
@@ -1,25 +1,79 @@
-# Todoist 任务管理领域知识
+# Todoist 任务管理 API 参考
 
-## 技能协作流程
-- 添加任务前，先调用 `todo_list_projects` 确认项目名是否存在
-- 如果用户说"明天下午"、"下周"等相对时间，先调用 `time_skill` 获取当前日期再转换
-- 任务完成后，建议调用 `todo_list` 确认状态已更新
-- `todo_query` 查不到任务时，先用 `todo_list` 列出全部任务再筛选
+## 工具列表
 
-## 常见陷阱
-- 优先级 4（紧急）仅在用户明确表达"非常急/立刻/马上"时使用
-- 不要在未确认项目存在时直接填写 project_name
-- 多个任务需分别调用 `todo_add`，不要试图合并为一次调用
+| 工具 | 功能 | 备注 |
+|------|------|------|
+| `todo_list_projects` | 列出所有项目及板块信息 | 添加/移动任务前先调用，确认项目名存在 |
+| `todo_list_sections` | 列出指定项目下的所有板块 | 可按 project_name 筛选 |
+| `todo_list_labels` | 列出所有标签 | 当前无已定义标签 |
+| `todo_list` | 列出未完成任务，支持筛选 | 参数：project_name / section_name / label / parent_id / ids / limit |
+| `todo_query` | 按 task_id 查询单个任务详情 | 查不到时回退到 todo_list |
+| `todo_add` | 添加新任务 | 完整参数控制 |
+| `todo_add_quick` | 快速添加任务 | 单字符串语法：内容 #项目 @标签 p3 明天下午 |
+| `todo_update` | 更新任务属性 | 支持 content / due / priority / description / labels / project_name / section_name 等 |
+| `todo_complete` | 完成任务 | 按 task_id |
+| `todo_uncomplete` | 重新打开已完成任务 | 按 task_id |
+| `todo_delete` | 删除任务 | 按 task_id |
 
-## 参数约定
-- `due_date` 支持自然语言（明天下午3点、下周五）或 `YYYY-MM-DD HH:MM`
-- `project_name` 大小写敏感，必须与 Todoist 中实际项目名一致
-- `priority`：1=低, 2=中, 3=高, 4=紧急
+## 操作规范
 
-## 错误处理规范
-| 错误场景 | 处理方式 |
-|----------|----------|
+### 添加任务（todo_add）
+
+**前置条件**：
+1. 用户表达相对时间（"明天""下周"）时，先通过 time_tool 获取当前日期再换算
+2. 调用 `todo_list_projects` 确认 project_name 存在
+
+**参数说明**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `content` | string | 任务名称，必填 |
+| `description` | string | 任务备注/描述 |
+| `due_string` | string | 自然语言截止时间（优先使用），与 due_date / due_datetime 互斥 |
+| `due_date` | string | 精确日期 `YYYY-MM-DD` 或 `YYYY-MM-DD HH:MM` |
+| `project_name` | string | 项目名，大小写敏感，需先确认存在 |
+| `section_name` | string | 板块名，需先确认该板块存在于目标项目中 |
+| `priority` | int | 1=低 / 2=中 / 3=高 / 4=紧急。仅用户明确表达紧急意图时用 p4 |
+| `labels` | string[] | 标签名列表 |
+| `auto_reminder` | bool | 设置了时间时自动添加默认提醒 |
+| `duration` | int | 预估时长数值（配合 duration_unit） |
+| `duration_unit` | "minute" \| "day" | 时长单位 |
+| `deadline_date` | string | ⚠️ 硬截止日期，当前 Todoist API 可能不支持（曾返回 403） |
+
+### 快速添加（todo_add_quick）
+
+单字符串语法，一行搞定。Todoist 自动解析其中的 `#项目名` `@标签` 和自然语言时间。
+
+```
+content: "买牛奶 #购物  明天下午3点 p2"
+```
+
+可选参数：
+- `note` — 附加备注
+- `reminder` — 提醒时间自然语言描述
+- `auto_reminder` — 默认 true
+
+### 更新任务（todo_update）
+
+支持修改 content、description、due_string/date/datetime、priority、labels、assignee_id、order、duration、deadline_date、project_name、section_name 等字段。
+
+**⚠️ 不稳定用法提醒**：
+- **板块间移动**：将任务从无板块状态移入板块（`section_name`），或跨板块移动时，当前实现可能返回 400 错误。稳定替代方案：删除原任务后在目标板块重新创建。
+- **deadline_date**：Todoist API 可能返回 403，不确定是否已开放。如遇错误，建议改用手动备注。
+
+### 查询任务
+
+- `todo_list` — 批量查询，支持按 project_name / section_name / label 筛选
+- `todo_query` — 单条精确查询，按 task_id。查不到时回退到 todo_list
+
+## 错误处理对照表
+
+| 错误场景 | 推荐处理方式 |
+|----------|------------|
 | content 为空 | 提示用户提供任务名称 |
-| project_name 不存在 | 调用 `todo_list_projects` 列出可用项目供用户选择 |
-| task_id 无效 | 调用 `todo_list` 列出任务后让用户确认 |
-| due_date 格式错误 | 尝试重新解析，或让用户提供明确格式 |
+| project_name 不存在 | 列出可用项目供用户确认 |
+| task_id 无效 | 列出全部任务让用户确认 |
+| due_date 格式错误 | 换一种格式重试，仍失败则请求用户提供准确时间 |
+| 板块移动报 400 | 删除 + 重建，在目标板块重新添加 |
+| deadline_date 报 403 | 改用 description 备注硬截止日期 |

--- a/tools/todo/todo_base.py
+++ b/tools/todo/todo_base.py
@@ -1,8 +1,9 @@
 """Todoist API 共享封装（内部依赖，不是 Tool）。"""
 
-from datetime import datetime
+from datetime import date, datetime
 
 from todoist_api_python.api import TodoistAPI
+from todoist_api_python.models import Label, Project, Section, Task
 
 
 class TodoAPIHelper:
@@ -20,7 +21,10 @@ class TodoAPIHelper:
             self._api = TodoistAPI(self._token)
         return self._api
 
+    # ── 项目 ──
+
     def get_project_id(self, project_name: str) -> str | None:
+        """按名称查找 project ID（大小写不敏感）。"""
         for projects in self.api.get_projects():
             for project in projects:
                 if project.name.lower() == project_name.lower():
@@ -28,14 +32,70 @@ class TodoAPIHelper:
         return None
 
     def get_project_name(self, project_id: str) -> str:
+        """按 ID 查找项目名称，未找到返回 'Inbox'。"""
         for projects in self.api.get_projects():
             for project in projects:
                 if project.id == project_id:
                     return project.name
         return "Inbox"
 
+    # ── 分区 ──
+
+    def get_section_id(self, section_name: str, project_id: str) -> str | None:
+        """按名称和所属项目查找 section ID。"""
+        for sections in self.api.get_sections(project_id=project_id):
+            for section in sections:
+                if section.name.lower() == section_name.lower():
+                    return section.id
+        return None
+
+    def get_section_name(self, section_id: str, project_id: str | None = None) -> str | None:
+        """按 ID 查找 section 名称。传入 project_id 可缩小搜索范围。"""
+        for sections in self.api.get_sections(project_id=project_id):
+            for section in sections:
+                if section.id == section_id:
+                    return section.name
+        return None
+
+    def find_section_global(self, section_name: str) -> tuple[str, str] | None:
+        """在所有项目中查找指定名称的 section，返回 (project_id, section_id)。"""
+        for sections in self.api.get_sections():
+            for section in sections:
+                if section.name.lower() == section_name.lower():
+                    return section.project_id, section.id
+        return None
+
+    def get_sections_by_project(self, project_name: str) -> list[Section]:
+        """按项目名获取所有分区列表。"""
+        pid = self.get_project_id(project_name)
+        if pid is None:
+            return []
+        result: list[Section] = []
+        for sections in self.api.get_sections(project_id=pid):
+            result.extend(sections)
+        return result
+
+    def get_all_sections(self) -> list[Section]:
+        """获取所有项目的所有分区。"""
+        result: list[Section] = []
+        for sections in self.api.get_sections():
+            result.extend(sections)
+        return result
+
+    # ── 标签 ──
+
+    def get_all_labels(self) -> list[Label]:
+        """获取所有标签。"""
+        result: list[Label] = []
+        for labels in self.api.get_labels():
+            result.extend(labels)
+        return result
+
+    # ── 日期解析 ──
+
     @staticmethod
     def parse_date(date_str: str) -> datetime | None:
+        """解析日期字符串为 datetime（兼容 YYYY-MM-DD / YYYY-MM-DD HH:MM / YYYY-MM-DDTHH:MM）。"""
         formats = ["%Y-%m-%d", "%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M"]
         for fmt in formats:
             try:
@@ -45,7 +105,29 @@ class TodoAPIHelper:
         return None
 
     @staticmethod
+    def parse_deadline(date_str: str) -> date | None:
+        """解析 deadline 日期字符串为 date 对象（仅 YYYY-MM-DD）。"""
+        try:
+            return datetime.strptime(date_str, "%Y-%m-%d").date()
+        except (ValueError, TypeError):
+            return None
+
+    @staticmethod
+    def parse_datetime(date_str: str) -> datetime | None:
+        """解析含时间的日期字符串为 datetime 对象。"""
+        formats = ["%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M", "%Y-%m-%d"]
+        for fmt in formats:
+            try:
+                return datetime.strptime(date_str, fmt)
+            except (ValueError, TypeError):
+                continue
+        return None
+
+    # ── 格式化（旧接口，保留向后兼容）──
+
+    @staticmethod
     def format_due_date(task) -> str | None:
+        """从 task.due 中提取日期字符串。"""
         if task.due and task.due.date:
             return str(task.due.date)
         return None
@@ -53,3 +135,100 @@ class TodoAPIHelper:
     @staticmethod
     def now_str() -> str:
         return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    # ── 统一序列化 ──
+
+    def task_to_dict(self, task: Task) -> dict:
+        """Task → 完整响应字典。供 add / update / query / list / add_quick 统一使用。"""
+        due_dict: dict | None = None
+        if task.due:
+            due_dict = {
+                "date": str(task.due.date) if task.due.date else None,
+                "string": task.due.string,
+                "lang": task.due.lang,
+                "is_recurring": task.due.is_recurring,
+                "timezone": task.due.timezone,
+            }
+
+        deadline_dict: dict | None = None
+        if task.deadline:
+            deadline_dict = {
+                "date": str(task.deadline.date) if task.deadline.date else None,
+                "lang": task.deadline.lang,
+            }
+
+        duration_dict: dict | None = None
+        if task.duration:
+            duration_dict = {
+                "amount": task.duration.amount,
+                "unit": task.duration.unit,
+            }
+
+        return {
+            "task_id": task.id,
+            "content": task.content,
+            "description": task.description,
+            "project_id": task.project_id,
+            "project_name": self.get_project_name(task.project_id),
+            "section_id": task.section_id,
+            "section_name": (
+                self.get_section_name(task.section_id, task.project_id)
+                if task.section_id
+                else None
+            ),
+            "parent_id": task.parent_id,
+            "labels": task.labels,
+            "priority": task.priority,
+            "due": due_dict,
+            "deadline": deadline_dict,
+            "duration": duration_dict,
+            "order": task.order,
+            "is_collapsed": task.is_collapsed,
+            "assignee_id": task.assignee_id,
+            "assigner_id": task.assigner_id,
+            "creator_id": task.creator_id,
+            "is_completed": task.is_completed,
+            "url": getattr(task, "url", None),
+        }
+
+    def project_to_dict(self, project: Project) -> dict:
+        """Project → 响应字典。"""
+        return {
+            "project_id": project.id,
+            "name": project.name,
+            "description": project.description,
+            "color": project.color,
+            "order": project.order,
+            "is_favorite": project.is_favorite,
+            "is_archived": project.is_archived,
+            "is_shared": project.is_shared,
+            "is_collapsed": project.is_collapsed,
+            "parent_id": project.parent_id,
+            "view_style": project.view_style,
+            "can_assign_tasks": project.can_assign_tasks,
+            "is_inbox_project": project.is_inbox_project,
+            "workspace_id": project.workspace_id,
+            "folder_id": project.folder_id,
+        }
+
+    def section_to_dict(self, section: Section) -> dict:
+        """Section → 响应字典。"""
+        return {
+            "section_id": section.id,
+            "name": section.name,
+            "project_id": section.project_id,
+            "project_name": self.get_project_name(section.project_id),
+            "order": section.order,
+            "is_collapsed": section.is_collapsed,
+        }
+
+    @staticmethod
+    def label_to_dict(label: Label) -> dict:
+        """Label → 响应字典。"""
+        return {
+            "label_id": label.id,
+            "name": label.name,
+            "color": label.color,
+            "order": label.order,
+            "is_favorite": label.is_favorite,
+        }

--- a/tools/todo/tool_add.py
+++ b/tools/todo/tool_add.py
@@ -1,5 +1,7 @@
 """Tool: todo_add — 向 Todoist 添加新任务。"""
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 from tools.base import ToolBase, format_error, format_success
@@ -14,14 +16,80 @@ class TodoAddInput(BaseModel):
         description="设为 true 以获取 Todoist 领域知识文档（首次使用或不确定参数规则时建议先调用）",
     )
     content: str = Field(default="", description="任务名称/内容，例如'完成项目报告'")
+    description: str = Field(
+        default="",
+        description="任务描述/备注，例如详细的背景说明或 checklist",
+    )
+    due_string: str | None = Field(
+        default=None,
+        description=(
+            "截止日期的自然语言描述，例如 next Monday、tomorrow at 3pm、every Friday"
+            " 等。与 due_date / due_datetime 互斥，优先使用 due_string"
+        ),
+    )
+    due_lang: str | None = Field(
+        default=None,
+        description="due_string 的解析语种，如 'en'（默认）、'zh' 等",
+    )
     due_date: str | None = Field(
         default=None,
-        description="截止日期。支持自然语言（明天下午3点、下周五）或 YYYY-MM-DD HH:MM",
+        description="截止日期。支持 YYYY-MM-DD 或 YYYY-MM-DD HH:MM 格式。与 due_string / due_datetime 互斥",
+    )
+    due_datetime: str | None = Field(
+        default=None,
+        description="精确截止时间，YYYY-MM-DD HH:MM 格式。与 due_string / due_date 互斥",
     )
     priority: int = Field(default=1, description="1=低, 2=中, 3=高, 4=紧急")
     project_name: str = Field(
         default="Inbox",
         description="所属项目名。务必先通过 todo_list_projects 确认项目存在",
+    )
+    section_name: str | None = Field(
+        default=None,
+        description=(
+            "分区名（项目下的 section）。传入后会自动解析为 section_id。"
+            " 务必先通过 todo_list_projects 查看项目的可用 section"
+        ),
+    )
+    labels: list[str] | None = Field(
+        default=None,
+        description="标签名称列表，如 ['urgent', 'work']。注意是标签名而非 ID",
+    )
+    parent_id: str | None = Field(
+        default=None,
+        description="父任务 ID。用于创建子任务",
+    )
+    assignee_id: str | None = Field(
+        default=None,
+        description="指派给的用户 ID",
+    )
+    order: int | None = Field(
+        default=None,
+        description="任务在项目或分区中的排序位置",
+    )
+    auto_reminder: bool | None = Field(
+        default=None,
+        description="设为 true 则在设置了时间时自动添加默认提醒",
+    )
+    auto_parse_labels: bool | None = Field(
+        default=None,
+        description="设为 true 则从 content 中解析 #标签 和 @标签 语法",
+    )
+    duration: int | None = Field(
+        default=None,
+        description="预估时长数值（需配合 duration_unit 使用）",
+    )
+    duration_unit: Literal["minute", "day"] | None = Field(
+        default=None,
+        description="时长单位，'minute' 或 'day'",
+    )
+    deadline_date: str | None = Field(
+        default=None,
+        description="硬截止期限日期，YYYY-MM-DD 格式。与 due 不同，deadline 不绑定时间",
+    )
+    deadline_lang: str | None = Field(
+        default=None,
+        description="deadline_date 的解析语种",
     )
 
 
@@ -45,9 +113,24 @@ class TodoAddTool(ToolBase):
         self,
         get_doc: bool = False,
         content: str = "",
+        description: str = "",
+        due_string: str | None = None,
+        due_lang: str | None = None,
         due_date: str | None = None,
+        due_datetime: str | None = None,
         priority: int = 1,
         project_name: str = "Inbox",
+        section_name: str | None = None,
+        labels: list[str] | None = None,
+        parent_id: str | None = None,
+        assignee_id: str | None = None,
+        order: int | None = None,
+        auto_reminder: bool | None = None,
+        auto_parse_labels: bool | None = None,
+        duration: int | None = None,
+        duration_unit: Literal["minute", "day"] | None = None,
+        deadline_date: str | None = None,
+        deadline_lang: str | None = None,
     ) -> str:
         if get_doc:
             return self._load_doc()
@@ -69,22 +152,50 @@ class TodoAddTool(ToolBase):
                 f"项目 '{project_name}' 不存在。请先调用 todo_list_projects 查看可用项目"
             )
 
+        section_id = None
+        if section_name:
+            section_id = self.helper.get_section_id(section_name, project_id)
+            if section_id is None:
+                return format_error(
+                    f"项目 '{project_name}' 下不存在分区 '{section_name}'。"
+                    " 请先调用 todo_list_projects 查看可用分区"
+                )
+
         try:
-            due_date_obj = self.helper.parse_date(due_date) if due_date else None
+            description_val = description or None
+            due_date_obj = None
+            if due_date:
+                parsed_due = self.helper.parse_date(due_date)
+                if parsed_due:
+                    due_date_obj = parsed_due.date()
+            due_datetime_obj = (
+                self.helper.parse_datetime(due_datetime) if due_datetime else None
+            )
+            deadline_date_obj = (
+                self.helper.parse_deadline(deadline_date) if deadline_date else None
+            )
+
             task = api.add_task(
                 content=content,
+                description=description_val,
                 project_id=project_id,
+                section_id=section_id,
                 priority=priority,
+                due_string=due_string,
+                due_lang=due_lang,
                 due_date=due_date_obj,
+                due_datetime=due_datetime_obj,
+                labels=labels,
+                parent_id=parent_id,
+                assignee_id=assignee_id,
+                order=order,
+                auto_reminder=auto_reminder,
+                auto_parse_labels=auto_parse_labels,
+                duration=duration,
+                duration_unit=duration_unit,
+                deadline_date=deadline_date_obj,
+                deadline_lang=deadline_lang,
             )
-            return format_success(
-                {
-                    "task_id": task.id,
-                    "content": task.content,
-                    "due_date": self.helper.format_due_date(task),
-                    "priority": task.priority,
-                    "project": self.helper.get_project_name(task.project_id),
-                }
-            )
+            return format_success(self.helper.task_to_dict(task))
         except Exception as e:
             return format_error(f"添加任务失败: {e}")

--- a/tools/todo/tool_add_quick.py
+++ b/tools/todo/tool_add_quick.py
@@ -1,0 +1,81 @@
+"""Tool: todo_add_quick — 使用 Quick Add 语法快速添加任务。"""
+
+from pydantic import BaseModel, Field
+
+from tools.base import ToolBase, format_error, format_success
+from tools.todo.todo_base import TodoAPIHelper
+
+
+class TodoAddQuickInput(BaseModel):
+    get_doc: bool = Field(
+        default=False,
+        description="设为 true 以获取 Todoist 领域知识文档",
+    )
+    text: str = Field(
+        default="",
+        description=(
+            "Quick Add 语法文本。Todoist 会自动解析其中的 #项目 @标签 自然语言日期 p1-p4 优先级等。"
+            " 例如：'买牛奶 #购物 @日用品 明天下午3点 p2'"
+        ),
+    )
+    note: str | None = Field(
+        default=None,
+        description="附加备注/说明",
+    )
+    reminder: str | None = Field(
+        default=None,
+        description="提醒日期/时间的自然语言描述，例如 '30分钟前'、'明天上午9点'",
+    )
+    auto_reminder: bool = Field(
+        default=True,
+        description="如果设置了时间，自动添加默认提醒",
+    )
+
+
+class TodoAddQuickTool(ToolBase):
+    name: str = "todo_add_quick"
+    description: str = (
+        "使用 Quick Add 语法快速向 Todoist 添加任务。"
+        "支持在 text 中直接写 #项目名、@标签名、自然语言日期、p1-p4 优先级等。"
+        "比 todo_add 更简洁，但无法精细控制所有字段。"
+        "[调用积极性: 可自由看情况调用] [get_doc: 仅在发生错误时 get_doc]"
+    )
+    args_schema: type[BaseModel] = TodoAddQuickInput
+
+    _helper: TodoAPIHelper | None = None
+
+    @property
+    def helper(self) -> TodoAPIHelper:
+        if self._helper is None:
+            self._helper = TodoAPIHelper(self.client._todoist_token)
+        return self._helper
+
+    def _run(
+        self,
+        get_doc: bool = False,
+        text: str = "",
+        note: str | None = None,
+        reminder: str | None = None,
+        auto_reminder: bool = True,
+    ) -> str:
+        if get_doc:
+            return self._load_doc()
+
+        if not text:
+            return format_error("text 不能为空，请提供任务描述")
+
+        try:
+            api = self.helper.api
+        except ValueError as e:
+            return format_error(str(e))
+
+        try:
+            task = api.add_task_quick(
+                text=text,
+                note=note,
+                reminder=reminder,
+                auto_reminder=auto_reminder,
+            )
+            return format_success(self.helper.task_to_dict(task))
+        except Exception as e:
+            return format_error(f"快速添加任务失败: {e}")

--- a/tools/todo/tool_list.py
+++ b/tools/todo/tool_list.py
@@ -8,11 +8,43 @@ from tools.todo.todo_base import TodoAPIHelper
 
 class TodoListInput(BaseModel):
     get_doc: bool = Field(default=False, description="设为 true 以获取使用说明")
+    project_name: str | None = Field(
+        default=None,
+        description="按项目名筛选。先通过 todo_list_projects 确认项目名",
+    )
+    section_name: str | None = Field(
+        default=None,
+        description=(
+            "按分区名筛选。可配合 project_name 一起使用，"
+            "如果未传 project_name 则在所有项目中查找该分区名"
+        ),
+    )
+    label: str | None = Field(
+        default=None,
+        description="按标签名筛选，例如 'urgent'、'work'",
+    )
+    parent_id: str | None = Field(
+        default=None,
+        description="按父任务 ID 筛选，只返回该任务的子任务",
+    )
+    ids: list[str] | None = Field(
+        default=None,
+        description="按任务 ID 列表精确查询，例如 ['id1', 'id2']",
+    )
+    limit: int | None = Field(
+        default=None,
+        description="返回数量上限（1-200）",
+        ge=1,
+        le=200,
+    )
 
 
 class TodoListTool(ToolBase):
     name: str = "todo_list"
-    description: str = "列出 Todoist 中所有未完成任务，按 ID 排序。直接调用即可。[调用积极性: 可自由看情况调用] [get_doc: 仅在发生错误时 get_doc]"
+    description: str = (
+        "列出 Todoist 中所有未完成任务，支持按项目、分区、标签等条件筛选。"
+        " [调用积极性: 可自由看情况调用] [get_doc: 仅在发生错误时 get_doc]"
+    )
     args_schema: type[BaseModel] = TodoListInput
 
     _helper: TodoAPIHelper | None = None
@@ -23,7 +55,16 @@ class TodoListTool(ToolBase):
             self._helper = TodoAPIHelper(self.client._todoist_token)
         return self._helper
 
-    def _run(self, get_doc: bool = False) -> str:
+    def _run(
+        self,
+        get_doc: bool = False,
+        project_name: str | None = None,
+        section_name: str | None = None,
+        label: str | None = None,
+        parent_id: str | None = None,
+        ids: list[str] | None = None,
+        limit: int | None = None,
+    ) -> str:
         if get_doc:
             return self._load_doc()
 
@@ -32,22 +73,45 @@ class TodoListTool(ToolBase):
         except ValueError as e:
             return format_error(str(e))
 
+        # 构建过滤参数
+        kwargs: dict = {}
+
+        if project_name:
+            pid = self.helper.get_project_id(project_name)
+            if pid is None:
+                return format_success({"total": 0, "tasks": []})
+            kwargs["project_id"] = pid
+
+        if section_name:
+            if project_name:
+                # 已知项目上下文
+                sid = self.helper.get_section_id(
+                    section_name, kwargs.get("project_id", "")
+                )
+                if sid is None:
+                    return format_success({"total": 0, "tasks": []})
+                kwargs["section_id"] = sid
+            else:
+                # 跨项目查找
+                result = self.helper.find_section_global(section_name)
+                if result is None:
+                    return format_success({"total": 0, "tasks": []})
+                kwargs["section_id"] = result[1]
+
+        if label:
+            kwargs["label"] = label
+        if parent_id:
+            kwargs["parent_id"] = parent_id
+        if ids:
+            kwargs["ids"] = ids
+        if limit:
+            kwargs["limit"] = limit
+
         all_tasks = []
-        for tasks in api.get_tasks():
+        for tasks in api.get_tasks(**kwargs):
             all_tasks.extend(tasks)
 
-        task_list = []
-        for task in all_tasks:
-            task_list.append(
-                {
-                    "task_id": task.id,
-                    "content": task.content,
-                    "due_date": self.helper.format_due_date(task),
-                    "priority": task.priority,
-                    "project": self.helper.get_project_name(task.project_id),
-                    "is_completed": task.is_completed,
-                }
-            )
+        task_list = [self.helper.task_to_dict(t) for t in all_tasks]
         task_list.sort(key=lambda x: x["task_id"])
 
         return format_success({"total": len(task_list), "tasks": task_list})

--- a/tools/todo/tool_list_labels.py
+++ b/tools/todo/tool_list_labels.py
@@ -1,0 +1,37 @@
+"""Tool: todo_list_labels — 列出所有标签。"""
+
+from pydantic import BaseModel, Field
+
+from tools.base import ToolBase, format_error, format_success
+from tools.todo.todo_base import TodoAPIHelper
+
+
+class TodoListLabelsInput(BaseModel):
+    get_doc: bool = Field(default=False, description="设为 true 以获取使用说明")
+
+
+class TodoListLabelsTool(ToolBase):
+    name: str = "todo_list_labels"
+    description: str = (
+        "列出 Todoist 中所有标签。添加任务前可通过此工具确认可用的标签名。"
+        "[调用积极性: 可自由看情况调用] [get_doc: 仅在发生错误时 get_doc]"
+    )
+    args_schema: type[BaseModel] = TodoListLabelsInput
+
+    _helper: TodoAPIHelper | None = None
+
+    @property
+    def helper(self) -> TodoAPIHelper:
+        if self._helper is None:
+            self._helper = TodoAPIHelper(self.client._todoist_token)
+        return self._helper
+
+    def _run(self, get_doc: bool = False) -> str:
+        if get_doc:
+            return self._load_doc()
+
+        all_labels = self.helper.get_all_labels()
+        label_list = [self.helper.label_to_dict(l) for l in all_labels]
+        label_list.sort(key=lambda x: x["name"])
+
+        return format_success({"total": len(label_list), "labels": label_list})

--- a/tools/todo/tool_list_projects.py
+++ b/tools/todo/tool_list_projects.py
@@ -12,7 +12,7 @@ class TodoListProjectsInput(BaseModel):
 
 class TodoListProjectsTool(ToolBase):
     name: str = "todo_list_projects"
-    description: str = "列出 Todoist 中所有项目及其 ID。添加任务前建议先调用以确认项目名。[调用积极性: 可自由看情况调用] [get_doc: 仅在发生错误时 get_doc]"
+    description: str = "列出 Todoist 中所有项目及其详细信息。添加任务前建议先调用以确认项目名。[调用积极性: 可自由看情况调用] [get_doc: 仅在发生错误时 get_doc]"
     args_schema: type[BaseModel] = TodoListProjectsInput
 
     _helper: TodoAPIHelper | None = None
@@ -36,7 +36,7 @@ class TodoListProjectsTool(ToolBase):
         for projects in api.get_projects():
             all_projects.extend(projects)
 
-        project_list = [{"project_id": p.id, "name": p.name} for p in all_projects]
+        project_list = [self.helper.project_to_dict(p) for p in all_projects]
         project_list.sort(key=lambda x: x["project_id"])
 
         return format_success({"total": len(project_list), "projects": project_list})

--- a/tools/todo/tool_list_sections.py
+++ b/tools/todo/tool_list_sections.py
@@ -1,0 +1,51 @@
+"""Tool: todo_list_sections — 列出分区。"""
+
+from pydantic import BaseModel, Field
+
+from tools.base import ToolBase, format_error, format_success
+from tools.todo.todo_base import TodoAPIHelper
+
+
+class TodoListSectionsInput(BaseModel):
+    get_doc: bool = Field(default=False, description="设为 true 以获取使用说明")
+    project_name: str | None = Field(
+        default=None,
+        description="按项目名筛选。不传则列出所有项目的分区",
+    )
+
+
+class TodoListSectionsTool(ToolBase):
+    name: str = "todo_list_sections"
+    description: str = (
+        "列出 Todoist 中的分区（section），可按项目筛选。"
+        "添加或移动任务到特定分区前建议先调用此工具确认分区名。"
+        "[调用积极性: 可自由看情况调用] [get_doc: 仅在发生错误时 get_doc]"
+    )
+    args_schema: type[BaseModel] = TodoListSectionsInput
+
+    _helper: TodoAPIHelper | None = None
+
+    @property
+    def helper(self) -> TodoAPIHelper:
+        if self._helper is None:
+            self._helper = TodoAPIHelper(self.client._todoist_token)
+        return self._helper
+
+    def _run(self, get_doc: bool = False, project_name: str | None = None) -> str:
+        if get_doc:
+            return self._load_doc()
+
+        if project_name:
+            pid = self.helper.get_project_id(project_name)
+            if pid is None:
+                return format_error(
+                    f"项目 '{project_name}' 不存在。请先调用 todo_list_projects 查看可用项目"
+                )
+            all_sections = self.helper.get_sections_by_project(project_name)
+        else:
+            all_sections = self.helper.get_all_sections()
+
+        section_list = [self.helper.section_to_dict(s) for s in all_sections]
+        section_list.sort(key=lambda x: x["section_id"])
+
+        return format_success({"total": len(section_list), "sections": section_list})

--- a/tools/todo/tool_query.py
+++ b/tools/todo/tool_query.py
@@ -37,15 +37,6 @@ class TodoQueryTool(ToolBase):
 
         try:
             task = api.get_task(task_id)
-            return format_success(
-                {
-                    "task_id": task.id,
-                    "content": task.content,
-                    "due_date": self.helper.format_due_date(task),
-                    "priority": task.priority,
-                    "project": self.helper.get_project_name(task.project_id),
-                    "is_completed": task.is_completed,
-                }
-            )
+            return format_success(self.helper.task_to_dict(task))
         except Exception as e:
             return format_error(f"任务不存在: {e}")

--- a/tools/todo/tool_update.py
+++ b/tools/todo/tool_update.py
@@ -1,5 +1,7 @@
 """Tool: todo_update — 更新任务属性。"""
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 from tools.base import ToolBase, format_error, format_success
@@ -7,25 +9,57 @@ from tools.todo.todo_base import TodoAPIHelper
 
 
 class TodoUpdateInput(BaseModel):
-    get_doc: bool = Field(
-        default=False, description="设为 true 以获取 Todoist 领域知识文档"
-    )
+    get_doc: bool = Field(default=False, description="设为 true 以获取 Todoist 领域知识文档")
     task_id: str = Field(default="", description="要更新的任务 ID")
     content: str | None = Field(default=None, description="新的任务名称")
+    description: str | None = Field(default=None, description="新的任务描述/备注")
+    due_string: str | None = Field(
+        default=None,
+        description="截止日期的自然语言描述，例如 next Monday、tomorrow at 3pm",
+    )
+    due_lang: str | None = Field(default=None, description="due_string 的解析语种")
     due_date: str | None = Field(
-        default=None, description="新的截止日期，YYYY-MM-DD 或 YYYY-MM-DD HH:MM"
+        default=None,
+        description="新的截止日期，YYYY-MM-DD 或 YYYY-MM-DD HH:MM。传空字符串 '' 可清除现有日期",
+    )
+    due_datetime: str | None = Field(
+        default=None,
+        description="新的精确截止时间，YYYY-MM-DD HH:MM 格式",
     )
     priority: int | None = Field(default=None, description="1=低, 2=中, 3=高, 4=紧急")
+    labels: list[str] | None = Field(default=None, description="新的标签列表（覆盖原有标签）")
+    assignee_id: str | None = Field(default=None, description="重新指派给的用户 ID")
+    order: int | None = Field(default=None, description="在项目/分区中的排序位置")
+    day_order: int | None = Field(default=None, description="在今日/最近7天视图中的排序位置")
+    collapsed: bool | None = Field(default=None, description="是否折叠子任务")
+    duration: int | None = Field(default=None, description="预估时长数值")
+    duration_unit: Literal["minute", "day"] | None = Field(
+        default=None, description="时长单位，'minute' 或 'day'"
+    )
+    deadline_date: str | None = Field(
+        default=None, description="新的硬截止期限日期 YYYY-MM-DD"
+    )
+    deadline_lang: str | None = Field(default=None, description="deadline_date 的解析语种")
+
+    # 移动相关
     project_name: str | None = Field(
         default=None,
         description="新的项目名（用于移动任务）。先通过 todo_list_projects 确认存在",
+    )
+    section_name: str | None = Field(
+        default=None,
+        description=(
+            "新的分区名（用于将任务移动到另一分区）。"
+            " 如果同时传了 project_name 则在该项目中查找，否则在当前项目中查找"
+        ),
     )
 
 
 class TodoUpdateTool(ToolBase):
     name: str = "todo_update"
     description: str = (
-        "更新 Todoist 中现有任务的内容、截止日期、优先级或所属项目。"
+        "更新 Todoist 中现有任务的内容、截止日期、优先级、描述、标签、指派等属性，"
+        "或将任务移动到其他项目/分区。"
         "[调用积极性: 可自由看情况调用] [get_doc: 仅在发生错误时 get_doc]"
     )
     args_schema: type[BaseModel] = TodoUpdateInput
@@ -43,9 +77,23 @@ class TodoUpdateTool(ToolBase):
         get_doc: bool = False,
         task_id: str = "",
         content: str | None = None,
+        description: str | None = None,
+        due_string: str | None = None,
+        due_lang: str | None = None,
         due_date: str | None = None,
+        due_datetime: str | None = None,
         priority: int | None = None,
+        labels: list[str] | None = None,
+        assignee_id: str | None = None,
+        order: int | None = None,
+        day_order: int | None = None,
+        collapsed: bool | None = None,
+        duration: int | None = None,
+        duration_unit: Literal["minute", "day"] | None = None,
+        deadline_date: str | None = None,
+        deadline_lang: str | None = None,
         project_name: str | None = None,
+        section_name: str | None = None,
     ) -> str:
         if get_doc:
             return self._load_doc()
@@ -62,7 +110,10 @@ class TodoUpdateTool(ToolBase):
         try:
             current_task = api.get_task(task_id)
 
-            # 如果需要移动项目
+            # ── 移动逻辑：project 和/或 section ──
+            move_kwargs: dict[str, str] = {}
+            section_target_project: str | None = None
+
             if project_name:
                 pid = self.helper.get_project_id(project_name)
                 if pid is None:
@@ -70,34 +121,55 @@ class TodoUpdateTool(ToolBase):
                         f"项目 '{project_name}' 不存在。请先调用 todo_list_projects 查看可用项目"
                     )
                 if pid != current_task.project_id:
-                    api.move_task(task_id=task_id, project_id=pid)
+                    move_kwargs["project_id"] = pid
+                section_target_project = pid
 
-            # 解析日期
-            due_date_obj = None
-            if due_date is not None:
-                if due_date == "":
-                    due_date_obj = None
-                else:
-                    due_date_obj = self.helper.parse_date(due_date)
-                    if due_date_obj is None:
-                        return format_error(
-                            "due_date 格式错误，应为 YYYY-MM-DD 或 YYYY-MM-DD HH:MM"
-                        )
+            if section_name:
+                ctx_project = section_target_project or current_task.project_id
+                sid = self.helper.get_section_id(section_name, ctx_project)
+                if sid is None:
+                    return format_error(
+                        f"项目 '{self.helper.get_project_name(ctx_project)}'"
+                        f" 下不存在分区 '{section_name}'"
+                    )
+                # section 隐式关联了 project，传 section_id 即可
+                move_kwargs["section_id"] = sid
+
+            if move_kwargs:
+                api.move_task(task_id=task_id, **move_kwargs)
+
+            # ── 字段更新 ──
+            parsed_due_date = None
+            if due_date:
+                parsed = self.helper.parse_date(due_date)
+                parsed_due_date = parsed.date() if parsed else None
+
+            due_datetime_obj = (
+                self.helper.parse_datetime(due_datetime) if due_datetime else None
+            )
+            deadline_date_obj = (
+                self.helper.parse_deadline(deadline_date) if deadline_date else None
+            )
 
             task = api.update_task(
                 task_id=task_id,
                 content=content,
+                description=description,
+                labels=labels,
                 priority=priority,
-                due_date=due_date_obj,
+                due_string=due_string,
+                due_lang=due_lang,
+                due_date=parsed_due_date,
+                due_datetime=due_datetime_obj,
+                assignee_id=assignee_id,
+                order=order,
+                day_order=day_order,
+                collapsed=collapsed,
+                duration=duration,
+                duration_unit=duration_unit,
+                deadline_date=deadline_date_obj,
+                deadline_lang=deadline_lang,
             )
-            return format_success(
-                {
-                    "task_id": task.id,
-                    "content": task.content,
-                    "due_date": self.helper.format_due_date(task),
-                    "priority": task.priority,
-                    "project": self.helper.get_project_name(task.project_id),
-                }
-            )
+            return format_success(self.helper.task_to_dict(task))
         except Exception as e:
             return format_error(f"任务不存在或更新失败: {e}")


### PR DESCRIPTION

## 变更内容

### 增强现有工具（6 个）
- **todo_base.py** — 新增 10 个 helper 方法（`task_to_dict`, `project_to_dict` 等统一序列化）
- **tool_add.py** — 补齐 12 个 SDK 字段（labels, parent_id, due_datetime, duration, deadline 等）
- **tool_update.py** — 补齐 14 个 SDK 字段 + section 移动支持
- **tool_list.py** — 新增 6 个过滤参数（project_name, section_name, label, parent_id, ids, limit）
- **tool_query.py** / **tool_list_projects.py** — 全字段回显

### 新增工具（3 个）
- **tool_list_sections.py** — 列出分区（可按项目筛选）
- **tool_list_labels.py** — 列出所有标签
- **tool_add_quick.py** — Quick Add 自然语言快速添加

### 测试
- 新建 `tests/test_todo/` 测试套件，70 个测试用例全部通过

### 注册
- `tools/__init__.py` 注册 3 个新工具，共 44 个工具（含 11 个 todo 工具）

Closes #169
