### PR TITLE
fix: Python 自动执行模式下仍需要逐条手动确认

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -256,6 +256,10 @@ async def _run_agent_turn(
     # 1. [准备环境] 从 WebSocket 获取应用状态
     app_state = ws.app.state
     session.auto_approve = auto_approve
+    # 在 ws 对象上直接挂载 auto_approve，避免 ContextVar 在 LangGraph 内传播失效
+    ws.auto_approve = auto_approve
+    # 确保 auto_approve ContextVar 在当前任务上下文生效
+    interaction.auto_approve.set(auto_approve)
     ws_callback = WebSocketCallback(ws)  # WebUI 回调函数系统
 
     # 获取默认上下文窗口大小

--- a/tools/system/tool_python.py
+++ b/tools/system/tool_python.py
@@ -35,8 +35,6 @@ def _check_auto_approve() -> bool:
     try:
         ws = interaction.current_ws.get()
         # 通过 WebSocket 路径参数获取 session_id，再获取 session
-        from api.session_manager import SessionState  # noqa: F811
-
         session_id = ws.path_params.get("session_id", "")
         if session_id:
             app_state = ws.app.state

--- a/tools/system/tool_python.py
+++ b/tools/system/tool_python.py
@@ -26,6 +26,35 @@ def _exec_code(code: str) -> str:
         sys.stdout = old_stdout
 
 
+def _check_auto_approve() -> bool:
+    """检查自动批准模式。
+
+    优先从 session 获取（最可靠），绕过 ContextVar 在 LangGraph 内的传播失效，
+    回退到 ws 属性挂载，最后回退到 ContextVar。
+    """
+    try:
+        ws = interaction.current_ws.get()
+        # 通过 WebSocket 路径参数获取 session_id，再获取 session
+        from api.session_manager import SessionState  # noqa: F811
+
+        session_id = ws.path_params.get("session_id", "")
+        if session_id:
+            app_state = ws.app.state
+            session = app_state.session_manager.get(session_id)
+            if session is not None and session.auto_approve:
+                return True
+        # 回退：ws 对象上直接挂载的属性
+        if getattr(ws, "auto_approve", False):
+            return True
+    except Exception:
+        pass
+    # 最终回退到 ContextVar
+    try:
+        return interaction.auto_approve.get()
+    except Exception:
+        return False
+
+
 class RunPythonInput(BaseModel):
     get_doc: bool = Field(
         default=False, description="设为 true 以获取使用说明和安全限制"
@@ -50,7 +79,8 @@ class RunPythonTool(ToolBase):
         if not code:
             return format_error("code 不能为空")
 
-        if interaction.auto_approve.get():
+        # 优先从 session 读取 auto_approve（绕过 ContextVar 在 LangGraph 内的传播失效）
+        if _check_auto_approve():
             try:
                 output = await asyncio.to_thread(_exec_code, code)
                 return format_success({"output": output, "code": code})


### PR DESCRIPTION
## 关联 Issue

Closes #189

## 问题

开启「Python 代码自动执行」开关后，每次 AI Agent 调用 `run_python` 工具时仍弹出确认对话框。

**根因**：`interaction.auto_approve` 是一个 Python `ContextVar`。LangGraph 内部执行工具时，`tool.arun()` 中 `set_config_context` → `copy_context()` → `coro_with_context(coro, context)` → `asyncio.create_task(coro, context=context)` 使得 ContextVar 在跨异步任务传播时丢失，`auto_approve.get()` 返回默认值 `False`。

## 修改

### `tools/system/tool_python.py`

新增模块级函数 `_check_auto_approve()`，三层回退：

1. **优先**：通过 `interaction.current_ws.get()`（已验证可工作）获取 WebSocket → 路径参数 `session_id` → `session_manager.get()` → `session.auto_approve`
2. **其次**：`ws.auto_approve` 属性（`_run_agent_turn` 中设置）
3. **最终**：`interaction.auto_approve.get()` ContextVar

### `api/routes/chat.py`

`_run_agent_turn()` 中新增 `ws.auto_approve = auto_approve`，确保第二层回退有值。

## 涉及文件

- `tools/system/tool_python.py`（+31/-1）
- `api/routes/chat.py`（+4/-0）