### PR TITLE
fix: 版本号改为从 version.py 动态读取，消除硬编码

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,9 @@
-"""SonettoHere v2.0.0 — LangGraph ReAct AI Agent Web 入口。"""
+"""SonettoHere — LangGraph ReAct AI Agent Web 入口。"""
 
 import sys
 
 import uvicorn
+from version import __version__
 
 from api.server import create_app
 from memory.user_init import ensure_all
@@ -17,7 +18,7 @@ def main():
         print(f"[auth] Token rotated: {rotated}")
         return
 
-    print("SonettoHere v2.0.0")
+    print(f"SonettoHere {__version__}")
     print()
 
     ensure_all()

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,14 @@ import shutil
 import subprocess
 import sys
 
+from version import __version__
+
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
 def header():
     print("=" * 48)
-    print("  SonettoHere v2.0.0 — 首次初始化")
+    print(f"  SonettoHere {__version__} — 首次初始化")
     print("=" * 48)
     print()
     print("本脚本将自动安装依赖并准备好运行环境。")


### PR DESCRIPTION
## 关联 Issue

Closes #187

## 问题

`version.py` 是项目版本号单一数据源（当前 `v2.6.0`），但 `main.py` 和 `setup.py` 中仍硬编码着 `v2.0.0`。

## 修改

| 文件 | 改动 |
|---|---|
| `main.py` | 删除硬编码 `"v2.0.0"`，改为 `from version import __version__` + f-string |
| `setup.py` | 同上 |

`api/server.py`、`api/health.py`、`pyproject.toml` 已正确使用 `version.py`，无需改动。

## 验证

```
$ grep -r "SonettoHere v\d" .  # 无匹配，硬编码已清除
$ python -c "from version import __version__; print(__version__)"
v2.6.0
```