### PR TITLE
feat: 默认供应商/模型 UI + 能力检测框架

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -10,11 +10,21 @@ _tools: list | None = None
 def get_llm(provider_manager=None):
     """获取 LLM。
 
-    从 ProviderManager 中取第一个 enabled provider 创建 LLM。
+    从 ProviderManager 中优先取 is_default_provider=True 的供应商创建 LLM，
+    若无默认供应商则取第一个 enabled provider。
     若无可用的 provider 则抛出 RuntimeError。
     LLM 配置统一由 providers.yaml 管理，不再降级到 .env。
     """
     if provider_manager is not None and provider_manager.count > 0:
+        # 优先取默认供应商
+        for provider in provider_manager.iter_enabled():
+            if provider.config.is_default_provider:
+                return provider.create_llm(
+                    provider.default_model,
+                    temperature=0.7,
+                    streaming=True,
+                )
+        # 退化到第一个 enabled provider
         for provider in provider_manager.iter_enabled():
             return provider.create_llm(
                 provider.default_model,

--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -20,11 +20,20 @@ class ProviderConfig:
     enabled: bool = True
     context_window: int = 256_000
     model_vision: dict[str, bool] = field(default_factory=dict)
+    model_capabilities: dict[str, dict[str, bool]] = field(default_factory=dict)
+    is_default_provider: bool = False
+    default_model: str | None = None
 
     def to_dict(self) -> dict:
         d = asdict(self)
         if not d.get("model_vision"):
             del d["model_vision"]
+        if not d.get("model_capabilities"):
+            d.pop("model_capabilities", None)
+        if not d.get("is_default_provider"):
+            d.pop("is_default_provider", None)
+        if d.get("default_model") is None:
+            d.pop("default_model", None)
         return d
 
 
@@ -49,6 +58,8 @@ class Provider(ABC):
 
     @property
     def default_model(self) -> str:
+        if self.config.default_model and self.config.default_model in self.config.models:
+            return self.config.default_model
         return self.config.models[0] if self.config.models else ""
 
     @property

--- a/api/providers/capabilities/__init__.py
+++ b/api/providers/capabilities/__init__.py
@@ -1,0 +1,36 @@
+"""通用能力检测框架 — 注册检测器与辅助函数。"""
+
+from pathlib import Path
+
+from api.providers import ProviderConfig
+from api.providers.capabilities.base import CapabilityTester  # noqa: F401
+from api.providers.capabilities.base import CapabilityTestResult  # noqa: F401
+from api.providers.capabilities.vision import VisionTester
+from api.providers.capabilities.tool_call import ToolCallTester
+from api.providers.capabilities.structured_output import StructuredOutputTester
+from api.providers.openai_provider import OpenAIProvider
+
+
+def get_all_testers(image_path: Path | None = None) -> list[CapabilityTester]:
+    """返回所有可用的能力检测器。"""
+    testers: list[CapabilityTester] = [
+        ToolCallTester(),
+        StructuredOutputTester(),
+    ]
+    if image_path and image_path.exists():
+        testers.append(VisionTester(image_path))
+    return testers
+
+
+async def test_model_capabilities(
+    config: ProviderConfig,
+    model_name: str,
+    testers: list[CapabilityTester],
+) -> dict[str, bool]:
+    """对单个模型运行所有检测器，返回能力名 → 是否支持的映射。"""
+    provider = OpenAIProvider(config)
+    results: dict[str, bool] = {}
+    for tester in testers:
+        result = await tester.test(provider, model_name)
+        results[result.capability] = result.supported
+    return results

--- a/api/providers/capabilities/base.py
+++ b/api/providers/capabilities/base.py
@@ -1,0 +1,28 @@
+"""能力检测基础类型 — CapabilityTester 接口与 CapabilityTestResult。"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class CapabilityTestResult:
+    """单个模型的能力检测结果。"""
+
+    capability: str          # "vision" | "tool_call" | "structured_output"
+    supported: bool          # 是否支持该能力
+    detail: str | None = None  # 失败原因/补充信息
+
+
+class CapabilityTester(ABC):
+    """所有能力检测器必须实现的接口。"""
+
+    @property
+    @abstractmethod
+    def capability_name(self) -> str:
+        """能力名称标识，例如 'vision'、'tool_call'、'structured_output'。"""
+        ...
+
+    @abstractmethod
+    async def test(self, provider, model_name: str) -> CapabilityTestResult:
+        """检测指定模型是否支持该能力。"""
+        ...

--- a/api/providers/capabilities/structured_output.py
+++ b/api/providers/capabilities/structured_output.py
@@ -1,0 +1,56 @@
+"""模型结构化输出能力检测器。
+
+请求 response_format: {type: "json_object"} 看模型能否返回合法 JSON。
+"""
+
+from langchain_core.messages import HumanMessage
+
+from api.providers import Provider
+from api.providers.capabilities.base import CapabilityTester, CapabilityTestResult
+
+_PROMPT = 'Output a JSON object with one key "name" set to "test". Reply with ONLY valid JSON.'
+
+
+class StructuredOutputTester(CapabilityTester):
+    """检测模型是否支持 JSON 结构化输出。"""
+
+    @property
+    def capability_name(self) -> str:
+        return "structured_output"
+
+    async def test(self, provider: Provider, model_name: str) -> CapabilityTestResult:
+        try:
+            llm = provider.create_llm(
+                model_name,
+                temperature=0,
+                model_kwargs={"response_format": {"type": "json_object"}},
+            )
+
+            response = await llm.ainvoke([HumanMessage(content=_PROMPT)])
+            raw = response.content if hasattr(response, "content") else str(response)
+            text = raw if isinstance(raw, str) else str(raw)
+
+            import json
+            data = json.loads(text.strip().removeprefix("```json").removesuffix("```").strip())
+            if isinstance(data, dict) and "name" in data:
+                return CapabilityTestResult(
+                    capability="structured_output",
+                    supported=True,
+                )
+            return CapabilityTestResult(
+                capability="structured_output",
+                supported=False,
+                detail=f"Response did not contain expected key: {text[:200]}",
+            )
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            return CapabilityTestResult(
+                capability="structured_output",
+                supported=False,
+                detail=str(exc)[:200],
+            )
+        except Exception as exc:
+            return CapabilityTestResult(
+                capability="structured_output",
+                supported=False,
+                detail=str(exc)[:200],
+            )

--- a/api/providers/capabilities/tool_call.py
+++ b/api/providers/capabilities/tool_call.py
@@ -1,0 +1,59 @@
+"""模型工具调用能力检测器。
+
+向模型发一条带虚假 tool_choice 的消息，看模型能否正常响应。
+"""
+
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+
+from api.providers import Provider
+from api.providers.capabilities.base import CapabilityTester, CapabilityTestResult
+
+
+@tool
+def _test_tool(query: str) -> str:
+    """A test tool for capability detection."""
+    return f"echo: {query}"
+
+
+class ToolCallTester(CapabilityTester):
+    """检测模型是否支持工具/函数调用。"""
+
+    @property
+    def capability_name(self) -> str:
+        return "tool_call"
+
+    async def test(self, provider: Provider, model_name: str) -> CapabilityTestResult:
+        try:
+            llm = provider.create_llm(model_name, temperature=0).bind_tools([_test_tool])
+
+            response = await llm.ainvoke([
+                HumanMessage(content="Say 'ping' using the test tool.")
+            ])
+
+            # 检查响应是否包含工具调用
+            if hasattr(response, "tool_calls") and response.tool_calls:
+                return CapabilityTestResult(
+                    capability="tool_call",
+                    supported=True,
+                )
+
+            # 部分模型会拒绝调用但返回有效文本，也算支持工具调用
+            if hasattr(response, "content") and response.content:
+                return CapabilityTestResult(
+                    capability="tool_call",
+                    supported=True,
+                    detail="Model responded with text instead of tool call, but did not error",
+                )
+
+            return CapabilityTestResult(
+                capability="tool_call",
+                supported=False,
+                detail="No tool call and no valid response",
+            )
+        except Exception as exc:
+            return CapabilityTestResult(
+                capability="tool_call",
+                supported=False,
+                detail=str(exc),
+            )

--- a/api/providers/capabilities/vision.py
+++ b/api/providers/capabilities/vision.py
@@ -1,0 +1,60 @@
+"""模型视觉能力检测器。
+
+向模型发送一张包含文字 "Sonetto" 的测试图片，
+要求模型读出图片中的文字，若响应包含 "Sonetto" 则视为有视觉能力。
+"""
+
+import base64
+from pathlib import Path
+
+from langchain_core.messages import HumanMessage
+
+from api.providers import Provider
+from api.providers.capabilities import CapabilityTester, CapabilityTestResult
+
+_PROMPT = "What text is shown in this image? Reply with only the text."
+
+
+class VisionTester(CapabilityTester):
+    """检测模型是否支持多模态视觉输入。"""
+
+    def __init__(self, image_path: Path):
+        self.image_path = image_path
+
+    @property
+    def capability_name(self) -> str:
+        return "vision"
+
+    async def test(self, provider: Provider, model_name: str) -> CapabilityTestResult:
+        try:
+            llm = provider.create_llm(model_name, temperature=0)
+
+            with open(self.image_path, "rb") as f:
+                image_bytes = f.read()
+            image_b64 = base64.b64encode(image_bytes).decode("utf-8")
+
+            message = HumanMessage(
+                content=[
+                    {"type": "text", "text": _PROMPT},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{image_b64}"},
+                    },
+                ]
+            )
+
+            response = await llm.ainvoke([message])
+            raw = response.content if hasattr(response, "content") else str(response)
+            text = raw if isinstance(raw, str) else str(raw)
+            supported = "Sonetto".lower() in text.lower()
+            return CapabilityTestResult(
+                capability="vision",
+                supported=supported,
+                detail=None if supported else "Response did not contain expected text 'Sonetto'",
+            )
+        except Exception as exc:
+            return CapabilityTestResult(
+                capability="vision",
+                supported=False,
+                detail=str(exc),
+            )

--- a/api/providers/vision.py
+++ b/api/providers/vision.py
@@ -1,79 +1,42 @@
-"""模型视觉能力检测。
+"""模型视觉能力检测 — 兼容层，委托到 capabilities 包。"""
 
-保存提供商时自动检测每个模型是否具备视觉能力：
-1. 向模型发送一张包含文字 "Sonetto" 的测试图片
-2. 要求模型读出图片中的文字
-3. 若响应中包含 "Sonetto" 则视为有视觉能力，否则无
-"""
-
-import asyncio
-import base64
 from pathlib import Path
 
-from langchain_core.messages import HumanMessage
-
-from api.providers import Provider, ProviderConfig
-
-_PROMPT = "What text is shown in this image? Reply with only the text."
+from api.providers import ProviderConfig
+from api.providers.capabilities.vision import VisionTester
+from api.providers.openai_provider import OpenAIProvider
 
 
 async def test_model_vision(
-    provider: Provider, model_name: str, image_path: Path
+    provider: "api.providers.Provider", model_name: str, image_path: Path
 ) -> bool:
-    """检测单个模型是否具备视觉能力。
-
-    向模型发送一张包含 "Sonetto" 文字的测试图片，要求读出文字。
-    若报错或响应不包含 "Sonetto" 则认为该模型无视觉能力。
-    """
-    try:
-        llm = provider.create_llm(model_name, temperature=0)
-
-        with open(image_path, "rb") as f:
-            image_bytes = f.read()
-        image_b64 = base64.b64encode(image_bytes).decode("utf-8")
-
-        message = HumanMessage(
-            content=[
-                {"type": "text", "text": _PROMPT},
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{image_b64}"},
-                },
-            ]
-        )
-
-        response = await llm.ainvoke([message])
-        raw = response.content if hasattr(response, "content") else str(response)
-        text = raw if isinstance(raw, str) else str(raw)
-        return "Sonetto".lower() in text.lower()
-    except Exception:
-        return False
+    """检测单个模型是否具备视觉能力（兼容旧接口）。"""
+    tester = VisionTester(image_path)
+    result = await tester.test(provider, model_name)
+    return result.supported
 
 
 async def detect_vision_capabilities(
     config: ProviderConfig, image_path: Path
 ) -> dict[str, bool]:
-    """批量检测提供商下所有模型的视觉能力。
+    """批量检测提供商下所有模型的视觉能力（兼容旧接口）。"""
+    import asyncio
 
-    并发测试 config.models 中的每个模型，返回 model_name → bool 的映射。
-    测试失败的模型视为无视觉能力。
-    """
     if not config.models:
         return {}
 
-    from api.providers.openai_provider import OpenAIProvider
-
     provider = OpenAIProvider(config)
+    tester = VisionTester(image_path)
 
-    tasks = [
-        test_model_vision(provider, model, image_path) for model in config.models
-    ]
+    tasks = [tester.test(provider, model) for model in config.models]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     vision: dict[str, bool] = {}
     for model, result in zip(config.models, results):
         if isinstance(result, bool):
-            vision[model] = result
+            vision[model] = bool(result)
+        elif hasattr(result, "supported"):
+            vision[model] = result.supported
         else:
             vision[model] = False
 

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -24,9 +24,17 @@ router = APIRouter()
 
 
 def _get_provider_context(app_state) -> tuple[int, str]:
-    """从 ProviderManager 获取默认 context_window 和 model_name。"""
+    """从 ProviderManager 获取默认 context_window 和 model_name。
+
+    优先取 is_default_provider=True 的供应商。
+    """
     mgr = getattr(app_state, "provider_manager", None)
     if mgr is not None and mgr.count > 0:
+        # 优先取默认供应商
+        for provider in mgr.iter_enabled():
+            if provider.config.is_default_provider:
+                return provider.config.context_window, provider.default_model
+        # 退化到第一个 enabled provider
         for provider in mgr.iter_enabled():
             return provider.config.context_window, provider.default_model
     return 256_000, ""
@@ -397,6 +405,34 @@ async def _run_agent_turn(
                 "payload": {"code": "AGENT_ERROR", "message": str(e)},
             }
         )
+        # 运行时能力修正：检测是否因能力不足导致错误，触发重测
+        if provider_id and model_name and hasattr(app_state, "provider_manager"):
+            try:
+                mgr = app_state.provider_manager
+                config = mgr.get_config(provider_id)
+                if config is not None:
+                    err_str = str(e).lower()
+                    needs_retest = []
+                    if "vision" in err_str or "image" in err_str or "multimodal" in err_str:
+                        needs_retest.append("vision")
+                    if "tool" in err_str or "function call" in err_str:
+                        needs_retest.append("tool_call")
+                    if "json" in err_str or "structure" in err_str or "parse" in err_str:
+                        needs_retest.append("structured_output")
+                    if needs_retest:
+                        from api.providers.capabilities import get_all_testers, test_model_capabilities
+                        testers = [
+                            t for t in get_all_testers()
+                            if t.capability_name in needs_retest
+                        ]
+                        if testers:
+                            results = await test_model_capabilities(config, model_name, testers)
+                            model_caps = config.model_capabilities.get(model_name, {})
+                            model_caps.update(results)
+                            config.model_capabilities[model_name] = model_caps
+                            mgr.save_config(config)
+            except Exception as retest_err:
+                print(f"[capability-retest] Error during retest: {retest_err}", file=sys.stderr)
     finally:
         session._active_task = None
         context_usage = await _calculate_context_usage(

--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -1,4 +1,4 @@
-"""REST API — 提供商 CRUD 与连接测试。"""
+"""REST API — 提供商 CRUD、连接测试、能力检测。"""
 
 from pathlib import Path
 
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from api.providers import ProviderConfig
-from api.providers.vision import detect_vision_capabilities
+from api.providers.capabilities import get_all_testers, test_model_capabilities
 from api.dependencies import get_llm
 
 router = APIRouter()
@@ -38,12 +38,19 @@ class ProviderUpdateBody(BaseModel):
     models: list[str] | None = None
     enabled: bool | None = None
     context_window: int | None = None
+    is_default_provider: bool | None = None
+    default_model: str | None = None
 
 
 class TestConnectionBody(BaseModel):
     api_key: str
     base_url: str
     provider_type: str = "openai"
+
+
+class TestCapabilityBody(BaseModel):
+    model_name: str
+    capability: str | None = None  # None = 测试所有能力
 
 
 # ── HELPERS ─────────────────────────────────────────────
@@ -66,12 +73,24 @@ async def _refresh_app_llm(request: Request) -> None:
                 request.app.state.llm,
                 ws_registry=request.app.state.ws_registry,
             )
-            print("[provider] LLM became available \u2014 LTM consumer started")
+            print("[provider] LLM became available — LTM consumer started")
     except RuntimeError:
         request.app.state.llm = None
         if ltm is not None and ltm.is_listening:
             await ltm.stop_listening()
-            print("[provider] LLM became unavailable \u2014 LTM consumer stopped")
+            print("[provider] LLM became unavailable — LTM consumer stopped")
+
+
+def _get_testers() -> list:
+    """获取可用的能力检测器列表。"""
+    from api.providers.capabilities.vision import VisionTester
+    from api.providers.capabilities.tool_call import ToolCallTester
+    from api.providers.capabilities.structured_output import StructuredOutputTester
+
+    testers = [ToolCallTester(), StructuredOutputTester()]
+    if IMAGE_PATH.exists():
+        testers.append(VisionTester(IMAGE_PATH))
+    return testers
 
 
 # ── CRUD ────────────────────────────────────────────────
@@ -95,7 +114,7 @@ def get_provider(provider_id: str, request: Request):
 
 @router.post("/providers")
 async def create_provider(body: ProviderCreateBody, request: Request):
-    """新增提供商，并自动检测每个模型的视觉能力。"""
+    """新增提供商（不再自动检测能力，需用户手动触发）。"""
     mgr = _get_manager(request)
     if mgr.get_config(body.id) is not None:
         raise HTTPException(
@@ -113,40 +132,43 @@ async def create_provider(body: ProviderCreateBody, request: Request):
         context_window=body.context_window,
     )
 
-    # 先写入基础配置（不含 vision）
     mgr.save_config(config)
-
-    # 检测视觉能力并更新配置
-    if config.models and IMAGE_PATH.exists():
-        vision = await detect_vision_capabilities(config, IMAGE_PATH)
-        config.model_vision = vision
-        mgr.save_config(config)
-
     await _refresh_app_llm(request)
     return config.to_dict()
 
 
 @router.put("/providers/{provider_id}")
 async def update_provider(provider_id: str, body: ProviderUpdateBody, request: Request):
-    """更新提供商配置（部分字段），并重新检测视觉能力。"""
+    """更新提供商配置（部分字段），不再自动检测能力。"""
     mgr = _get_manager(request)
     config = mgr.get_config(provider_id)
     if config is None:
         raise HTTPException(status_code=404, detail="Provider not found")
 
     update_data = body.model_dump(exclude_unset=True)
+
+    # 唯一性约束：设置 is_default_provider=True 时清除其他供应商的标记
+    if update_data.get("is_default_provider") is True:
+        all_configs = mgr.list_configs()
+        for other in all_configs:
+            if other.id != provider_id and other.is_default_provider:
+                other.is_default_provider = False
+                mgr.save_config(other)
+
+    # 验证 default_model 在当前 models 列表中
+    if "default_model" in update_data:
+        dm = update_data["default_model"]
+        models = update_data.get("models", config.models)
+        if dm is not None and dm not in models:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Default model '{dm}' is not in the provider's model list",
+            )
+
     for field, value in update_data.items():
         setattr(config, field, value)
 
-    # 先写入更新（不含 vision）
     mgr.save_config(config)
-
-    # 检测视觉能力并更新配置
-    if config.models and IMAGE_PATH.exists():
-        vision = await detect_vision_capabilities(config, IMAGE_PATH)
-        config.model_vision = vision
-        mgr.save_config(config)
-
     await _refresh_app_llm(request)
     return config.to_dict()
 
@@ -215,6 +237,7 @@ async def discover_models(body: TestConnectionBody):
         client = AsyncOpenAI(api_key=body.api_key, base_url=body.base_url)
         models = await client.models.list()
         model_names = sorted(m.id for m in models.data)
+
         return {"models": model_names}
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -222,7 +245,10 @@ async def discover_models(body: TestConnectionBody):
 
 @router.post("/providers/{provider_id}/discover-models")
 async def discover_models_for_existing(provider_id: str, request: Request):
-    """拉取已保存提供商的模型列表并更新缓存。"""
+    """拉取已保存提供商的模型列表并更新缓存。
+
+    重新拉取后，如果原来的 default_model 已不存在，自动置 None 并返回警告。
+    """
     from openai import AsyncOpenAI
 
     mgr = _get_manager(request)
@@ -235,9 +261,69 @@ async def discover_models_for_existing(provider_id: str, request: Request):
         models = await client.models.list()
         model_names = sorted(m.id for m in models.data)
 
+        # 默认模型联动：检查 default_model 是否还在新列表中
+        warning = None
+        if config.default_model is not None and config.default_model not in model_names:
+            warning = f"Default model '{config.default_model}' is no longer available and has been reset"
+            config.default_model = None
+
         config.models = model_names
         mgr.save_config(config)
 
-        return {"models": model_names}
+        result: dict = {"models": model_names}
+        if warning:
+            result["default_model_warning"] = warning
+        return result
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+
+
+# ── 能力检测 ─────────────────────────────────────────────
+
+
+@router.post("/providers/{provider_id}/test-capability")
+async def test_single_capability(provider_id: str, body: TestCapabilityBody, request: Request):
+    """测试指定模型的单个或所有能力，并保存结果。"""
+    mgr = _get_manager(request)
+    config = mgr.get_config(provider_id)
+    if config is None:
+        raise HTTPException(status_code=404, detail="Provider not found")
+
+    if body.model_name not in config.models:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Model '{body.model_name}' is not in provider's model list",
+        )
+
+    testers = _get_testers()
+    if body.capability:
+        testers = [t for t in testers if t.capability_name == body.capability]
+        if not testers:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown capability '{body.capability}'",
+            )
+
+    results = await test_model_capabilities(config, body.model_name, testers)
+
+    # 保存到 model_capabilities
+    if body.capability:
+        # 单项测试：只更新一个能力
+        model_caps = config.model_capabilities.get(body.model_name, {})
+        model_caps[body.capability] = results[body.capability]
+        if body.model_name not in config.model_capabilities:
+            config.model_capabilities[body.model_name] = {}
+        config.model_capabilities[body.model_name].update(model_caps)
+    else:
+        # 全量测试：替换整个模型的记录
+        config.model_capabilities[body.model_name] = results
+
+    mgr.save_config(config)
+    return {"capabilities": results}
+
+
+@router.post("/providers/{provider_id}/test-all-capabilities")
+async def test_all_capabilities(provider_id: str, body: TestCapabilityBody, request: Request):
+    """测试指定模型的所有能力。兼容旧端点路径。"""
+    return await test_single_capability(provider_id, body, request)
+

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -145,6 +145,18 @@ export const api = {
       method: 'POST',
     }),
 
+  testCapability: (id: string, body: { model_name: string; capability?: string }) =>
+    request<{ capabilities: Record<string, boolean> }>(`/providers/${id}/test-capability`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  testAllCapabilities: (id: string, body: { model_name: string }) =>
+    request<{ capabilities: Record<string, boolean> }>(`/providers/${id}/test-all-capabilities`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
   // ── News ──
 
   listNews: () =>

--- a/web/src/components/CapabilityBadges.vue
+++ b/web/src/components/CapabilityBadges.vue
@@ -1,0 +1,33 @@
+<template>
+  <span class="cap-badges">
+    <span v-if="caps?.vision === true" class="cap-icon" title="支持视觉">🖼️</span>
+    <span v-else-if="caps?.vision === false" class="cap-icon unsupported" title="不支持视觉">🖼️✗</span>
+    <span v-if="caps?.tool_call === true" class="cap-icon" title="支持工具调用">⚙️</span>
+    <span v-else-if="caps?.tool_call === false" class="cap-icon unsupported" title="不支持工具调用">⚙️✗</span>
+    <span v-if="caps?.structured_output === true" class="cap-icon" title="支持结构化输出">📋</span>
+    <span v-else-if="caps?.structured_output === false" class="cap-icon unsupported" title="不支持结构化输出">📋✗</span>
+  </span>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  capabilities: Record<string, boolean> | undefined
+}>()
+</script>
+
+<style scoped>
+.cap-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  margin-left: 2px;
+  vertical-align: middle;
+}
+.cap-icon {
+  font-size: 10px;
+  line-height: 1;
+}
+.cap-icon.unsupported {
+  opacity: 0.35;
+}
+</style>

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -560,7 +560,10 @@ function selectProvider(id: string) {
   openDropdown.value = null
   const p = providers.value.find(p => p.id === id)
   currentModels.value = p?.models ?? []
-  selectedModelName.value = currentModels.value[0] || ''
+  // 优先使用供应商的 default_model，退化到第一个模型
+  selectedModelName.value = (p?.default_model && currentModels.value.includes(p.default_model))
+    ? p.default_model
+    : (currentModels.value[0] || '')
   emit('modelChange', selectedProviderId.value, selectedModelName.value)
 }
 
@@ -586,9 +589,10 @@ async function loadProviders() {
   try {
     const res = await api.listProviders()
     providers.value = res.providers.filter(p => p.enabled)
-    // 默认选中第一个已启用的提供商
+    // 默认选中默认供应商，退化到第一个已启用的提供商
     if (providers.value.length > 0 && !selectedProviderId.value) {
-      selectProvider(providers.value[0].id)
+      const defaultP = providers.value.find(p => p.is_default_provider) || providers.value[0]
+      selectProvider(defaultP.id)
     }
   } catch {
     // 静默失败

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -389,6 +389,9 @@ export interface ProviderConfig {
   enabled: boolean
   context_window?: number
   model_vision?: Record<string, boolean>
+  model_capabilities?: Record<string, Record<string, boolean>>
+  is_default_provider?: boolean
+  default_model?: string | null
 }
 
 export interface ListProvidersResponse {
@@ -403,6 +406,7 @@ export interface TestConnectionResponse {
 
 export interface DiscoverModelsResponse {
   models: string[]
+  default_model_warning?: string
 }
 
 // === 系统更新动态 ===

--- a/web/src/views/ProvidersView.vue
+++ b/web/src/views/ProvidersView.vue
@@ -19,6 +19,7 @@
           <div class="card-header">
             <div class="card-title-row">
               <span class="card-label">{{ p.label }}</span>
+              <span v-if="p.is_default_provider" class="default-star" title="默认供应商">⭐</span>
               <span class="card-type-badge">OPENAI</span>
             </div>
             <button
@@ -36,8 +37,9 @@
           <div class="card-models-section">
             <div class="card-models-title">模型（{{ p.models.length }}）</div>
             <div class="card-models-tags">
-              <span v-for="m in p.models" :key="m" class="model-tag">
-                {{ m }}<Icon v-if="p.model_vision?.[m] === true" name="image-cog" :size="12" class="vision-dot" title="支持视觉" />
+              <span v-for="m in p.models" :key="m" class="model-tag" :class="{ 'default-model-tag': m === p.default_model }">
+                {{ m }}<span v-if="m === p.default_model" class="default-model-star" title="默认模型">⭐</span>
+                <CapabilityBadges :capabilities="getModelCapabilities(p, m)" />
               </span>
               <span v-if="p.models.length === 0" class="model-tag empty">未配置</span>
             </div>
@@ -98,28 +100,62 @@
         <input v-model.number="form.context_window" class="input mono" type="number" placeholder="256000" />
       </div>
 
+      <!-- 默认供应商 -->
+      <div v-if="isEditing" class="form-section">
+        <label class="form-label checkbox-label">
+          <input type="checkbox" v-model="form.isDefaultProvider" />
+          设为默认供应商
+        </label>
+      </div>
+
       <!-- 测试 & 拉取模型 -->
       <div class="form-row">
         <button type="button" class="btn" :disabled="!isEditing && (!form.api_key || !form.base_url)" @click="handleTest">
           {{ testing ? '测试中...' : 'PING' }}
         </button>
-        <button type="button" class="btn" :disabled="!isEditing && (!form.api_key || !form.base_url)" @click="handleDiscover">
+        <button type="button" class="btn" :disabled="(!isEditing && (!form.api_key || !form.base_url)) || testingCap !== null" @click="handleDiscover">
           {{ discovering ? '拉取中...' : '拉取模型列表' }}
         </button>
       </div>
       <div v-if="formError" class="msg error">{{ formError }}</div>
       <div v-if="testOk" class="msg ok">连接成功 ({{ testLatency }}ms)</div>
 
+      <!-- 默认模型警告 -->
+      <div v-if="defaultModelWarning" class="msg warn">{{ defaultModelWarning }}</div>
+
       <!-- 模型列表 -->
       <div v-if="discoveredModels.length > 0" class="form-section">
         <label class="form-label">选择模型（{{ selectedModels.length }}/{{ discoveredModels.length }}）</label>
         <div class="model-list">
-          <label v-for="m in discoveredModels" :key="m" class="model-item">
-            <input type="checkbox" :value="m" :checked="selectedModels.includes(m)" @change="toggleModel(m)" />
-            {{ m }}
-            <span v-if="editingModelVision[m] === true" class="vision-badge">视觉</span>
-            <span v-else-if="editingModelVision[m] === false" class="vision-badge no-vision">无视觉</span>
-          </label>
+          <div v-for="m in discoveredModels" :key="m" class="model-item" :class="{ 'default-model-item': form.defaultModel === m }">
+            <label class="model-checkbox-label">
+              <input type="checkbox" :value="m" :checked="selectedModels.includes(m)" @change="toggleModel(m)" />
+              <span class="model-name-text">{{ m }}</span>
+              <span v-if="editingModelCapabilities[m]?.vision === true" class="cap-badge vision" title="视觉">🖼️</span>
+              <span v-else-if="editingModelCapabilities[m]?.vision === false" class="cap-badge no-cap" title="无视觉">🖼️✗</span>
+              <span v-if="editingModelCapabilities[m]?.tool_call === true" class="cap-badge tool" title="工具调用">⚙️</span>
+              <span v-else-if="editingModelCapabilities[m]?.tool_call === false" class="cap-badge no-cap" title="无工具调用">⚙️✗</span>
+              <span v-if="editingModelCapabilities[m]?.structured_output === true" class="cap-badge structured" title="结构化输出">📋</span>
+              <span v-else-if="editingModelCapabilities[m]?.structured_output === false" class="cap-badge no-cap" title="无结构化输出">📋✗</span>
+            </label>
+            <div class="model-actions">
+              <button
+                type="button"
+                class="btn-set-default"
+                :class="{ active: form.defaultModel === m }"
+                :disabled="!selectedModels.includes(m)"
+                @click.stop="form.defaultModel = m"
+                :title="form.defaultModel === m ? '当前默认模型' : '设为默认模型'"
+              >{{ form.defaultModel === m ? '⭐' : '☆' }}</button>
+              <button
+                type="button"
+                class="btn-test-cap"
+                :disabled="testingCap !== null"
+                @click.stop="testModelCapabilities(m)"
+                :title="testingCap === m ? '测试中...' : (testingCap !== null ? '请等待当前检测完成' : '测试能力')"
+              >{{ testingCap === m ? '⏳' : '🔍' }}</button>
+            </div>
+          </div>
         </div>
         <button type="button" class="btn sm" @click="selectAllModels">全选</button>
         <button type="button" class="btn sm" @click="selectedModels = []">取消全选</button>
@@ -158,9 +194,20 @@ const providers = ref<ProviderConfig[]>([])
 const loading = ref(false)
 
 // ── 表单 ──
-const form = ref({ id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: '', context_window: 256000 })
+interface FormState {
+  id: string
+  provider_type: string
+  label: string
+  api_key: string
+  base_url: string
+  context_window: number
+  isDefaultProvider: boolean
+  defaultModel: string | null
+}
+const form = ref<FormState>({ id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: '', context_window: 256000, isDefaultProvider: false, defaultModel: null })
 const isEditing = computed(() => mode.value === 'edit')
 const editingId = ref('')
+const defaultModelWarning = ref('')
 
 function presetBaseUrl(id: string) {
   return presets.find(p => p.id === id)?.base_url || ''
@@ -172,7 +219,6 @@ function onPresetChange(newType: string) {
     form.value.base_url = presetBaseUrl(newType)
   }
 }
-// watch provider_type
 import { watch } from 'vue'
 watch(() => form.value.provider_type, onPresetChange)
 
@@ -209,17 +255,41 @@ const discovering = ref(false)
 const discoveredModels = ref<string[]>([])
 const selectedModels = ref<string[]>([])
 
-// ── 视觉能力 ──
-const editingModelVision = ref<Record<string, boolean>>({})
+// ── 能力检测 ──
+const editingModelCapabilities = ref<Record<string, Record<string, boolean>>>({})
+const testingCap = ref<string | null>(null)
+
+function getModelCapabilities(provider: ProviderConfig, model: string): Record<string, boolean> | undefined {
+  return provider.model_capabilities?.[model] ?? (provider.model_vision ? { vision: provider.model_vision[model] } as Record<string, boolean> : undefined)
+}
+
+async function testModelCapabilities(model: string) {
+  if (testingCap.value !== null) return
+  if (discovering.value) return  // 拉取中不可检测
+  testingCap.value = model
+  try {
+    const res = await api.testAllCapabilities(editingId.value, { model_name: model })
+    editingModelCapabilities.value[model] = res.capabilities
+  } catch (e: any) {
+    console.error('能力测试失败', e)
+  } finally {
+    testingCap.value = null
+  }
+}
 
 async function handleDiscover() {
   discovering.value = true
   formError.value = ''
+  defaultModelWarning.value = ''
   try {
     if (isEditing.value && !form.value.api_key) {
       const res = await api.discoverModelsForExisting(editingId.value)
       discoveredModels.value = res.models
       selectedModels.value = [...res.models]
+      if (res.default_model_warning) {
+        defaultModelWarning.value = res.default_model_warning
+        form.value.defaultModel = null
+      }
     } else {
       const res = await api.discoverModels({
         api_key: form.value.api_key,
@@ -231,13 +301,21 @@ async function handleDiscover() {
   } catch (e: any) {
     formError.value = e.message
   } finally {
+    // 清除已不存在模型的旧能力数据
+    const newSet = new Set(discoveredModels.value)
+    for (const m of Object.keys(editingModelCapabilities.value)) {
+      if (!newSet.has(m)) delete editingModelCapabilities.value[m]
+    }
     discovering.value = false
   }
 }
 
 function toggleModel(m: string) {
   const idx = selectedModels.value.indexOf(m)
-  if (idx >= 0) selectedModels.value.splice(idx, 1)
+  if (idx >= 0) {
+    selectedModels.value.splice(idx, 1)
+    if (form.value.defaultModel === m) form.value.defaultModel = null
+  }
   else selectedModels.value.push(m)
 }
 
@@ -263,10 +341,11 @@ async function loadProviders() {
 
 function startAdd() {
   mode.value = 'add'
-  form.value = { id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: presetBaseUrl('deepseek'), context_window: 256000 }
+  form.value = { id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: presetBaseUrl('deepseek'), context_window: 256000, isDefaultProvider: false, defaultModel: null }
   discoveredModels.value = []
   selectedModels.value = []
-  editingModelVision.value = {}
+  editingModelCapabilities.value = {}
+  defaultModelWarning.value = ''
   formError.value = ''
   testOk.value = false
 }
@@ -281,10 +360,21 @@ function startEdit(p: ProviderConfig) {
     api_key: '',
     base_url: p.base_url,
     context_window: p.context_window ?? 256000,
+    isDefaultProvider: p.is_default_provider ?? false,
+    defaultModel: p.default_model ?? null,
   }
   discoveredModels.value = [...p.models]
   selectedModels.value = [...p.models]
-  editingModelVision.value = p.model_vision ?? {}
+  // 合并 model_capabilities 和向后兼容的 model_vision
+  editingModelCapabilities.value = {}
+  for (const m of p.models) {
+    const caps: Record<string, boolean> = { ...(p.model_capabilities?.[m] || {}) }
+    if (p.model_vision?.[m] !== undefined && caps.vision === undefined) {
+      caps.vision = p.model_vision[m]
+    }
+    editingModelCapabilities.value[m] = caps
+  }
+  defaultModelWarning.value = ''
   formError.value = ''
   testOk.value = false
 }
@@ -310,7 +400,14 @@ async function handleSave() {
     }
     if (isEditing.value) {
       // PUT — only send changed fields
-      const updateBody: any = { label: body.label, base_url: body.base_url, models: body.models, context_window: body.context_window }
+      const updateBody: any = {
+        label: body.label,
+        base_url: body.base_url,
+        models: body.models,
+        context_window: body.context_window,
+        is_default_provider: form.value.isDefaultProvider,
+        default_model: form.value.defaultModel || null,
+      }
       if (form.value.api_key) updateBody.api_key = form.value.api_key
       await api.updateProvider(editingId.value, updateBody)
     } else {
@@ -341,15 +438,6 @@ async function testProvider(id: string) {
     testResult.value[id] = res
   } catch (e: any) {
     testResult.value[id] = { status: 'error', latency_ms: null, detail: e.message }
-  }
-}
-
-async function discoverProvider(id: string) {
-  try {
-    await api.discoverModelsForExisting(id)
-    await loadProviders()
-  } catch (e: any) {
-    alert('拉取失败: ' + e.message)
   }
 }
 
@@ -403,7 +491,6 @@ onMounted(loadProviders)
   border-color: var(--accent);
 }
 .btn.sm { padding: 4px 10px; font-size: 12px; }
-.btn.danger { color: var(--status-error); border-color: var(--status-error); }
 
 /* ── List ── */
 .loading, .empty {
@@ -450,6 +537,11 @@ onMounted(loadProviders)
   font-weight: 600;
   color: #9ca3af;
   letter-spacing: 0.5px;
+}
+
+/* ── 默认标记 ── */
+.default-star {
+  font-size: 14px;
 }
 
 /* ── 开关按钮 ── */
@@ -519,22 +611,26 @@ onMounted(loadProviders)
   color: #d1d5db;
   font-family: inherit;
 }
+.default-model-tag {
+  background: #fef3c7;
+  color: #92400e;
+}
+.default-model-star {
+  margin-left: 2px;
+}
 .vision-dot {
   margin-left: 2px;
   opacity: 0.6;
   vertical-align: middle;
 }
-.vision-badge {
+
+/* ── 能力标记 ── */
+.cap-badge {
   font-size: 10px;
-  padding: 1px 6px;
-  border-radius: 4px;
-  margin-left: 6px;
-  background: #d1fae5;
-  color: #065f46;
+  margin-left: 2px;
 }
-.vision-badge.no-vision {
-  background: #f3f4f6;
-  color: #9ca3af;
+.cap-badge.no-cap {
+  opacity: 0.35;
 }
 
 .card-context-window {
@@ -621,26 +717,79 @@ select.input { cursor: pointer; }
 }
 .msg.ok { background: #d1fae5; color: #065f46; }
 .msg.error { background: #fee2e2; color: #991b1b; }
+.msg.warn { background: #fef3c7; color: #92400e; }
 
 .model-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  max-height: 240px;
+  gap: 2px;
+  max-height: 300px;
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 8px;
 }
 .model-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px;
+  border-radius: 4px;
   font-size: 13px;
   font-family: 'SF Mono', 'Consolas', monospace;
-  padding: 4px 6px;
-  cursor: pointer;
-  border-radius: 4px;
 }
 .model-item:hover { background: var(--bg-secondary); }
-.model-item input { margin-right: 8px; }
+.default-model-item {
+  background: #fffbeb;
+}
+.model-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+}
+.model-checkbox-label input { margin: 0; flex-shrink: 0; }
+.model-name-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.model-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.btn-set-default, .btn-test-cap {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+}
+.btn-set-default:hover, .btn-test-cap:hover,
+.btn-set-default.active {
+  opacity: 1;
+}
+.btn-set-default:disabled {
+  opacity: 0.2;
+  cursor: not-allowed;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+.checkbox-label input {
+  margin: 0;
+}
 
 .form-actions {
   display: flex;


### PR DESCRIPTION
## 模块 1+2：默认供应商/模型 UI + 能力检测框架

Closes #211

### 模块 1 — 默认供应商 + 默认模型
- `ProviderConfig` 新增 `is_default_provider`、`default_model` 字段
- `get_llm()` 和对话上下文优先取默认供应商
- 前端卡片显示默认供应商/模型星标 ⭐
- 编辑表单支持设置默认供应商复选框和默认模型选择器
- 重新拉取模型时默认模型联动警告
- `ChatInput.vue` 初始化时优先选中默认供应商和默认模型

### 模块 2 — 通用能力检测框架
- `CapabilityTester` 抽象接口 + 三个检测器（VisionTester、ToolCallTester、StructuredOutputTester）
- 新增 API 端点：`POST /providers/{id}/test-capability`、`POST /providers/{id}/test-all-capabilities`
- 保存配置时不再自动批量检测，改为用户手动触发
- 运行时出错时自动重测并更正能力标记
- 前端模型列表显示 🖼️ ⚙️ 📋 能力标记和 🔍 测试按钮
- 新增 `CapabilityBadges.vue` 子组件

### 文件变更
- **新增：** `api/providers/capabilities/`（5 文件）、`web/src/components/CapabilityBadges.vue`
- **修改：** `api/dependencies.py`、`api/providers/__init__.py`、`api/providers/vision.py`、`api/routes/chat.py`、`api/routes/providers.py`、`web/src/api/index.ts`、`web/src/components/ChatInput.vue`、`web/src/types/index.ts`、`web/src/views/ProvidersView.vue`