### PR TITLE
fix: 修复 CodeQL 路径穿越安全漏洞

### DIFF
--- a/api/routes/images.py
+++ b/api/routes/images.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import FileResponse
 
+from tools.base import check_path_access
+
 router = APIRouter()
 
 IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp'}
@@ -25,5 +27,10 @@ async def serve_image(path: str = Query(...)):
     ext = file_path.suffix.lower()
     if ext not in IMAGE_EXTENSIONS:
         raise HTTPException(status_code=400, detail="不支持的图片格式")
+
+    # 安全校验：SonettoBlocker + 路径白名单
+    blocker_err = check_path_access(str(file_path))
+    if blocker_err is not None:
+        raise HTTPException(status_code=403, detail="路径被安全策略阻断")
 
     return FileResponse(path=str(file_path))

--- a/tools/network/tool_image_understand.py
+++ b/tools/network/tool_image_understand.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from zai import ZhipuAiClient
 
 from config.settings import get_settings
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, check_path_access, format_error, format_success
 
 MODEL = "glm-5v-turbo"
 
@@ -28,6 +28,10 @@ def _load_image_bytes(image_source: str) -> tuple[bytes, str]:
     """解析 image_source 前缀，返回 (bytes, mime_type)。"""
     if image_source.startswith("local:"):
         path = image_source[6:]
+        # 安全校验：SonettoBlocker + 路径白名单
+        err = check_path_access(path)
+        if err is not None:
+            raise PermissionError(err)
         file_path = Path(path)
         if not file_path.exists():
             raise FileNotFoundError(f"文件不存在: {path}")


### PR DESCRIPTION
## 修复内容

关闭 CodeQL 报告的 7 个 OPEN 安全告警（均为 HIGH 严重级别）。

### api/routes/images.py（4 个告警）
- `/api/images/serve` 端点缺少路径限制，可读取系统任意图片文件
- 修复：添加 `check_path_access()` 校验，与工具系统的 SonettoBlocker + 路径白名单一致

### tools/network/tool_image_understand.py（3 个告警）
- `local:` 前缀模式下可读取任意文件，无扩展名限制
- 修复：`_load_image_bytes()` 中读取本地文件前调用 `check_path_access()`

### 审计说明
已 dismissed 的告警（如 tools/base.py、sonetto_blocker.py、files.py）均已有 SonettoBlocker + 白名单保护，无须处理。