### PR TITLE
style(todo-bubble): 移除气泡头部和左侧图标，调整详情间距

### DIFF
--- a/web/src/components/tools/todo/ActionResultBubble.vue
+++ b/web/src/components/tools/todo/ActionResultBubble.vue
@@ -6,11 +6,9 @@
         <div class="lf-tool-label">{{ actionLabel }}</div>
         <div class="lf-timestamp">{{ nowStr }}</div>
       </div>
-      <div class="lf-header-icon" v-html="actionSvg"></div>
     </div>
 
     <div class="action-result">
-      <div class="ar-icon">{{ actionIcon }}</div>
       <div class="ar-text">
         <div class="ar-title" :class="{ done: isCompleteAction }">{{ taskTitle }}</div>
         <div class="ar-detail">{{ actionDetail }}</div>
@@ -50,42 +48,6 @@ const actionLabel = computed(() => {
     unknown: 'Task',
   }
   return m[actionType.value]
-})
-
-const actionIcon = computed(() => {
-  const m: Record<string, string> = {
-    create: '+',
-    complete: '✓',
-    uncomplete: '↩',
-    delete: '✕',
-    update: '✎',
-    unknown: '•',
-  }
-  return m[actionType.value]
-})
-
-const actionSvg = computed(() => {
-  const m: Record<string, string> = {
-    create: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="10"/><polyline points="8,12 11,15 16,9"/>
-    </svg>`,
-    complete: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="10"/><polyline points="8,12 11,15 16,9"/>
-    </svg>`,
-    uncomplete: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="10"/><polyline points="12,8 12,16 8,12 16,12"/>
-    </svg>`,
-    delete: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="10"/><line x1="8" y1="8" x2="16" y2="16"/><line x1="16" y1="8" x2="8" y2="16"/>
-    </svg>`,
-    update: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M17 2l4 4-14 14-4-4z"/><line x1="15" y1="6" x2="18" y2="9"/>
-    </svg>`,
-    unknown: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
-    </svg>`,
-  }
-  return m[actionType.value] ?? m.unknown
 })
 
 const nowStr = computed(() => {
@@ -171,39 +133,16 @@ const prioritySuffix = computed(() => {
   color: var(--text-tertiary, #bbb);
   letter-spacing: 0.3px;
 }
-.lf-header-icon {
-  width: 32px;
-  height: 32px;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-.lf-header-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
 /* ── 操作结果 ── */
 .action-result {
   display: flex;
   align-items: center;
   gap: 12px;
 }
-.ar-icon {
-  width: 28px;
-  height: 28px;
-  border: 1.5px solid var(--text-primary);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-primary);
-  font-size: 14px;
-  flex-shrink: 0;
-}
 .ar-text {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 6px;
   flex: 1;
   min-width: 0;
 }

--- a/web/src/components/tools/todo/LabelListBubble.vue
+++ b/web/src/components/tools/todo/LabelListBubble.vue
@@ -6,18 +6,11 @@
         <div class="lf-tool-label">Labels · {{ total }}</div>
         <div class="lf-timestamp">{{ total === 0 ? '未定义标签' : '' }}</div>
       </div>
-      <div class="lf-header-icon">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z"/>
-          <line x1="7" y1="7" x2="7.01" y2="7"/>
-        </svg>
-      </div>
     </div>
 
     <!-- 标签网格 -->
     <div v-if="labels.length" class="label-grid">
       <span v-for="l in labels" :key="l.label_id" class="lg-tag">
-        <span class="lg-dot" :style="{ background: dotColor(l.color) }"></span>
         {{ l.name }}
       </span>
     </div>
@@ -38,19 +31,6 @@ const labels = computed<Array<Record<string, any>>>(() => {
   return Array.isArray(list) ? list : []
 })
 
-const COLOR_MAP: Record<string, string> = {
-  berry_red: '#6b7280', red: '#6b7280', orange: '#9ca3af',
-  yellow: '#9ca3af', olive_green: '#9ca3af', lime_green: '#9ca3af',
-  green: '#9ca3af', mint_green: '#d1d5db', teal: '#9ca3af',
-  sky_blue: '#d1d5db', light_blue: '#d1d5db', blue: '#6b7280',
-  grape: '#6b7280', violet: '#6b7280', lavender: '#d1d5db',
-  magenta: '#6b7280', salmon: '#9ca3af', charcoal: '#333333',
-  grey: '#d1d5db', taupe: '#9ca3af',
-}
-
-function dotColor(color: string | null | undefined): string {
-  return COLOR_MAP[color ?? ''] ?? '#d1d5db'
-}
 </script>
 
 <style scoped>
@@ -85,17 +65,6 @@ function dotColor(color: string | null | undefined): string {
   color: var(--text-tertiary, #bbb);
   letter-spacing: 0.3px;
 }
-.lf-header-icon {
-  width: 32px;
-  height: 32px;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-.lf-header-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
 /* ── 标签列表 ── */
 .label-grid {
   display: flex;
@@ -110,15 +79,6 @@ function dotColor(color: string | null | undefined): string {
   border-radius: 2px;
   letter-spacing: 0.3px;
 }
-.lg-dot {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  margin-right: 6px;
-  vertical-align: middle;
-}
-
 /* ── 空状态 ── */
 .empty-state {
   text-align: center;

--- a/web/src/components/tools/todo/ProjectTreeBubble.vue
+++ b/web/src/components/tools/todo/ProjectTreeBubble.vue
@@ -6,21 +6,12 @@
         <div class="lf-tool-label">Projects · {{ total }}</div>
         <div class="lf-timestamp">{{ nowStr }}</div>
       </div>
-      <div class="lf-header-icon">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="3" y="3" width="7" height="7" rx="1"/>
-          <rect x="14" y="3" width="7" height="7" rx="1"/>
-          <rect x="3" y="14" width="7" height="7" rx="1"/>
-          <rect x="14" y="14" width="7" height="7" rx="1"/>
-        </svg>
-      </div>
     </div>
 
     <!-- 项目列表 -->
     <div v-if="projects.length" class="project-tree">
       <div v-for="p in projects" :key="p.project_id" class="pt-node">
         <div class="pt-project">
-          <span class="pt-color-dot" :style="{ background: dotColor(p.color) }"></span>
           <span class="pt-name">{{ p.name }}</span>
           <span v-if="p.is_inbox_project" class="pt-badge">INBOX</span>
           <span class="pt-count">{{ p.view_style === 'board' ? 'board' : 'list' }}</span>
@@ -49,20 +40,6 @@ const nowStr = computed(() => {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
 })
 
-/** Todoist 颜色名 → 灰度色值 */
-const COLOR_MAP: Record<string, string> = {
-  berry_red: '#6b7280', red: '#6b7280', orange: '#9ca3af',
-  yellow: '#9ca3af', olive_green: '#9ca3af', lime_green: '#9ca3af',
-  green: '#9ca3af', mint_green: '#d1d5db', teal: '#9ca3af',
-  sky_blue: '#d1d5db', light_blue: '#d1d5db', blue: '#6b7280',
-  grape: '#6b7280', violet: '#6b7280', lavender: '#d1d5db',
-  magenta: '#6b7280', salmon: '#9ca3af', charcoal: '#333333',
-  grey: '#d1d5db', taupe: '#9ca3af',
-}
-
-function dotColor(color: string | null | undefined): string {
-  return COLOR_MAP[color ?? ''] ?? '#d1d5db'
-}
 </script>
 
 <style scoped>
@@ -98,17 +75,6 @@ function dotColor(color: string | null | undefined): string {
   color: var(--text-tertiary, #bbb);
   letter-spacing: 0.3px;
 }
-.lf-header-icon {
-  width: 32px;
-  height: 32px;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-.lf-header-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
 /* ── 项目树 ── */
 .project-tree {
   display: flex;
@@ -125,12 +91,6 @@ function dotColor(color: string | null | undefined): string {
   display: flex;
   align-items: center;
   gap: 10px;
-}
-.pt-color-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
 }
 .pt-name {
   font-size: 13px;

--- a/web/src/components/tools/todo/SectionListBubble.vue
+++ b/web/src/components/tools/todo/SectionListBubble.vue
@@ -6,20 +6,12 @@
         <div class="lf-tool-label">{{ headerLabel }}</div>
         <div class="lf-timestamp">{{ total }} section{{ total !== 1 ? 's' : '' }}</div>
       </div>
-      <div class="lf-header-icon">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="3" y1="6" x2="21" y2="6"/>
-          <line x1="3" y1="12" x2="21" y2="12"/>
-          <line x1="3" y1="18" x2="21" y2="18"/>
-        </svg>
-      </div>
     </div>
 
     <!-- 分区列表 -->
     <div v-if="sections.length" class="section-tree">
       <div v-for="s in sections" :key="s.section_id" class="st-node">
         <div class="st-row">
-          <span class="pt-color-dot" :style="{ background: dotColor(s._color) }"></span>
           <span class="st-name">{{ s.name }}</span>
           <span v-if="s.project_name" class="st-project">{{ s.project_name }}</span>
           <span class="pt-count">#{{ s.order }}</span>
@@ -50,10 +42,6 @@ const headerLabel = computed(() => {
   if (props.toolData?.project_name) return `${props.toolData.project_name} · Sections`
   return 'Sections'
 })
-
-function dotColor(_color: string | null | undefined): string {
-  return '#9ca3af'
-}
 </script>
 
 <style scoped>
@@ -88,17 +76,6 @@ function dotColor(_color: string | null | undefined): string {
   color: var(--text-tertiary, #bbb);
   letter-spacing: 0.3px;
 }
-.lf-header-icon {
-  width: 32px;
-  height: 32px;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-.lf-header-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
 /* ── 分区列表 ── */
 .section-tree {
   display: flex;
@@ -115,12 +92,6 @@ function dotColor(_color: string | null | undefined): string {
   display: flex;
   align-items: center;
   gap: 10px;
-}
-.pt-color-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
 }
 .st-name {
   font-size: 13px;

--- a/web/src/components/tools/todo/TaskDetailBubble.vue
+++ b/web/src/components/tools/todo/TaskDetailBubble.vue
@@ -6,13 +6,6 @@
         <div class="lf-tool-label">Task · {{ task.content ?? 'N/A' }}</div>
         <div class="lf-timestamp">{{ projectPath }}</div>
       </div>
-      <div class="lf-header-icon">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="4" y="4" width="16" height="16" rx="2"/>
-          <line x1="9" y1="4" x2="9" y2="20"/>
-          <line x1="15" y1="4" x2="15" y2="20"/>
-        </svg>
-      </div>
     </div>
 
     <div v-if="hasTask" class="td-grid">
@@ -124,17 +117,6 @@ function priorityLabel(p: number | null | undefined): string {
   color: var(--text-tertiary, #bbb);
   letter-spacing: 0.3px;
 }
-.lf-header-icon {
-  width: 32px;
-  height: 32px;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-.lf-header-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
 /* ── 详情网格 ── */
 .td-grid {
   display: grid;
@@ -157,7 +139,7 @@ function priorityLabel(p: number | null | undefined): string {
   letter-spacing: 1px;
   text-transform: uppercase;
   color: var(--text-tertiary, #bbb);
-  margin-bottom: 3px;
+  margin-bottom: 6px;
 }
 .td-value {
   color: var(--text-primary);

--- a/web/src/components/tools/todo/TaskListBubble.vue
+++ b/web/src/components/tools/todo/TaskListBubble.vue
@@ -6,13 +6,6 @@
         <div class="lf-tool-label">{{ headerLabel }}</div>
         <div class="lf-timestamp">{{ total }} tasks</div>
       </div>
-      <div class="lf-header-icon">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="4" y="4" width="16" height="16" rx="2"/>
-          <line x1="4" y1="10" x2="20" y2="10"/>
-          <line x1="12" y1="4" x2="12" y2="20"/>
-        </svg>
-      </div>
     </div>
 
     <!-- 任务列表 -->
@@ -102,17 +95,6 @@ function dueText(t: Record<string, any>): string | null {
   color: var(--text-tertiary, #bbb);
   letter-spacing: 0.3px;
 }
-.lf-header-icon {
-  width: 32px;
-  height: 32px;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-.lf-header-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
 /* ── 任务列表 ── */
 .task-list {
   display: flex;


### PR DESCRIPTION
## 变更内容

移除 Todoist 气泡组件的冗余装饰元素，回归纯文字线框风格。

### 具体改动

- **移除右上角图标** — 6 个气泡组件全部删除 `.lf-header-icon` SVG 图标
- **移除左侧图标** — 项目/分区/标签的彩色圆点（`.pt-color-dot`、`.lg-dot`）全部移除
- **移除操作结果符号** — `ActionResultBubble` 的圆圈符号（`.ar-icon`）移除
- **清理无用代码** — 删除 `COLOR_MAP`、`dotColor()`、`actionSvg`、`actionIcon` 等
- **调整间距** — `.ar-text` gap 2px→6px，`.td-label` margin-bottom 3px→6px

### 涉及文件

| 文件 | 行数变动 |
|------|----------|
| ActionResultBubble.vue | -63 |
| LabelListBubble.vue | -40 |
| ProjectTreeBubble.vue | -40 |
| SectionListBubble.vue | -29 |
| TaskDetailBubble.vue | -20 |
| TaskListBubble.vue | -18 |