### PR TITLE
style(tools): 工具气泡阴影浓度下调一级

### DIFF
--- a/web/src/components/tools/_shared/shared.css
+++ b/web/src/components/tools/_shared/shared.css
@@ -5,7 +5,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-card);
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-sm);
   overflow: hidden;
 }
 


### PR DESCRIPTION

## 变更内容

- 工具气泡 `.tool-bubble` 阴影从 `--shadow-md`（0 2px 8px rgba(0,0,0,0.08)）下调至 `--shadow-sm`（0 1px 4px rgba(0,0,0,0.06)）
- 仅影响工具气泡，不影响消息气泡等其他组件
