### PR TITLE
fix: 修复添加 Provider 后 app.state.llm 不刷新导致 Memory 消费者异常和标题生成无响应

### DIFF
--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from api.providers import ProviderConfig
 from api.providers.vision import detect_vision_capabilities
+from api.dependencies import get_llm
 
 router = APIRouter()
 
@@ -50,6 +51,27 @@ class TestConnectionBody(BaseModel):
 
 def _get_manager(request: Request):
     return request.app.state.provider_manager
+
+
+async def _refresh_app_llm(request: Request) -> None:
+    """从 provider_manager 刷新 app.state.llm，同步 LTM 消费者生命周期。"""
+    mgr = _get_manager(request)
+    old_llm = getattr(request.app.state, "llm", None)
+    ltm = getattr(request.app.state, "ltm", None)
+
+    try:
+        request.app.state.llm = get_llm(mgr)
+        if old_llm is None and ltm is not None and not ltm.is_listening:
+            ltm.start_listening(
+                request.app.state.llm,
+                ws_registry=request.app.state.ws_registry,
+            )
+            print("[provider] LLM became available \u2014 LTM consumer started")
+    except RuntimeError:
+        request.app.state.llm = None
+        if ltm is not None and ltm.is_listening:
+            await ltm.stop_listening()
+            print("[provider] LLM became unavailable \u2014 LTM consumer stopped")
 
 
 # ── CRUD ────────────────────────────────────────────────
@@ -100,6 +122,7 @@ async def create_provider(body: ProviderCreateBody, request: Request):
         config.model_vision = vision
         mgr.save_config(config)
 
+    await _refresh_app_llm(request)
     return config.to_dict()
 
 
@@ -124,14 +147,16 @@ async def update_provider(provider_id: str, body: ProviderUpdateBody, request: R
         config.model_vision = vision
         mgr.save_config(config)
 
+    await _refresh_app_llm(request)
     return config.to_dict()
 
 
 @router.delete("/providers/{provider_id}")
-def delete_provider(provider_id: str, request: Request):
+async def delete_provider(provider_id: str, request: Request):
     """删除提供商配置。"""
     if not _get_manager(request).delete_config(provider_id):
         raise HTTPException(status_code=404, detail="Provider not found")
+    await _refresh_app_llm(request)
     return {"status": "deleted"}
 
 

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from api.const_session_store import flatten_content
 from api.context_usage import estimate_context_usage
+from api.dependencies import get_llm
 from agent.prompts import get_system_prompt_parts
 
 router = APIRouter()
@@ -232,7 +233,19 @@ async def generate_session_title(session_id: str, request: Request):
     prompt = f"{system_prompt}\n\n对话内容：\n{conversation_text}\n\n标题："
 
     try:
-        llm = request.app.state.llm
+        # 优先通过 provider_manager 动态获取 LLM（支持 Web UI 添加后的热更新）
+        mgr = getattr(request.app.state, "provider_manager", None)
+        if mgr is not None and mgr.count > 0:
+            llm = get_llm(mgr)
+        else:
+            llm = request.app.state.llm
+
+        if llm is None:
+            raise HTTPException(
+                status_code=503,
+                detail="没有可用的 LLM 提供商。请在模型设置中添加并启用一个提供商。",
+            )
+
         response = await llm.ainvoke(prompt)
         title = (
             response.content.strip().strip('"').strip("'")
@@ -242,6 +255,8 @@ async def generate_session_title(session_id: str, request: Request):
         title = title[:50]
         if not title:
             title = "未命名会话"
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"标题生成失败: {e}")
 

--- a/web/src/components/SessionSidebar.vue
+++ b/web/src/components/SessionSidebar.vue
@@ -158,6 +158,7 @@
           @click.stop
         >
           <div class="constify-card-title">固定会话</div>
+          <div v-if="constifyError" class="constify-error">{{ constifyError }}</div>
           <div class="constify-input-row">
             <input
               ref="constifyInputRef"
@@ -336,6 +337,7 @@ const constifyInputRef = ref<HTMLInputElement | null>(null)
 const constifyCardTop = ref(0)
 const constifyCardLeft = ref(0)
 const generating = ref(false)
+const constifyError = ref('')
 
 /** 鼠标右键触发时的目标元素 rect，用于定位卡片 */
 let constifyAnchorRect: DOMRect | null = null
@@ -380,6 +382,7 @@ function showConstifyCard(session: SessionInfo) {
   }
   constifyTarget.value = session
   constifyName.value = session.const_name || ''
+  constifyError.value = ''
   closeContextMenu()
   nextTick(() => {
     adjustConstifyCardPosition()
@@ -401,6 +404,7 @@ async function generateTitle() {
     })
   } catch (e) {
     console.error('[constify] 标题生成失败:', e)
+    constifyError.value = e instanceof Error ? e.message : '标题生成失败'
   } finally {
     generating.value = false
   }
@@ -416,6 +420,7 @@ function confirmConstify() {
 function cancelConstify() {
   constifyTarget.value = null
   constifyName.value = ''
+  constifyError.value = ''
 }
 
 // ── 悬浮详情卡片 ──────────────────────────────────────────────
@@ -784,6 +789,16 @@ function closeContextMenu() {
   font-size: 14px;
   font-weight: 600;
   color: var(--text-primary);
+}
+
+.constify-error {
+  font-size: 12px;
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.08);
+  padding: 6px 10px;
+  border-radius: 6px;
+  line-height: 1.4;
+  word-break: break-all;
 }
 
 .constify-input-row {


### PR DESCRIPTION
## 问题

两个表面症状，同一根因：
1. Memory 状态显示"后台消费者异常"
2. 标题生成按钮无反应

**根因**：`app.state.llm` 只在启动时初始化一次。若启动时 `providers.yaml` 为空，用户随后在 Web UI 添加 Provider 后，`app.state.llm` 仍为 `None`，导致 Memory 消费者未启动、标题生成调用崩溃。

## 修改

| 文件 | 修改 |
|------|------|
| `api/routes/providers.py` | 添加 `_refresh_app_llm()`，CRUD 后自动刷新 `app.state.llm` 并同步启动/停止 Memory 消费者 |
| `api/routes/sessions.py` | 标题生成改为通过 `provider_manager` 动态获取 LLM，无 LLM 时返回 503 明确提示 |
| `web/src/components/SessionSidebar.vue` | 标题生成失败时在卡片内显示红色错误信息（之前仅 console.error） |

Closes #206