### PR TITLE
refactor(mcp): YAML 配置驱动 MCP 服务器桥接

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ api/data/SonettoBlocker
 # 认证 Token（自动生成，每用户本地配置）
 api/data/auth_token.yaml
 
+# MCP 服务器配置（每用户本地配置，可能含 API Key 等敏感信息）
+config/mcp_servers.yaml
+
 # Anthropic Skills（忽略 skill 子目录，保留目录本身用于 .gitkeep）
 anthropic_skills/*/
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,59 @@ category: <分类名>
 
 > Macro 的优势是轻量：无需修改代码、无需重启服务，新建一篇 Markdown 文件即可扩展 AI 的能力。
 
+## MCP 服务器
+
+SonettoHere 支持通过 MCP（Model Context Protocol）接入外部工具，只需编辑 `config/mcp_servers.yaml` 即可添加 MCP 服务器，无需改动代码。
+
+支持 4 种传输类型：本地子进程（stdio）和远程连接（SSE / Streamable HTTP / WebSocket）。
+
+### 配置字段
+
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `server_id` | ✓ | 唯一标识，将作为工具名前缀（`{server_id}_工具名`）|
+| `enabled` | | 是否启用，`true`/`false`，默认为 `true` |
+| `description` | | 人类可读的描述，仅用于展示 |
+| `transport` | ✓ | 传输类型：`stdio` / `sse` / `streamable_http` / `websocket` |
+
+#### stdio（本地子进程）
+
+```yaml
+- server_id: "my-server"
+  enabled: true
+  transport: "stdio"
+  command: "node"           # 可执行文件路径
+  args: ["server.js"]       # 命令行参数
+  env:                       # 可选：环境变量
+    API_KEY: "xxx"
+  cwd: "/path/to/workdir"   # 可选：工作目录
+```
+
+#### SSE / Streamable HTTP / WebSocket（远程连接）
+
+```yaml
+- server_id: "remote-service"
+  enabled: true
+  transport: "streamable_http"   # 或 "sse" / "websocket"
+  url: "https://example.com/mcp" # 服务端地址
+  headers:                        # 可选：HTTP 请求头
+    Authorization: "Bearer token"
+  timeout: 30                     # 可选：连接超时（秒）
+```
+
+### 激活方式
+
+- **重启后端**：自动读取配置
+- **热加载**：调用 `POST /api/mcp/reload`，无需重启
+
+### 注意事项
+
+- 工具名称会自动添加 `{server_id}_` 前缀，避免多服务器间的命名冲突
+- MCP 工具在前端统一使用 ToolCallCard 展示，无需注册专属气泡组件
+- `config/mcp_servers.yaml` 已加入 `.gitignore`，不会提交到版本库
+
+---
+
 ## 引用机制
 
 SonettoHere 支持在输入框中引用多种类型的内容作为对话上下文：

--- a/api/callbacks/websocket_callback.py
+++ b/api/callbacks/websocket_callback.py
@@ -42,9 +42,6 @@ class WebSocketCallback(BaseCallbackHandler):
         try:
             parsed = json.loads(out_str)
         except (json.JSONDecodeError, TypeError):
-            # MCP Word 工具返回纯文本而非 JSON — 包装为 _raw 让提取器能处理
-            if tool_name.startswith("word_"):
-                return _dispatch(tool_name, {"_raw": out_str}, tool_input)
             return None
         return _dispatch(tool_name, parsed, tool_input)
 

--- a/api/routes/mcp.py
+++ b/api/routes/mcp.py
@@ -1,0 +1,46 @@
+"""REST API — MCP 服务器配置查看与热加载。"""
+
+from fastapi import APIRouter, HTTPException, Request
+
+from tools.mcp import get_mcp_error, get_mcp_servers_info, reload_mcp
+
+router = APIRouter()
+
+
+@router.get("/mcp/servers")
+async def list_mcp_servers(request: Request):
+    """返回所有已配置的 MCP 服务器（含 disabled）。"""
+    servers = get_mcp_servers_info()
+    error = get_mcp_error()
+    mcp_tools = getattr(request.app.state, "mcp_tools", [])
+    return {
+        "servers": servers,
+        "last_error": error,
+        "tool_count": len(mcp_tools),
+    }
+
+
+@router.post("/mcp/reload")
+async def reload_mcp_servers(request: Request):
+    """热加载：重新解析 YAML → 重建连接 → 替换 app.state。
+
+    失败时保留旧工具列表不变。
+    """
+    try:
+        old_tools = request.app.state.mcp_tools
+        new_tools = await reload_mcp()
+        request.app.state.mcp_tools = new_tools
+        request.app.state.tools = request.app.state.native_tools + new_tools
+        server_info = get_mcp_servers_info()
+        error = get_mcp_error()
+        return {
+            "status": "ok",
+            "servers": server_info,
+            "tool_count": len(new_tools),
+            "last_error": error,
+        }
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"MCP 重载失败: {exc}",
+        )

--- a/api/server.py
+++ b/api/server.py
@@ -23,6 +23,7 @@ from api.routes import persona as persona_router
 from api.routes import sonetto_blocker as sonetto_blocker_router
 from api.routes import skills as skills_router
 from api.routes import news as news_router
+from api.routes import mcp as mcp_router
 from api.routes import restart as restart_router
 from api.session_manager import SessionManager, SessionState
 from api.ws_registry import WebSocketRegistry
@@ -123,7 +124,7 @@ async def lifespan(app: FastAPI):
     else:
         print("[ltm] Skipped (no LLM available)")
 
-    # 加载 MCP 工具（Word 文档编辑能力）
+    # 从 YAML 配置加载 MCP 工具
     app.state.mcp_tools = await init_mcp_tools()
     app.state.tools = app.state.native_tools + app.state.mcp_tools
 
@@ -177,6 +178,9 @@ def create_app() -> FastAPI:
 
     # Provider CRUD 路由
     app.include_router(providers.router, prefix="/api")
+
+    # MCP 服务器配置查看与热加载
+    app.include_router(mcp_router.router, prefix="/api")
 
     # 人设读写 (SOUL.md / USER.md)
     app.include_router(persona_router.router, prefix="/api")

--- a/dev_docs/projects/uml/skills.md
+++ b/dev_docs/projects/uml/skills.md
@@ -312,7 +312,7 @@ Server Startup
   ├─ get_all_skills()
   │    └─ 每个 Skill 注入 SharedAPIClient（单例）
   ├─ init_mcp_tools()
-  │    └─ MultiServerMCPClient → word_* 工具（带前缀）
+  │    └─ 从 YAML 配置加载 MCP 工具
   └─ tools = native + mcp
 
 Every Chat Turn

--- a/dev_docs/projects/uml/websocket.md
+++ b/dev_docs/projects/uml/websocket.md
@@ -50,10 +50,6 @@ class extract_weather <<@register>> {
   + city, temp, condition, humidity, wind
 }
 
-class extract_word <<@register_prefix("word_")>> {
-  + tool_type, action, success, message, ...
-}
-
 ' ===== 交互注册表 =====
 
 class InteractionRegistry {

--- a/tools/mcp.py
+++ b/tools/mcp.py
@@ -1,33 +1,294 @@
-"""MCP 工具管理器 — 通用 MCP 客户端桥接框架。
+"""MCP 工具管理器 — 从 YAML 配置加载的通用 MCP 客户端桥接框架。
 
-保留此模块作为 MCP 基础设施，支持通过 init_mcp_tools() 动态配置各
-类 MCP 服务器（如 Word、数据库等）。当前无活跃配置，返回空列表。
-
-如需接入新的 MCP 服务器，在此文件中添加对应的 MultiServerMCPClient
-配置即可，前端通过 word_ 前缀规则路由（见 registry.ts）。
+所有 MCP 工具统一使用前端 ToolCallCard 兜底组件展示，
+无需在 registry.ts 中注册专属气泡组件。
 """
 
-from langchain_core.tools import BaseTool
+from pathlib import Path
+from typing import Annotated, Any, Literal, Union
 
-_client = None
+import yaml
+from langchain_core.tools import BaseTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from pydantic import BaseModel, Field
+
+_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "mcp_servers.yaml"
+
+_client: MultiServerMCPClient | None = None
 _tools: list[BaseTool] | None = None
+_config: list["MCPServerConfig"] | None = None
+_last_error: str | None = None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Pydantic 配置模型
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class _BaseServerMixin(BaseModel):
+    """所有 MCP 服务器配置变体共享的字段。"""
+
+    server_id: str
+    enabled: bool = True
+    description: str = ""
+
+
+class StdioServerConfig(_BaseServerMixin):
+    """stdio 传输 — 本地子进程。"""
+
+    transport: Literal["stdio"] = "stdio"
+    command: str
+    args: list[str] = []
+    env: dict[str, str] | None = None
+    cwd: str | None = None
+
+    def to_connection(self) -> dict[str, Any]:
+        conn: dict[str, Any] = {
+            "transport": "stdio",
+            "command": self.command,
+            "args": self.args,
+        }
+        if self.env is not None:
+            conn["env"] = self.env
+        if self.cwd is not None:
+            conn["cwd"] = self.cwd
+        return conn
+
+
+class SSEServerConfig(_BaseServerMixin):
+    """SSE 传输 — HTTP 服务器推送事件。"""
+
+    transport: Literal["sse"] = "sse"
+    url: str
+    headers: dict[str, str] | None = None
+    timeout: float | None = None
+    sse_read_timeout: float | None = None
+
+    def to_connection(self) -> dict[str, Any]:
+        conn: dict[str, Any] = {
+            "transport": "sse",
+            "url": self.url,
+        }
+        if self.headers is not None:
+            conn["headers"] = self.headers
+        if self.timeout is not None:
+            conn["timeout"] = self.timeout
+        if self.sse_read_timeout is not None:
+            conn["sse_read_timeout"] = self.sse_read_timeout
+        return conn
+
+
+class StreamableHttpServerConfig(_BaseServerMixin):
+    """Streamable HTTP 传输 — MCP 2025-03-26 规范。"""
+
+    transport: Literal["streamable_http"] = "streamable_http"
+    url: str
+    headers: dict[str, str] | None = None
+    timeout: float | None = None
+
+    def to_connection(self) -> dict[str, Any]:
+        conn: dict[str, Any] = {
+            "transport": "streamable_http",
+            "url": self.url,
+        }
+        if self.headers is not None:
+            conn["headers"] = self.headers
+        if self.timeout is not None:
+            conn["timeout"] = self.timeout
+        return conn
+
+
+class WebsocketServerConfig(_BaseServerMixin):
+    """WebSocket 传输。"""
+
+    transport: Literal["websocket"] = "websocket"
+    url: str
+
+    def to_connection(self) -> dict[str, Any]:
+        return {"transport": "websocket", "url": self.url}
+
+
+MCPServerConfig = Annotated[
+    Union[
+        StdioServerConfig,
+        SSEServerConfig,
+        StreamableHttpServerConfig,
+        WebsocketServerConfig,
+    ],
+    Field(discriminator="transport"),
+]
+
+
+class MCPServersConfigFile(BaseModel):
+    """config/mcp_servers.yaml 的根结构。"""
+
+    mcp_servers: list[MCPServerConfig] = []
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 配置加载
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def load_mcp_config() -> list[MCPServerConfig]:
+    """解析并验证 config/mcp_servers.yaml。"""
+    global _last_error, _config
+
+    if _config is not None:
+        return _config
+
+    if not _CONFIG_PATH.exists():
+        _config = []
+        return []
+
+    try:
+        with open(_CONFIG_PATH, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        validated = MCPServersConfigFile(**raw)
+        _config = validated.mcp_servers
+        _last_error = None
+        return _config
+    except Exception as exc:
+        _last_error = f"加载 MCP 配置失败: {exc}"
+        print(f"[mcp] {_last_error}")
+        _config = []
+        return []
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 生命周期
+# ═══════════════════════════════════════════════════════════════════════
 
 
 async def init_mcp_tools() -> list[BaseTool]:
-    """初始化 MCP 客户端并返回所有 MCP 工具列表。
+    """从 YAML 加载配置并初始化 MCP 客户端。
 
-    当前无已注册的 MCP 服务器，返回空列表。
-    子类可继承或在外部重写此模块的 _client / _tools 全局变量来接入自定义 MCP。
+    仅连接 enabled=True 的服务器，工具名自动加 {serverId}_ 前缀。
     """
-    global _client, _tools
+    global _client, _tools, _last_error
+
     if _tools is not None:
         return _tools
-    _tools = []
+
+    configs = load_mcp_config()
+    enabled = [c for c in configs if c.enabled]
+    if not enabled:
+        _tools = []
+        return _tools
+
+    connections: dict[str, Any] = {}
+    server_errors: list[str] = []
+
+    for cfg in enabled:
+        try:
+            connections[cfg.server_id] = cfg.to_connection()
+        except Exception as exc:
+            msg = f"服务器 '{cfg.server_id}' 连接构建失败: {exc}"
+            server_errors.append(msg)
+            print(f"[mcp] {msg}")
+
+    if not connections:
+        _tools = []
+        if server_errors:
+            _last_error = "; ".join(server_errors)
+        return _tools
+
+    try:
+        _client = MultiServerMCPClient(
+            connections=connections,
+            tool_name_prefix=True,
+        )
+        _tools = await _client.get_tools()
+        _last_error = None
+
+        for cfg in enabled:
+            prefix = f"{cfg.server_id}_"
+            count = sum(1 for t in _tools if t.name.startswith(prefix))
+            print(f"[mcp] 服务器 '{cfg.server_id}' 已加载 {count} 个工具")
+    except Exception as exc:
+        _last_error = f"初始化 MCP 客户端失败: {exc}"
+        print(f"[mcp] {_last_error}")
+        _tools = []
+
     return _tools
 
 
 async def close_mcp():
-    """释放 MCP 客户端资源。"""
-    global _client, _tools
+    """释放 MCP 客户端资源。
+
+    MultiServerMCPClient v0.2.2 没有 close() 方法（会话是短暂的，
+    每次工具调用创建/销毁），这里仅重置模块级状态。
+    """
+    global _client, _tools, _config, _last_error
     _client = None
     _tools = None
+    _config = None
+    _last_error = None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 热加载 & 查询
+# ═══════════════════════════════════════════════════════════════════════
+
+
+async def reload_mcp() -> list[BaseTool]:
+    """重新加载 MCP 配置并重建连接。
+
+    失败时保留旧状态不变。
+    """
+    global _client, _tools, _config, _last_error
+
+    old_client = _client
+    old_tools = _tools
+    old_config = _config
+    old_error = _last_error
+
+    # 清除缓存，强制重新加载
+    _client = None
+    _tools = None
+    _config = None
+    _last_error = None
+
+    try:
+        result = await init_mcp_tools()
+        if _tools is None:
+            _tools = []
+        return _tools
+    except Exception as exc:
+        # 恢复旧状态
+        _client = old_client
+        _tools = old_tools
+        _config = old_config
+        _last_error = old_error
+        raise
+
+
+def get_mcp_servers_info() -> list[dict[str, Any]]:
+    """返回序列化的服务器配置（供 API 使用）。"""
+    global _config
+    if _config is None:
+        load_mcp_config()
+
+    if not _config:
+        return []
+
+    result = []
+    for c in _config:
+        info: dict[str, Any] = {
+            "server_id": c.server_id,
+            "transport": c.transport,
+            "enabled": c.enabled,
+            "description": c.description,
+        }
+        if _tools:
+            prefix = f"{c.server_id}_"
+            info["tool_count"] = sum(1 for t in _tools if t.name.startswith(prefix))
+        else:
+            info["tool_count"] = 0
+        result.append(info)
+    return result
+
+
+def get_mcp_error() -> str | None:
+    """返回最近一次的错误信息（无错误则返回 None）。"""
+    return _last_error


### PR DESCRIPTION
## 变更内容

- 新增 `config/mcp_servers.yaml` 声明式配置，用户仅需编辑此 YAML 即可添加 MCP 服务器
- 重写 `tools/mcp.py`：Pydantic 判别联合体模型、YAML 加载、MultiServerMCPClient 桥接
- 新增 `api/routes/mcp.py`：`GET /api/mcp/servers`（查看配置）+ `POST /api/mcp/reload`（热加载）
- 移除 `websocket_callback.py` 中 `word_` 前缀特殊处理逻辑
- MCP 工具统一走前端 ToolCallCard 兜底组件展示
- 更新 UML 文档移除 `word_` 相关引用

## 支持传输类型

| 类型 | 说明 |
|---|---|
| `stdio` | 本地子进程 |
| `sse` | HTTP 服务器推送事件 |
| `streamable_http` | MCP 2025-03-26 规范 |
| `websocket` | WebSocket |

## 使用方式

1. 编辑 `config/mcp_servers.yaml` 添加服务器条目
2. 调用 `POST /api/mcp/reload` 热加载，或重启后端
3. 工具名称自动添加 `{server_id}_` 前缀，前端以 ToolCallCard 展示

Closes #180