### PR TITLE
fix(api): 固定会话时展平多模态内容，剔除图片 base64

### DIFF
--- a/api/const_session_store.py
+++ b/api/const_session_store.py
@@ -20,13 +20,28 @@ def _ensure_dir() -> Path:
 # ── 消息序列化 ─────────────────────────────────────────────────
 
 
+def flatten_content(content) -> str:
+    """将消息 content 展平为纯文本字符串。
+
+    当 content 为列表（多模态格式，含 image_url 等）时，
+    仅提取所有 text 字段，忽略非文本块（图片 base64 等）。
+    """
+    if isinstance(content, list):
+        texts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                texts.append(part.get("text", ""))
+        return "\n".join(texts)
+    return content if isinstance(content, str) else str(content or "")
+
+
 def serialize_messages(raw_messages: list) -> list[dict]:
     """将 LangChain BaseMessage 对象列表转为可序列化的纯 dict 列表。"""
     result = []
     for msg in raw_messages:
         entry: dict = {
             "type": getattr(msg, "type", "unknown"),
-            "content": msg.content if hasattr(msg, "content") else str(msg),
+            "content": flatten_content(msg.content) if hasattr(msg, "content") else str(msg),
         }
         if hasattr(msg, "tool_call_id") and msg.tool_call_id:
             entry["tool_call_id"] = msg.tool_call_id

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from api.const_session_store import flatten_content
 from api.context_usage import estimate_context_usage
 from agent.prompts import get_system_prompt_parts
 
@@ -209,7 +210,7 @@ async def generate_session_title(session_id: str, request: Request):
     conversation_lines = []
     for m in messages:
         role = "user" if m.type == "human" else "assistant"
-        content = (m.content[:600] if hasattr(m, "content") else str(m))[:600]
+        content = flatten_content(getattr(m, "content", None))[:600]
         conversation_lines.append(f"[{role}]\n{content}")
     conversation_text = "\n\n".join(conversation_lines)
 


### PR DESCRIPTION
## 问题

多模态消息的 content 为列表格式（含 `image_url` base64），标题生成时将整个列表 repr 混入 prompt，耗竭 LLM 上下文窗口；固定会话时将 base64 原样写入 YAML，文件体积暴增。

## 修改

新增 `flatten_content()` 工具函数，将消息 content 展平为纯文本：
- 列表格式 → 仅提取 `type == \text\` 的字段
- 字符串 → 原样返回

应用到两个位置：
1. `serialize_messages` — 固定会话 YAML 存储不再包含 base64
2. `generate_title` — 标题生成 prompt 只含对话文本

## 测试

- 普通纯文本会话：无行为变化
- 含图片的多模态会话：YAML 体积大幅缩减，标题生成 prompt 不再被 base64 污染