### PR TITLE
enhance(auth): 集中 WebSocket 认证至 AuthMiddleware ASGI 中间件，解除业务层耦合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ anthropic_skills/*/
 
 # Macros（同上）
 macros/*/
+
+# 安全威胁模型（本地文档，不提交）
+dev_docs/security/

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -45,9 +45,10 @@ class AuthMiddleware:
     def _extract_token(self, scope) -> str:
         """从请求头提取 Token。
 
-        优先 X-Sonetto-Token 自定义头，WebSocket 场景回退到
-        Sec-WebSocket-Protocol（浏览器 WebSocket API 无法设置自定义头，
-        前端通过 sub-protocol 传入）。
+        HTTP / WebSocket 通用路径: X-Sonetto-Token 自定义头
+        WebSocket 专用路径: scope.subprotocols（由 ASGI server/uvicorn 从
+        Sec-WebSocket-Protocol 握手头部解析，前端通过 new WebSocket(url, [token])
+        传入）。优先使用 subprotocols 字段，比手动解析 raw header 更可靠。
         """
         headers = dict(scope.get("headers", []))
 
@@ -56,14 +57,13 @@ class AuthMiddleware:
         if token_bytes:
             return token_bytes.decode()
 
-        # WebSocket 专用：从 Sec-WebSocket-Protocol 提取
-        # 前端传参格式: new WebSocket(url, [token])
-        # 此时 token 作为唯一 sub-protocol 出现在该头部
+        # WebSocket 专用：从 ASGI scope 的 subprotocols 字段提取
+        # ASGI server 在握手时自动解析 Sec-WebSocket-Protocol 头部，
+        # 存入 scope["subprotocols"] = [token]
         if scope["type"] == "websocket":
-            protocols = headers.get(b"sec-websocket-protocol", b"").decode()
+            protocols = scope.get("subprotocols", [])
             if protocols:
-                # 取第一个非空协议作为 token（前端只传了一个）
-                return protocols.split(", ")[0].strip()
+                return protocols[0]
 
         return ""
 

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -2,8 +2,8 @@
 认证中间件 — ASGI 中间件，统一拦截 HTTP API 和 WebSocket 请求进行 Token 鉴权。
 
 Token 来源：
-- HTTP: 优先 X-Sonetto-Token 请求头，回退到 ?token= 查询参数
-- WebSocket: ?token= 查询参数（WebSocket API 不支持自定义请求头）
+- HTTP / WebSocket 通用: X-Sonetto-Token 请求头
+- WebSocket (浏览器子协议): Sec-WebSocket-Protocol（前端通过 WebSocket sub-protocol 传入）
 
 鉴权失败的响应：
 - HTTP: 401 JSONResponse
@@ -43,19 +43,28 @@ class AuthMiddleware:
         return await self.app(scope, receive, send)
 
     def _extract_token(self, scope) -> str:
-        """从请求头或查询参数提取 Token。"""
-        if scope["type"] == "http":
-            # HTTP：优先请求头
-            headers = dict(scope.get("headers", []))
-            token_bytes = headers.get(b"x-sonetto-token", b"")
-            if token_bytes:
-                return token_bytes.decode()
+        """从请求头提取 Token。
 
-        # WebSocket & HTTP fallback：从查询参数获取
-        query_string = scope.get("query_string", b"").decode()
-        for part in query_string.split("&"):
-            if part.startswith("token="):
-                return part[6:]  # 前端已用 encodeURIComponent，无需额外解码
+        优先 X-Sonetto-Token 自定义头，WebSocket 场景回退到
+        Sec-WebSocket-Protocol（浏览器 WebSocket API 无法设置自定义头，
+        前端通过 sub-protocol 传入）。
+        """
+        headers = dict(scope.get("headers", []))
+
+        # 通用：X-Sonetto-Token 自定义头
+        token_bytes = headers.get(b"x-sonetto-token", b"")
+        if token_bytes:
+            return token_bytes.decode()
+
+        # WebSocket 专用：从 Sec-WebSocket-Protocol 提取
+        # 前端传参格式: new WebSocket(url, [token])
+        # 此时 token 作为唯一 sub-protocol 出现在该头部
+        if scope["type"] == "websocket":
+            protocols = headers.get(b"sec-websocket-protocol", b"").decode()
+            if protocols:
+                # 取第一个非空协议作为 token（前端只传了一个）
+                return protocols.split(", ")[0].strip()
+
         return ""
 
     async def _reject(self, scope, receive, send):

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -30,15 +30,28 @@ class AuthMiddleware:
         if path == "/api/health":
             return await self.app(scope, receive, send)
 
-        # 从 scope 提取 Token
+        # 提取并校验 Token
         token = self._extract_token(scope)
-
-        # 从 app state 获取期望的 Token
         app = scope.get("app")
         expected = app.state.auth_token if app is not None else None
 
         if not expected or token != expected:
             return await self._reject(scope, receive, send)
+
+        # WebSocket 鉴权通过后：拦截 handler 的 websocket.accept 消息，
+        # 自动注入 subprotocol（前端通过 new WebSocket(url, [token]) 请求的协议），
+        # 业务 handler 无需感知 sub-protocol 协商细节。
+        if scope["type"] == "websocket":
+            protocols = scope.get("subprotocols", [])
+            if protocols:
+                original_send = send
+
+                async def _accept_with_subprotocol(message):
+                    if message.get("type") == "websocket.accept" and not message.get("subprotocol"):
+                        message = {**message, "subprotocol": protocols[0]}
+                    await original_send(message)
+
+                return await self.app(scope, receive, _accept_with_subprotocol)
 
         return await self.app(scope, receive, send)
 

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,42 +1,70 @@
 """
-认证中间件 — 对 API 和 WebSocket 路径校验 Token。
+认证中间件 — ASGI 中间件，统一拦截 HTTP API 和 WebSocket 请求进行 Token 鉴权。
 
-Token 来源（按优先级）：
-1. X-Sonetto-Token 请求头（REST API 使用）
-2. ?token= 查询参数（WebSocket 使用，因其无法设置自定义头）
+Token 来源：
+- HTTP: 优先 X-Sonetto-Token 请求头，回退到 ?token= 查询参数
+- WebSocket: ?token= 查询参数（WebSocket API 不支持自定义请求头）
+
+鉴权失败的响应：
+- HTTP: 401 JSONResponse
+- WebSocket: 4001 关闭码
 """
 
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
 
-class AuthMiddleware(BaseHTTPMiddleware):
-    """拦截 /api/* 和 /ws/* 路径，校验认证 Token。"""
+class AuthMiddleware:
+    """ASGI 中间件 — 在请求到达路由前完成鉴权，HTTP 和 WebSocket 统一处理。"""
 
-    async def dispatch(self, request, call_next):
-        path = request.url.path
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        path = scope.get("path", "")
 
         # 仅保护 API 和 WebSocket 路径
         if not path.startswith("/api/") and not path.startswith("/ws/"):
-            return await call_next(request)
+            return await self.app(scope, receive, send)
 
         # 白名单：健康检查
         if path == "/api/health":
-            return await call_next(request)
+            return await self.app(scope, receive, send)
 
-        # 尝试从请求头或查询参数获取 Token
-        token = request.headers.get("x-sonetto-token", "")
-        if not token:
-            token = (
-                request.url.query.split("token=")[-1].split("&")[0]
-                if "token=" in request.url.query
-                else ""
-            )
+        # 从 scope 提取 Token
+        token = self._extract_token(scope)
 
-        expected = request.app.state.auth_token
+        # 从 app state 获取期望的 Token
+        app = scope.get("app")
+        expected = app.state.auth_token if app is not None else None
+
         if not expected or token != expected:
-            return JSONResponse(
+            return await self._reject(scope, receive, send)
+
+        return await self.app(scope, receive, send)
+
+    def _extract_token(self, scope) -> str:
+        """从请求头或查询参数提取 Token。"""
+        if scope["type"] == "http":
+            # HTTP：优先请求头
+            headers = dict(scope.get("headers", []))
+            token_bytes = headers.get(b"x-sonetto-token", b"")
+            if token_bytes:
+                return token_bytes.decode()
+
+        # WebSocket & HTTP fallback：从查询参数获取
+        query_string = scope.get("query_string", b"").decode()
+        for part in query_string.split("&"):
+            if part.startswith("token="):
+                return part[6:]  # 前端已用 encodeURIComponent，无需额外解码
+        return ""
+
+    async def _reject(self, scope, receive, send):
+        """根据 scope 类型返回 HTTP 401 或 WebSocket 4001 关闭。"""
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.close", "code": 4001})
+        else:
+            response = JSONResponse(
                 {"detail": "Unauthorized — X-Sonetto-Token 缺失或不匹配"},
                 status_code=401,
             )
-        return await call_next(request)
+            await response(scope, receive, send)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -473,13 +473,6 @@ async def websocket_chat(ws: WebSocket, session_id: str):
     """WebSocket 聊天端点 — 接收用户消息、驱动 Agent、处理取消和用户交互。"""
     await ws.accept()
 
-    # 校验 Token（accept 之后检查，避免 403 日志噪声）
-    token = ws.query_params.get("token", "")
-    expected = ws.app.state.auth_token
-    if not expected or token != expected:
-        await ws.close(code=4001)
-        return
-
     # ── 初始化会话 ────────────────────────────────────────
     app_state = ws.app.state
     session = app_state.session_manager.get_or_create(session_id)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -471,7 +471,10 @@ def _resume_sub_agent(ws: WebSocket, session: SessionState) -> asyncio.Task | No
 @router.websocket("/ws/chat/{session_id}")
 async def websocket_chat(ws: WebSocket, session_id: str):
     """WebSocket 聊天端点 — 接收用户消息、驱动 Agent、处理取消和用户交互。"""
-    await ws.accept()
+    # 前端通过 sub-protocol 传递 Token（new WebSocket(url, [token])），
+    # accept 时必须回选相同协议，否则浏览器握手失败直接断开。
+    protocols = (ws.scope or {}).get("subprotocols", [])
+    await ws.accept(subprotocol=protocols[0] if protocols else None)
 
     # ── 初始化会话 ────────────────────────────────────────
     app_state = ws.app.state

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -471,10 +471,7 @@ def _resume_sub_agent(ws: WebSocket, session: SessionState) -> asyncio.Task | No
 @router.websocket("/ws/chat/{session_id}")
 async def websocket_chat(ws: WebSocket, session_id: str):
     """WebSocket 聊天端点 — 接收用户消息、驱动 Agent、处理取消和用户交互。"""
-    # 前端通过 sub-protocol 传递 Token（new WebSocket(url, [token])），
-    # accept 时必须回选相同协议，否则浏览器握手失败直接断开。
-    protocols = (ws.scope or {}).get("subprotocols", [])
-    await ws.accept(subprotocol=protocols[0] if protocols else None)
+    await ws.accept()
 
     # ── 初始化会话 ────────────────────────────────────────
     app_state = ws.app.state

--- a/tests/test_api/test_auth_middleware.py
+++ b/tests/test_api/test_auth_middleware.py
@@ -33,37 +33,26 @@ class TestAuthMiddleware:
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
 
-    def test_correct_query_token(self, client, auth_token):
-        """?token= 正确 → 200。"""
-        resp = client.get(f"/api/test?token={auth_token}")
-        assert resp.status_code == 200
-        assert resp.json() == {"status": "ok"}
-
-    def test_query_token_wrong_still_401(self, client):
-        """?token= 值错误 → 401。"""
-        resp = client.get("/api/test?token=wrong-token")
-        assert resp.status_code == 401
-
     def test_ws_path_protected(self, client):
         """/ws/ 路径受保护。"""
         resp = client.get("/ws/test")
         assert resp.status_code == 401
 
     def test_ws_path_with_valid_token(self, client, auth_token):
-        """/ws/ 路径带有效 token → 200。"""
-        resp = client.get(f"/ws/test?token={auth_token}")
+        """/ws/ 路径带 X-Sonetto-Token 头 → 200。"""
+        resp = client.get("/ws/test", headers={"X-Sonetto-Token": auth_token})
         assert resp.status_code == 200
         assert resp.json() == {"status": "ws"}
 
     def test_ws_path_with_wrong_token(self, client):
-        """/ws/ 路径带无效 token → 401。"""
-        resp = client.get("/ws/test?token=wrong")
+        """/ws/ 路径带错误 X-Sonetto-Token → 401。"""
+        resp = client.get("/ws/test", headers={"X-Sonetto-Token": "wrong"})
         assert resp.status_code == 401
 
-    def test_query_token_with_extra_params(self, client, auth_token):
-        """?token= 后还有其他 query params 时仍正确提取。"""
-        resp = client.get(f"/api/test?token={auth_token}&other=value")
-        assert resp.status_code == 200
+    def test_query_param_no_longer_works(self, client):
+        """/api/ 路径仅接受 Header，?token= 查询参数不再有效。"""
+        resp = client.get("/api/test?token=any-token")
+        assert resp.status_code == 401
 
 
 class TestAuthMiddlewareNoToken:

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -167,8 +167,8 @@ function connectSession(sid: string) {
 
   const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
   const token = getToken()
-  const url = `${protocol}//${location.host}/ws/chat/${sid}?token=${encodeURIComponent(token)}`
-  ch.ws = new WebSocket(url)
+  const url = `${protocol}//${location.host}/ws/chat/${sid}`
+  ch.ws = new WebSocket(url, [token])
 
   ch.ws.onopen = () => {
     ch.connected = true

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       '/ws': {
         target: 'ws://localhost:8000',
         ws: true,
+        changeOrigin: true,
       },
     },
   },


### PR DESCRIPTION
## 概要

将 WebSocket 认证逻辑从业务路由层（`chat.py`）全部集中到 `AuthMiddleware` ASGI 中间件中，包括 Token 提取和 Sub-protocol 协商注入。业务层（`chat.py`）不再感知任何认证细节。

## 变更

### AuthMiddleware（`api/middleware/auth.py`）
- 从 HTTP-only `BaseHTTPMiddleware` 重构为 `__call__(self, scope, receive, send)` 纯 ASGI 中间件，同时拦截 HTTP API 和 WebSocket 升级请求
- Token 提取：新增 `_extract_token()`，支持 HTTP 头 `X-Sonetto-Token` 和 WebSocket `Sec-WebSocket-Protocol` 子协议双通道
- WebSocket 回绝：`_reject()` 返回 4001 关闭码而非 401 JSON
- Sub-protocol 自动注入：用 send wrapper 截获 `websocket.accept` ASGI 消息，自动写入前端请求的子协议值，业务 handler 无需感知

### WebSocket 端点（`api/routes/chat.py`）
- `await ws.accept()` 不再传 subprotocol 参数——完全由中间件接管
- 删除所有 `scope.get("subprotocols", [])` 相关代码

### 前端（`web/src/composables/useChat.ts`）
- 通过 `new WebSocket(url, [token])` 将 token 作为子协议传入（浏览器自动设为 `Sec-WebSocket-Protocol` 请求头）

### Vite 代理（`web/vite.config.ts`）
- `/ws` 代理添加 `changeOrigin: true`，使 `Sec-WebSocket-Protocol` 头在开发环境正确透传至后端

## 安全设计

- 放弃 URL 查询参数传 Token（`?token=`），改为 `Sec-WebSocket-Protocol` 握手头部——Token 不出现在 URL/日志中
- 单 Token 双入口：HTTP 用自定义头 `X-Sonetto-Token`，WebSocket 用子协议 `Sec-WebSocket-Protocol`，统一校验逻辑

## 修复

- 修复两次 `ECONNRESET` 错误：
  1. accept 时未回选手选的 sub-protocol 导致浏览器感知协议不匹配而断开
  2. send wrapper 中判断条件 `"subprotocol" not in message` 忽略 Starlette 发出 `{"subprotocol": None}` 的情况，改用 `not message.get("subprotocol")` 修复
