### PR TITLE
refactor(config): 统一配置文件目录到 config/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,17 +61,17 @@ config/personas/memory.yaml
 *.clean
 
 # Provider credentials (明文 API key)
-providers.yaml
+config/providers.yaml
 
 # 路径白名单（自动生成，每用户本地配置）
-api/data/path_whitelist.yaml
+config/path_whitelist.yaml
 
 # SonettoBlocker 拒止锚数据（自动生成，每用户本地配置）
-api/data/sonetto_blocker.yaml
-api/data/SonettoBlocker
+config/sonetto_blocker.yaml
+config/SonettoBlocker
 
 # 认证 Token（自动生成，每用户本地配置）
-api/data/auth_token.yaml
+config/auth_token.yaml
 
 # MCP 服务器配置（每用户本地配置，可能含 API Key 等敏感信息）
 config/mcp_servers.yaml

--- a/api/auth.py
+++ b/api/auth.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 
-AUTH_TOKEN_PATH = Path(__file__).resolve().parent / "data" / "auth_token.yaml"
+AUTH_TOKEN_PATH = Path(__file__).resolve().parent.parent / "config" / "auth_token.yaml"
 
 
 def load_or_create_token() -> str:

--- a/api/providers/store.py
+++ b/api/providers/store.py
@@ -10,7 +10,9 @@ from api.providers import ProviderConfig
 class ProviderConfigStore:
     """读写 providers.yaml，API key 直接存储在文件中。"""
 
-    def __init__(self, path: str | Path = "providers.yaml"):
+    def __init__(self, path: str | Path | None = None):
+        if path is None:
+            path = Path(__file__).resolve().parent.parent.parent / "config" / "providers.yaml"
         self.path = Path(path)
 
     def load_all(self) -> list[ProviderConfig]:

--- a/api/routes/env_vars.py
+++ b/api/routes/env_vars.py
@@ -10,7 +10,7 @@ from config.settings import get_settings
 
 router = APIRouter()
 
-ENV_PATH = Path(__file__).resolve().parent.parent.parent / ".env"
+ENV_PATH = Path(__file__).resolve().parent.parent.parent / "config" / ".env"
 
 # ── 已知环境变量元信息 ──
 

--- a/api/routes/path_whitelist.py
+++ b/api/routes/path_whitelist.py
@@ -14,8 +14,7 @@ router = APIRouter()
 
 WHITELIST_PATH = (
     Path(__file__).resolve().parent.parent.parent
-    / "api"
-    / "data"
+    / "config"
     / "path_whitelist.yaml"
 )
 

--- a/api/routes/sonetto_blocker.py
+++ b/api/routes/sonetto_blocker.py
@@ -14,8 +14,7 @@ router = APIRouter()
 
 YAML_PATH = (
     Path(__file__).resolve().parent.parent.parent
-    / "api"
-    / "data"
+    / "config"
     / "sonetto_blocker.yaml"
 )
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     tavily_api_key: str = ""
 
     model_config = {
-        "env_file": ".env",
+        "env_file": "config/.env",
         "env_file_encoding": "utf-8",
         "extra": "ignore",
     }

--- a/memory/user_init.py
+++ b/memory/user_init.py
@@ -38,10 +38,12 @@ def ensure_soul_md() -> None:
 
 
 def ensure_env_file() -> None:
-    """若 .env 不存在，从 .env.example 复制。"""
+    """若 .env 不存在，从 .env.example 复制到 config/。"""
+    env_dst = PROJECT_ROOT / "config" / ".env"
+    env_dst.parent.mkdir(parents=True, exist_ok=True)
     _copy_if_missing(
         PROJECT_ROOT / ".env.example",
-        PROJECT_ROOT / ".env",
+        env_dst,
         "请编辑 .env 填写 API Key",
     )
 

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ def setup_frontend():
 
 
 def setup_env():
-    env_path = os.path.join(PROJECT_ROOT, ".env")
+    env_path = os.path.join(PROJECT_ROOT, "config", ".env")
     example_path = os.path.join(PROJECT_ROOT, ".env.example")
 
     if os.path.exists(env_path):
@@ -230,7 +230,7 @@ def setup_provider():
         provider_id = "custom-provider"
 
     # 写入 providers.yaml
-    yaml_path = os.path.join(PROJECT_ROOT, "providers.yaml")
+    yaml_path = os.path.join(PROJECT_ROOT, "config", "providers.yaml")
     models_block = "\n".join(f"  - {m}" for m in models)
     entry = f"""- api_key: {api_key}
   base_url: {base_url}
@@ -298,9 +298,9 @@ def setup_persona():
 
 
 def summary():
-    env_path = os.path.join(PROJECT_ROOT, ".env")
+    env_path = os.path.join(PROJECT_ROOT, "config", ".env")
     env_ok = os.path.exists(env_path)
-    prov_path = os.path.join(PROJECT_ROOT, "providers.yaml")
+    prov_path = os.path.join(PROJECT_ROOT, "config", "providers.yaml")
     prov_ok = os.path.exists(prov_path) and os.path.getsize(prov_path) > 20
     print()
     print("=" * 48)

--- a/tests/test_memory/test_user_init.py
+++ b/tests/test_memory/test_user_init.py
@@ -123,14 +123,14 @@ class TestEnsureEnvFile:
     """ensure_env_file 测试。"""
 
     def test_creates_env_from_example(self, monkeypatch, tmp_path):
-        """.env 不存在时从 example 复制。"""
+        """.env 不存在时从 example 复制到 config/。"""
         project_root = tmp_path
         example = project_root / ".env.example"
         example.write_text("API_KEY=test", encoding="utf-8")
 
         monkeypatch.setattr(user_init, "PROJECT_ROOT", project_root)
 
-        env_file = project_root / ".env"
+        env_file = project_root / "config" / ".env"
         assert not env_file.exists()
 
         user_init.ensure_env_file()
@@ -144,7 +144,9 @@ class TestEnsureEnvFile:
         example = project_root / ".env.example"
         example.write_text("新内容。", encoding="utf-8")
 
-        env_file = project_root / ".env"
+        config_dir = project_root / "config"
+        config_dir.mkdir(parents=True)
+        env_file = config_dir / ".env"
         env_file.write_text("用户已有的配置。", encoding="utf-8")
 
         monkeypatch.setattr(user_init, "PROJECT_ROOT", project_root)
@@ -160,7 +162,7 @@ class TestEnsureEnvFile:
 
         user_init.ensure_env_file()
 
-        env_file = project_root / ".env"
+        env_file = project_root / "config" / ".env"
         assert not env_file.exists()
 
 
@@ -186,4 +188,4 @@ class TestEnsureAll:
         # 三个目标文件都应被创建
         assert (persona_dir / "USER.md").exists()
         assert (persona_dir / "SOUL.md").exists()
-        assert (project_root / ".env").exists()
+        assert (project_root / "config" / ".env").exists()

--- a/tools/base.py
+++ b/tools/base.py
@@ -149,7 +149,7 @@ def check_sonetto_blocker(target_path: str) -> str | None:
 # ── 路径白名单 ──────────────────────────────────────────────
 
 _WHITELIST_PATH = (
-    Path(__file__).resolve().parent.parent / "api" / "data" / "path_whitelist.yaml"
+    Path(__file__).resolve().parent.parent / "config" / "path_whitelist.yaml"
 )
 
 # 项目根目录：由 base.py 所在位置 (tools/base.py) 向上推一级
@@ -163,7 +163,7 @@ _DEFAULT_MACROS_WHITELIST_PATH = os.path.join(_PROJECT_ROOT, "macros")
 # ── 路径白名单 ──────────────────────────────────────────────
 
 _WHITELIST_PATH = (
-    Path(__file__).resolve().parent.parent / "api" / "data" / "path_whitelist.yaml"
+    Path(__file__).resolve().parent.parent / "config" / "path_whitelist.yaml"
 )
 
 
@@ -268,15 +268,15 @@ def _write_whitelist(entries: list) -> None:
 
 
 _BLOCKER_YAML_PATH = (
-    Path(__file__).resolve().parent.parent / "api" / "data" / "sonetto_blocker.yaml"
+    Path(__file__).resolve().parent.parent / "config" / "sonetto_blocker.yaml"
 )
 
 _BLOCKER_FILENAME = "SonettoBlocker"
-_AUTO_BLOCKER_PATH = os.path.join(_PROJECT_ROOT, "api", "data")
+_AUTO_BLOCKER_PATH = os.path.join(_PROJECT_ROOT, "config")
 
 
 def _ensure_blocker() -> None:
-    """确保 api/data/ 目录受 SonettoBlocker 保护。
+    """确保 config/ 目录受 SonettoBlocker 保护。
 
     在模块导入时自动运行：
     - 如果 api/data/ 下没有 SonettoBlocker 标记文件 → 创建
@@ -327,6 +327,8 @@ def _ensure_blocker() -> None:
 # 模块加载时自动执行：确保白名单存在 + api/data/ 拒止锚存在（首次 import 时运行一次）
 _ensure_whitelist()
 _ensure_blocker()
+
+# ── 路径白名单加载 ──────────────────────────────────────────────
 
 
 def _load_path_whitelist() -> list[tuple[str, bool]]:

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 
 function loadApiToken(): string {
   try {
-    const yamlPath = path.resolve(__dirname, '..', 'api', 'data', 'auth_token.yaml')
+    const yamlPath = path.resolve(__dirname, '..', 'config', 'auth_token.yaml')
     const raw = fs.readFileSync(yamlPath, 'utf-8')
     const match = raw.match(/^token:\s*(.+)$/m)
     const token = match?.[1]?.trim()


### PR DESCRIPTION
## 变更内容

将所有散落的配置文件集中到 `config/` 目录下，`api/data/` 仅保留运行时数据和发布内容。

### 迁移清单

| 文件 | 旧位置 → 新位置 |
|------|----------------|
| providers.yaml | 项目根目录 → config/ |
| .env | 项目根目录 → config/ |
| auth_token.yaml | api/data/ → config/ |
| path_whitelist.yaml | api/data/ → config/ |
| sonetto_blocker.yaml | api/data/ → config/ |
| SonettoBlocker 标记 | api/data/ → config/ |

### 涉及的代码变更（12 个文件）

更新了所有模块的 `__file__` 路径解析，同步更新 .gitignore 条目和测试适配。

### 验证

- ✅ 166 个测试全部通过
- ✅ 服务正常启动，无 import 错误
- ✅ 5 个配置 API 端点（providers、env-vars、path-whitelist、sonetto-blocker、news）返回正常

Closes #204