### PR TITLE
feat(weather): 分钟级降水自动压缩+前端渲染

### DIFF
--- a/tools/network/tool_weather.py
+++ b/tools/network/tool_weather.py
@@ -1,5 +1,9 @@
 """Tool: get_current_weather — 天气查询。"""
 
+from datetime import datetime
+from statistics import mean
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 from tools.base import ToolBase, format_error, format_success
@@ -19,6 +23,124 @@ class WeatherInput(BaseModel):
     minutely: bool = Field(default=False, description="返回分钟级降水预报（仅国内）")
     indices: bool = Field(default=False, description="返回18项生活指数")
     lang: str = Field(default="zh", description="语言：zh/en")
+
+
+# ── 降水强度分级（基于 2 分钟窗口 max_precip，经验阈值） ──
+_INTENSITY_LEVELS: list[tuple[float, str]] = [
+    (5.0, "暴雨"),
+    (2.0, "大雨"),
+    (0.5, "中雨"),
+    (0.1, "小雨"),
+]
+
+
+def _classify_intensity(max_precip: float) -> str:
+    for threshold, label in _INTENSITY_LEVELS:
+        if max_precip >= threshold:
+            return label
+    return "微量"
+
+
+def _strip_tz(ts: str) -> str:
+    if ts.endswith("+08:00"):
+        return ts[:-6]
+    return ts
+
+
+def _build_range(points: list[dict[str, Any]]) -> dict[str, Any]:
+    """从连续降水点列表构建一个区间统计。"""
+    precip_values = [p.get("precip", 0) for p in points]
+    max_precip = max(precip_values)
+    avg_precip = mean(precip_values)
+
+    start = points[0].get("time", "")
+    end = points[-1].get("time", "")
+
+    # 估算持续分钟数
+    duration = len(points) * 2  # 回退：每点 2 分钟
+    if start and end:
+        try:
+            fmt = "%Y-%m-%dT%H:%M:%S"
+            s = datetime.strptime(_strip_tz(start), fmt)
+            e = datetime.strptime(_strip_tz(end), fmt)
+            diff = (e - s).total_seconds()
+            if diff > 0:
+                duration = max(1, round(diff / 60))
+        except (ValueError, IndexError):
+            pass
+
+    return {
+        "start": start,
+        "end": end,
+        "max_precip": round(max_precip, 2),
+        "avg_precip": round(avg_precip, 2),
+        "intensity": _classify_intensity(max_precip),
+        "duration_minutes": duration,
+    }
+
+
+def _summarize_minutely(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    将分钟级降水 ~120 个原始数据点压缩为连续降水区间。
+
+    读取 data 中 ``minutely_precip`` / ``minutely`` / ``minutely_forecast`` 任一键，
+    返回压缩后的结构：
+
+    .. code-block:: python
+
+        {
+            "summary": "未来两小时有间歇性降雨",
+            "update_time": "2026-06-28T17:34:03+08:00",
+            "range_count": 2,
+            "original_point_count": 120,
+            "ranges": [ { "start": ..., "end": ..., "max_precip": 2.5,
+                          "avg_precip": 1.3, "intensity": "中雨",
+                          "duration_minutes": 18 }, ... ],
+        }
+    """
+    raw = data.get("minutely_precip") or data.get("minutely") or data.get("minutely_forecast")
+    if not raw:
+        return {"summary": "无分钟级降水数据", "ranges": [], "range_count": 0}
+
+    summary = raw.get("summary", "")
+    update_time = raw.get("update_time", "")
+    records = raw.get("data", [])
+
+    if not records:
+        return {
+            "summary": summary,
+            "update_time": update_time,
+            "ranges": [],
+            "range_count": 0,
+            "original_point_count": 0,
+        }
+
+    # 合并连续降水区间
+    ranges: list[dict[str, Any]] = []
+    current: list[dict[str, Any]] | None = None
+
+    for r in records:
+        precip = r.get("precip", 0)
+        if precip > 0:
+            if current is None:
+                current = [r]
+            else:
+                current.append(r)
+        else:
+            if current is not None:
+                ranges.append(_build_range(current))
+                current = None
+
+    if current is not None:
+        ranges.append(_build_range(current))
+
+    return {
+        "summary": summary,
+        "update_time": update_time,
+        "ranges": ranges,
+        "range_count": len(ranges),
+        "original_point_count": len(records),
+    }
 
 
 class WeatherTool(ToolBase):
@@ -55,6 +177,13 @@ class WeatherTool(ToolBase):
                 indices=indices,
                 lang=lang,
             )
+            # 自动压缩分钟级降水数据，替换原始 ~120 点数组，避免 LLM 接触冗余信息
+            if minutely:
+                compressed = _summarize_minutely(result)
+                # 替换所有原始键，确保 LLM 只看压缩版
+                for key in ("minutely_precip", "minutely", "minutely_forecast"):
+                    if key in result:
+                        result[key] = compressed
             return format_success(result)
         except Exception as e:
             return format_error(f"天气查询失败: {e}")

--- a/web/src/components/tools/WeatherBubble.vue
+++ b/web/src/components/tools/WeatherBubble.vue
@@ -57,6 +57,24 @@
             </div>
           </div>
 
+          <!-- 分钟级降水 -->
+          <div class="lf-precip" v-if="hasPrecip">
+            <div class="precip-summary">
+              <span class="precip-icon" v-html="precipIcon"></span>
+              <span>{{ precipData?.summary }}</span>
+            </div>
+            <div class="precip-ranges" v-if="precipData && precipData.ranges.length">
+              <div v-for="(range, i) in precipData.ranges" :key="i" class="precip-range-item">
+                <span class="p-time">{{ fmtTime(range.start) }} – {{ fmtTime(range.end) }}</span>
+                <span class="p-bar" :style="{ width: pBarWidth(range) + '%' }"
+                      :class="'p-level-' + range.intensity"></span>
+                <span class="p-intensity" :class="'p-level-' + range.intensity">{{ range.intensity }}</span>
+                <span class="p-duration">{{ range.duration_minutes }}′</span>
+                <span class="p-detail-extra" v-if="range.max_precip > 0.1">{{ range.max_precip }}mm</span>
+              </div>
+            </div>
+          </div>
+
           <!-- 详情 -->
           <div class="lf-details" v-if="hasDetails">
             <div class="lf-detail-item" v-if="td.temp_feel">
@@ -107,7 +125,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { ToolCall } from '@/types'
-import type { WeatherData, WeatherForecastItem } from './weather-types'
+import type { WeatherData, WeatherForecastItem, MinutePrecipSummary } from './weather-types'
 import BubbleChrome from './_shared/BubbleChrome.vue'
 
 const props = defineProps<{ toolCall: ToolCall }>()
@@ -266,6 +284,40 @@ const forecastList = computed<WeatherForecastItem[]>(() => {
   const fc = td.value.forecast
   return Array.isArray(fc) ? fc : []
 })
+
+// ── 分钟级降水 ──
+const precipData = computed<MinutePrecipSummary | null>(() => {
+  const p = td.value.minutely_precip
+  if (p && typeof p === 'object' && 'summary' in p && 'ranges' in p) {
+    return p as MinutePrecipSummary
+  }
+  return null
+})
+const hasPrecip = computed(() => !!precipData.value)
+
+const precipIcon = computed(() => {
+  const d = precipData.value
+  if (!d) return ''
+  if (d.range_count === 0) {
+    // 无降水
+    return '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.3"><circle cx="8" cy="8" r="5"/><line x1="8" y1="3" x2="8" y2="4"/><line x1="8" y1="12" x2="8" y2="13"/><line x1="3" y1="8" x2="4" y2="8"/><line x1="12" y1="8" x2="13" y2="8"/></svg>'
+  }
+  // 有降水
+  return '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.3"><path d="M3 8 Q3 5 5.5 5 Q6 3 8 3.5 Q10 3 10.5 5 Q13 4.8 13 8 L3 8Z"/><line x1="6" y1="10" x2="5.2" y2="13"/><line x1="9" y1="10" x2="8.2" y2="13"/><line x1="12" y1="10" x2="11.5" y2="12"/></svg>'
+})
+
+function fmtTime(iso: string): string {
+  if (!iso) return ''
+  // "2026-06-28T18:00:03+08:00" → "18:00"
+  const m = iso.match(/T(\d{2}:\d{2})/)
+  return m ? m[1] : iso
+}
+
+function pBarWidth(range: { max_precip: number; intensity: string }): number {
+  // 强度映射到宽度百分比
+  const map: Record<string, number> = { 暴雨: 100, 大雨: 72, 中雨: 44, 小雨: 22, 微量: 10 }
+  return map[range.intensity] || 10
+}
 
 function formatDay(day: string): string {
   if (!day) return ''
@@ -518,6 +570,85 @@ const displayOutput = computed(() => {
 .alert-text { color: var(--text-secondary); font-size: 11px; margin-top: 4px; }
 .alert-footer { margin-top: 6px; }
 .alert-guidance { font-size: 11px; color: var(--text-tertiary); line-height: 1.6; }
+
+/* ── 降水 ── */
+.lf-precip {
+  border-top: 1px solid var(--border);
+  padding: 6px 0 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.precip-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.precip-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-tertiary);
+}
+.precip-icon svg { width: 100%; height: 100%; }
+
+.precip-ranges {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin: 2px 0 0 20px;
+}
+.precip-range-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  line-height: 1.6;
+}
+.p-time {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+  min-width: 62px;
+  font-size: 10px;
+}
+.p-bar {
+  height: 6px;
+  border-radius: 1px;
+  min-width: 4px;
+  transition: width 0.2s;
+  background: currentColor;
+  opacity: 0.25;
+}
+.p-bar.p-level-暴雨 { color: #7c3aed; }
+.p-bar.p-level-大雨 { color: #dc2626; }
+.p-bar.p-level-中雨 { color: #ea580c; }
+.p-bar.p-level-小雨 { color: #2563eb; }
+.p-bar.p-level-微量 { color: var(--border); }
+.p-intensity {
+  font-size: 10px;
+  font-weight: 500;
+  min-width: 2em;
+}
+.p-intensity.p-level-暴雨 { color: #7c3aed; }
+.p-intensity.p-level-大雨 { color: #dc2626; }
+.p-intensity.p-level-中雨 { color: #ea580c; }
+.p-intensity.p-level-小雨 { color: #2563eb; }
+.p-intensity.p-level-微量 { color: var(--text-tertiary); }
+.p-duration {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+.p-detail-extra {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  margin-left: auto;
+}
 
 /* ── 降级 ── */
 .raw-output {

--- a/web/src/components/tools/weather-types.ts
+++ b/web/src/components/tools/weather-types.ts
@@ -28,6 +28,25 @@ export interface WeatherForecastItem {
   humidity?: string
 }
 
+/** 分钟级降水 — 单个降水区间 */
+export interface MinutePrecipRange {
+  start: string
+  end: string
+  max_precip: number
+  avg_precip: number
+  intensity: string
+  duration_minutes: number
+}
+
+/** 分钟级降水 — 压缩摘要 */
+export interface MinutePrecipSummary {
+  summary: string
+  update_time?: string
+  ranges: MinutePrecipRange[]
+  range_count: number
+  original_point_count: number
+}
+
 /** 逐小时预报（UI 暂未渲染） */
 export interface WeatherHourlyItem {
   time: string
@@ -68,7 +87,7 @@ export interface WeatherData {
 
   // 已提取但 UI 暂未渲染（阶段 F）
   hourly_forecast?: WeatherHourlyItem[]
-  minutely_precip?: unknown
+  minutely_precip?: MinutePrecipSummary
   minutely_forecast?: unknown
   life_indices?: Record<string, unknown>
 }


### PR DESCRIPTION
## 变更内容

### 后端 — 分钟级降水数据自动压缩
`tool_weather.py` 在 `minutely=True` 时，将上游 \~120 个 2 分钟间隔的降水数据点自动压缩为连续降水区间列表，每个区间携带：
- `max_precip` / `avg_precip` — 区间最大/平均降水强度
- `intensity` — 暴雨/大雨/中雨/小雨/微量 分级
- `duration_minutes` — 持续时间
- 原始 `data` 数组完全被替换，LLM 只接触压缩后的摘要结构

### 前端 — 气泡中渲染降水信息
- 新增 `MinutePrecipSummary` / `MinutePrecipRange` 类型
- 工具气泡中新增降水区块，位于**气象预警栏之下、详细信息栏之上**
- 无降水时只显示一行摘要文字
- 有降水时展示每个区间的时间范围、强度色条、等级标签、持续分钟数和降水量

## 预览

无降水时只显示一行摘要；有降水时展示区间时间轴。