### PR TITLE
fix(api): Todoist 分区/标签工具气泡空白

### DIFF
--- a/api/callbacks/tool_extractors.py
+++ b/api/callbacks/tool_extractors.py
@@ -109,6 +109,44 @@ def _extract_todo_projects(
     return result
 
 
+@register("todo_list_sections")
+def _extract_todo_sections(
+    _tool_name: str,
+    parsed: dict[str, Any],
+    _tool_input: str | None = None,
+) -> dict[str, Any] | None:
+    """返回 total, sections（含 project_name 上下文）。"""
+    data = _get_data(parsed)
+    if data is None:
+        return None
+    result: dict[str, Any] = {}
+    result["total"] = data.get("total")
+    sections = data.get("sections", [])
+    if isinstance(sections, list):
+        result["sections"] = sections
+        if sections and not result.get("project_name"):
+            result["project_name"] = sections[0].get("project_name")
+    return result if result.get("sections") is not None else None
+
+
+@register("todo_list_labels")
+def _extract_todo_labels(
+    _tool_name: str,
+    parsed: dict[str, Any],
+    _tool_input: str | None = None,
+) -> dict[str, Any] | None:
+    """返回 total, labels。"""
+    data = _get_data(parsed)
+    if data is None:
+        return None
+    result: dict[str, Any] = {}
+    result["total"] = data.get("total")
+    labels = data.get("labels", [])
+    if isinstance(labels, list):
+        result["labels"] = labels
+    return result if result.get("labels") is not None else None
+
+
 @register_prefix("todo_")
 def _extract_todo_generic(
     tool_name: str,


### PR DESCRIPTION
## 问题

 和  在 tool_extractors.py 中没有专属提取器，命中  泛用提取器后仅返回 ，前端 SectionListBubble / LabelListBubble 组件接收不到  /  数据，显示为空白。

## 修复

添加  和  精准匹配提取器，正确转发后端响应的原始 sections/labels 数据， 从首个 section 中提取作为顶部上下文。