### PR TITLE
feat: 默认供应商/模型 UI (M1)

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -10,11 +10,21 @@ _tools: list | None = None
 def get_llm(provider_manager=None):
     """获取 LLM。
 
-    从 ProviderManager 中取第一个 enabled provider 创建 LLM。
+    从 ProviderManager 中优先取 is_default_provider=True 的供应商创建 LLM，
+    若无默认供应商则取第一个 enabled provider。
     若无可用的 provider 则抛出 RuntimeError。
     LLM 配置统一由 providers.yaml 管理，不再降级到 .env。
     """
     if provider_manager is not None and provider_manager.count > 0:
+        # 优先取默认供应商
+        for provider in provider_manager.iter_enabled():
+            if provider.config.is_default_provider:
+                return provider.create_llm(
+                    provider.default_model,
+                    temperature=0.7,
+                    streaming=True,
+                )
+        # 退化到第一个 enabled provider
         for provider in provider_manager.iter_enabled():
             return provider.create_llm(
                 provider.default_model,

--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -20,11 +20,17 @@ class ProviderConfig:
     enabled: bool = True
     context_window: int = 256_000
     model_vision: dict[str, bool] = field(default_factory=dict)
+    is_default_provider: bool = False
+    default_model: str | None = None
 
     def to_dict(self) -> dict:
         d = asdict(self)
         if not d.get("model_vision"):
             del d["model_vision"]
+        if not d.get("is_default_provider"):
+            d.pop("is_default_provider", None)
+        if d.get("default_model") is None:
+            d.pop("default_model", None)
         return d
 
 
@@ -49,6 +55,8 @@ class Provider(ABC):
 
     @property
     def default_model(self) -> str:
+        if self.config.default_model and self.config.default_model in self.config.models:
+            return self.config.default_model
         return self.config.models[0] if self.config.models else ""
 
     @property

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -24,9 +24,17 @@ router = APIRouter()
 
 
 def _get_provider_context(app_state) -> tuple[int, str]:
-    """从 ProviderManager 获取默认 context_window 和 model_name。"""
+    """从 ProviderManager 获取默认 context_window 和 model_name。
+
+    优先取 is_default_provider=True 的供应商。
+    """
     mgr = getattr(app_state, "provider_manager", None)
     if mgr is not None and mgr.count > 0:
+        # 优先取默认供应商
+        for provider in mgr.iter_enabled():
+            if provider.config.is_default_provider:
+                return provider.config.context_window, provider.default_model
+        # 退化到第一个 enabled provider
         for provider in mgr.iter_enabled():
             return provider.config.context_window, provider.default_model
     return 256_000, ""

--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -38,6 +38,8 @@ class ProviderUpdateBody(BaseModel):
     models: list[str] | None = None
     enabled: bool | None = None
     context_window: int | None = None
+    is_default_provider: bool | None = None
+    default_model: str | None = None
 
 
 class TestConnectionBody(BaseModel):
@@ -135,6 +137,25 @@ async def update_provider(provider_id: str, body: ProviderUpdateBody, request: R
         raise HTTPException(status_code=404, detail="Provider not found")
 
     update_data = body.model_dump(exclude_unset=True)
+
+    # 唯一性约束：设置 is_default_provider=True 时清除其他供应商的标记
+    if update_data.get("is_default_provider") is True:
+        all_configs = mgr.list_configs()
+        for other in all_configs:
+            if other.id != provider_id and other.is_default_provider:
+                other.is_default_provider = False
+                mgr.save_config(other)
+
+    # 验证 default_model 在当前 models 列表中
+    if "default_model" in update_data:
+        dm = update_data["default_model"]
+        models = update_data.get("models", config.models)
+        if dm is not None and dm not in models:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Default model '{dm}' is not in the provider's model list",
+            )
+
     for field, value in update_data.items():
         setattr(config, field, value)
 
@@ -222,7 +243,10 @@ async def discover_models(body: TestConnectionBody):
 
 @router.post("/providers/{provider_id}/discover-models")
 async def discover_models_for_existing(provider_id: str, request: Request):
-    """拉取已保存提供商的模型列表并更新缓存。"""
+    """拉取已保存提供商的模型列表并更新缓存。
+
+    重新拉取后，如果原来的 default_model 已不存在，自动置 None 并返回警告。
+    """
     from openai import AsyncOpenAI
 
     mgr = _get_manager(request)
@@ -235,9 +259,18 @@ async def discover_models_for_existing(provider_id: str, request: Request):
         models = await client.models.list()
         model_names = sorted(m.id for m in models.data)
 
+        # 默认模型联动：检查 default_model 是否还在新列表中
+        warning = None
+        if config.default_model is not None and config.default_model not in model_names:
+            warning = f"Default model '{config.default_model}' is no longer available and has been reset"
+            config.default_model = None
+
         config.models = model_names
         mgr.save_config(config)
 
-        return {"models": model_names}
+        result: dict = {"models": model_names}
+        if warning:
+            result["default_model_warning"] = warning
+        return result
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc))

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -560,7 +560,10 @@ function selectProvider(id: string) {
   openDropdown.value = null
   const p = providers.value.find(p => p.id === id)
   currentModels.value = p?.models ?? []
-  selectedModelName.value = currentModels.value[0] || ''
+  // 优先使用供应商的 default_model，退化到第一个模型
+  selectedModelName.value = (p?.default_model && currentModels.value.includes(p.default_model))
+    ? p.default_model
+    : (currentModels.value[0] || '')
   emit('modelChange', selectedProviderId.value, selectedModelName.value)
 }
 
@@ -586,9 +589,10 @@ async function loadProviders() {
   try {
     const res = await api.listProviders()
     providers.value = res.providers.filter(p => p.enabled)
-    // 默认选中第一个已启用的提供商
+    // 默认选中默认供应商，退化到第一个已启用的提供商
     if (providers.value.length > 0 && !selectedProviderId.value) {
-      selectProvider(providers.value[0].id)
+      const defaultP = providers.value.find(p => p.is_default_provider) || providers.value[0]
+      selectProvider(defaultP.id)
     }
   } catch {
     // 静默失败

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -389,6 +389,8 @@ export interface ProviderConfig {
   enabled: boolean
   context_window?: number
   model_vision?: Record<string, boolean>
+  is_default_provider?: boolean
+  default_model?: string | null
 }
 
 export interface ListProvidersResponse {
@@ -403,6 +405,7 @@ export interface TestConnectionResponse {
 
 export interface DiscoverModelsResponse {
   models: string[]
+  default_model_warning?: string
 }
 
 // === 系统更新动态 ===

--- a/web/src/views/ProvidersView.vue
+++ b/web/src/views/ProvidersView.vue
@@ -19,6 +19,7 @@
           <div class="card-header">
             <div class="card-title-row">
               <span class="card-label">{{ p.label }}</span>
+              <span v-if="p.is_default_provider" class="default-star" title="默认供应商">⭐</span>
               <span class="card-type-badge">OPENAI</span>
             </div>
             <button
@@ -36,8 +37,9 @@
           <div class="card-models-section">
             <div class="card-models-title">模型（{{ p.models.length }}）</div>
             <div class="card-models-tags">
-              <span v-for="m in p.models" :key="m" class="model-tag">
-                {{ m }}<Icon v-if="p.model_vision?.[m] === true" name="image-cog" :size="12" class="vision-dot" title="支持视觉" />
+              <span v-for="m in p.models" :key="m" class="model-tag" :class="{ 'default-model-tag': m === p.default_model }">
+                {{ m }}<span v-if="m === p.default_model" class="default-model-star" title="默认模型">⭐</span>
+                <Icon v-if="p.model_vision?.[m] === true" name="image-cog" :size="12" class="vision-dot" title="支持视觉" />
               </span>
               <span v-if="p.models.length === 0" class="model-tag empty">未配置</span>
             </div>
@@ -98,6 +100,14 @@
         <input v-model.number="form.context_window" class="input mono" type="number" placeholder="256000" />
       </div>
 
+      <!-- 默认供应商 -->
+      <div v-if="isEditing" class="form-section">
+        <label class="form-label checkbox-label">
+          <input type="checkbox" v-model="form.isDefaultProvider" />
+          设为默认供应商
+        </label>
+      </div>
+
       <!-- 测试 & 拉取模型 -->
       <div class="form-row">
         <button type="button" class="btn" :disabled="!isEditing && (!form.api_key || !form.base_url)" @click="handleTest">
@@ -110,16 +120,31 @@
       <div v-if="formError" class="msg error">{{ formError }}</div>
       <div v-if="testOk" class="msg ok">连接成功 ({{ testLatency }}ms)</div>
 
+      <!-- 默认模型警告 -->
+      <div v-if="defaultModelWarning" class="msg warn">{{ defaultModelWarning }}</div>
+
       <!-- 模型列表 -->
       <div v-if="discoveredModels.length > 0" class="form-section">
         <label class="form-label">选择模型（{{ selectedModels.length }}/{{ discoveredModels.length }}）</label>
         <div class="model-list">
-          <label v-for="m in discoveredModels" :key="m" class="model-item">
-            <input type="checkbox" :value="m" :checked="selectedModels.includes(m)" @change="toggleModel(m)" />
-            {{ m }}
-            <span v-if="editingModelVision[m] === true" class="vision-badge">视觉</span>
-            <span v-else-if="editingModelVision[m] === false" class="vision-badge no-vision">无视觉</span>
-          </label>
+          <div v-for="m in discoveredModels" :key="m" class="model-item" :class="{ 'default-model-item': form.defaultModel === m }">
+            <label class="model-checkbox-label">
+              <input type="checkbox" :value="m" :checked="selectedModels.includes(m)" @change="toggleModel(m)" />
+              <span class="model-name-text">{{ m }}</span>
+              <span v-if="editingModelVision[m] === true" class="vision-badge">视觉</span>
+              <span v-else-if="editingModelVision[m] === false" class="vision-badge no-vision">无视觉</span>
+            </label>
+            <div class="model-actions">
+              <button
+                type="button"
+                class="btn-set-default"
+                :class="{ active: form.defaultModel === m }"
+                :disabled="!selectedModels.includes(m)"
+                @click.stop="form.defaultModel = m"
+                :title="form.defaultModel === m ? '当前默认模型' : '设为默认模型'"
+              >{{ form.defaultModel === m ? '⭐' : '☆' }}</button>
+            </div>
+          </div>
         </div>
         <button type="button" class="btn sm" @click="selectAllModels">全选</button>
         <button type="button" class="btn sm" @click="selectedModels = []">取消全选</button>
@@ -158,9 +183,10 @@ const providers = ref<ProviderConfig[]>([])
 const loading = ref(false)
 
 // ── 表单 ──
-const form = ref({ id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: '', context_window: 256000 })
+const form = ref({ id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: '', context_window: 256000, isDefaultProvider: false, defaultModel: null as string | null })
 const isEditing = computed(() => mode.value === 'edit')
 const editingId = ref('')
+const defaultModelWarning = ref('')
 
 function presetBaseUrl(id: string) {
   return presets.find(p => p.id === id)?.base_url || ''
@@ -215,11 +241,16 @@ const editingModelVision = ref<Record<string, boolean>>({})
 async function handleDiscover() {
   discovering.value = true
   formError.value = ''
+  defaultModelWarning.value = ''
   try {
     if (isEditing.value && !form.value.api_key) {
       const res = await api.discoverModelsForExisting(editingId.value)
       discoveredModels.value = res.models
       selectedModels.value = [...res.models]
+      if (res.default_model_warning) {
+        defaultModelWarning.value = res.default_model_warning
+        form.value.defaultModel = null
+      }
     } else {
       const res = await api.discoverModels({
         api_key: form.value.api_key,
@@ -237,7 +268,10 @@ async function handleDiscover() {
 
 function toggleModel(m: string) {
   const idx = selectedModels.value.indexOf(m)
-  if (idx >= 0) selectedModels.value.splice(idx, 1)
+  if (idx >= 0) {
+    selectedModels.value.splice(idx, 1)
+    if (form.value.defaultModel === m) form.value.defaultModel = null
+  }
   else selectedModels.value.push(m)
 }
 
@@ -263,10 +297,11 @@ async function loadProviders() {
 
 function startAdd() {
   mode.value = 'add'
-  form.value = { id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: presetBaseUrl('deepseek'), context_window: 256000 }
+  form.value = { id: '', provider_type: 'deepseek', label: '', api_key: '', base_url: presetBaseUrl('deepseek'), context_window: 256000, isDefaultProvider: false, defaultModel: null }
   discoveredModels.value = []
   selectedModels.value = []
   editingModelVision.value = {}
+  defaultModelWarning.value = ''
   formError.value = ''
   testOk.value = false
 }
@@ -281,10 +316,13 @@ function startEdit(p: ProviderConfig) {
     api_key: '',
     base_url: p.base_url,
     context_window: p.context_window ?? 256000,
+    isDefaultProvider: p.is_default_provider ?? false,
+    defaultModel: p.default_model ?? null,
   }
   discoveredModels.value = [...p.models]
   selectedModels.value = [...p.models]
   editingModelVision.value = p.model_vision ?? {}
+  defaultModelWarning.value = ''
   formError.value = ''
   testOk.value = false
 }
@@ -310,7 +348,14 @@ async function handleSave() {
     }
     if (isEditing.value) {
       // PUT — only send changed fields
-      const updateBody: any = { label: body.label, base_url: body.base_url, models: body.models, context_window: body.context_window }
+      const updateBody: any = {
+        label: body.label,
+        base_url: body.base_url,
+        models: body.models,
+        context_window: body.context_window,
+        is_default_provider: form.value.isDefaultProvider,
+        default_model: form.value.defaultModel || null,
+      }
       if (form.value.api_key) updateBody.api_key = form.value.api_key
       await api.updateProvider(editingId.value, updateBody)
     } else {
@@ -621,26 +666,92 @@ select.input { cursor: pointer; }
 }
 .msg.ok { background: #d1fae5; color: #065f46; }
 .msg.error { background: #fee2e2; color: #991b1b; }
+.msg.warn { background: #fef3c7; color: #92400e; }
 
+/* ── 默认标记 ── */
+.default-star {
+  font-size: 14px;
+}
+.default-model-tag {
+  background: #fef3c7;
+  color: #92400e;
+}
+.default-model-star {
+  margin-left: 2px;
+}
+
+/* ── 模型列表 Form ── */
 .model-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  max-height: 240px;
+  gap: 2px;
+  max-height: 300px;
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 8px;
 }
 .model-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px;
+  border-radius: 4px;
   font-size: 13px;
   font-family: 'SF Mono', 'Consolas', monospace;
-  padding: 4px 6px;
-  cursor: pointer;
-  border-radius: 4px;
 }
 .model-item:hover { background: var(--bg-secondary); }
-.model-item input { margin-right: 8px; }
+.default-model-item {
+  background: #fffbeb;
+}
+.model-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+}
+.model-checkbox-label input { margin: 0; flex-shrink: 0; }
+.model-name-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.model-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.btn-set-default {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+}
+.btn-set-default:hover,
+.btn-set-default.active {
+  opacity: 1;
+}
+.btn-set-default:disabled {
+  opacity: 0.2;
+  cursor: not-allowed;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+.checkbox-label input {
+  margin: 0;
+}
 
 .form-actions {
   display: flex;


### PR DESCRIPTION
## 模块 1 — 默认供应商 + 默认模型

- `ProviderConfig` 新增 `is_default_provider`、`default_model` 字段
- `get_llm()` 和对话上下文优先取默认供应商
- 前端卡片显示默认供应商/模型星标 ⭐
- 编辑表单支持设置默认供应商复选框和默认模型选择器
- 重新拉取模型时默认模型联动警告
- `ChatInput.vue` 初始化时优先选中默认供应商和默认模型

文件变更：`api/dependencies.py`、`api/providers/__init__.py`、`api/routes/chat.py`、`api/routes/providers.py`、`web/src/components/ChatInput.vue`、`web/src/types/index.ts`、`web/src/views/ProvidersView.vue`