### PR TITLE
feat: 通用能力检测框架 (M2)

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -20,11 +20,14 @@ class ProviderConfig:
     enabled: bool = True
     context_window: int = 256_000
     model_vision: dict[str, bool] = field(default_factory=dict)
+    model_capabilities: dict[str, dict[str, bool]] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         d = asdict(self)
         if not d.get("model_vision"):
             del d["model_vision"]
+        if not d.get("model_capabilities"):
+            d.pop("model_capabilities", None)
         return d
 
 

--- a/api/providers/capabilities/__init__.py
+++ b/api/providers/capabilities/__init__.py
@@ -1,0 +1,36 @@
+"""通用能力检测框架 — 注册检测器与辅助函数。"""
+
+from pathlib import Path
+
+from api.providers import ProviderConfig
+from api.providers.capabilities.base import CapabilityTester  # noqa: F401
+from api.providers.capabilities.base import CapabilityTestResult  # noqa: F401
+from api.providers.capabilities.vision import VisionTester
+from api.providers.capabilities.tool_call import ToolCallTester
+from api.providers.capabilities.structured_output import StructuredOutputTester
+from api.providers.openai_provider import OpenAIProvider
+
+
+def get_all_testers(image_path: Path | None = None) -> list[CapabilityTester]:
+    """返回所有可用的能力检测器。"""
+    testers: list[CapabilityTester] = [
+        ToolCallTester(),
+        StructuredOutputTester(),
+    ]
+    if image_path and image_path.exists():
+        testers.append(VisionTester(image_path))
+    return testers
+
+
+async def test_model_capabilities(
+    config: ProviderConfig,
+    model_name: str,
+    testers: list[CapabilityTester],
+) -> dict[str, bool]:
+    """对单个模型运行所有检测器，返回能力名 → 是否支持的映射。"""
+    provider = OpenAIProvider(config)
+    results: dict[str, bool] = {}
+    for tester in testers:
+        result = await tester.test(provider, model_name)
+        results[result.capability] = result.supported
+    return results

--- a/api/providers/capabilities/base.py
+++ b/api/providers/capabilities/base.py
@@ -1,0 +1,28 @@
+"""能力检测基础类型 — CapabilityTester 接口与 CapabilityTestResult。"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class CapabilityTestResult:
+    """单个模型的能力检测结果。"""
+
+    capability: str          # "vision" | "tool_call" | "structured_output"
+    supported: bool          # 是否支持该能力
+    detail: str | None = None  # 失败原因/补充信息
+
+
+class CapabilityTester(ABC):
+    """所有能力检测器必须实现的接口。"""
+
+    @property
+    @abstractmethod
+    def capability_name(self) -> str:
+        """能力名称标识，例如 'vision'、'tool_call'、'structured_output'。"""
+        ...
+
+    @abstractmethod
+    async def test(self, provider, model_name: str) -> CapabilityTestResult:
+        """检测指定模型是否支持该能力。"""
+        ...

--- a/api/providers/capabilities/structured_output.py
+++ b/api/providers/capabilities/structured_output.py
@@ -1,0 +1,56 @@
+"""模型结构化输出能力检测器。
+
+请求 response_format: {type: "json_object"} 看模型能否返回合法 JSON。
+"""
+
+from langchain_core.messages import HumanMessage
+
+from api.providers import Provider
+from api.providers.capabilities.base import CapabilityTester, CapabilityTestResult
+
+_PROMPT = 'Output a JSON object with one key "name" set to "test". Reply with ONLY valid JSON.'
+
+
+class StructuredOutputTester(CapabilityTester):
+    """检测模型是否支持 JSON 结构化输出。"""
+
+    @property
+    def capability_name(self) -> str:
+        return "structured_output"
+
+    async def test(self, provider: Provider, model_name: str) -> CapabilityTestResult:
+        try:
+            llm = provider.create_llm(
+                model_name,
+                temperature=0,
+                model_kwargs={"response_format": {"type": "json_object"}},
+            )
+
+            response = await llm.ainvoke([HumanMessage(content=_PROMPT)])
+            raw = response.content if hasattr(response, "content") else str(response)
+            text = raw if isinstance(raw, str) else str(raw)
+
+            import json
+            data = json.loads(text.strip().removeprefix("```json").removesuffix("```").strip())
+            if isinstance(data, dict) and "name" in data:
+                return CapabilityTestResult(
+                    capability="structured_output",
+                    supported=True,
+                )
+            return CapabilityTestResult(
+                capability="structured_output",
+                supported=False,
+                detail=f"Response did not contain expected key: {text[:200]}",
+            )
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            return CapabilityTestResult(
+                capability="structured_output",
+                supported=False,
+                detail=str(exc)[:200],
+            )
+        except Exception as exc:
+            return CapabilityTestResult(
+                capability="structured_output",
+                supported=False,
+                detail=str(exc)[:200],
+            )

--- a/api/providers/capabilities/tool_call.py
+++ b/api/providers/capabilities/tool_call.py
@@ -1,0 +1,59 @@
+"""模型工具调用能力检测器。
+
+向模型发一条带虚假 tool_choice 的消息，看模型能否正常响应。
+"""
+
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+
+from api.providers import Provider
+from api.providers.capabilities.base import CapabilityTester, CapabilityTestResult
+
+
+@tool
+def _test_tool(query: str) -> str:
+    """A test tool for capability detection."""
+    return f"echo: {query}"
+
+
+class ToolCallTester(CapabilityTester):
+    """检测模型是否支持工具/函数调用。"""
+
+    @property
+    def capability_name(self) -> str:
+        return "tool_call"
+
+    async def test(self, provider: Provider, model_name: str) -> CapabilityTestResult:
+        try:
+            llm = provider.create_llm(model_name, temperature=0).bind_tools([_test_tool])
+
+            response = await llm.ainvoke([
+                HumanMessage(content="Say 'ping' using the test tool.")
+            ])
+
+            # 检查响应是否包含工具调用
+            if hasattr(response, "tool_calls") and response.tool_calls:
+                return CapabilityTestResult(
+                    capability="tool_call",
+                    supported=True,
+                )
+
+            # 部分模型会拒绝调用但返回有效文本，也算支持工具调用
+            if hasattr(response, "content") and response.content:
+                return CapabilityTestResult(
+                    capability="tool_call",
+                    supported=True,
+                    detail="Model responded with text instead of tool call, but did not error",
+                )
+
+            return CapabilityTestResult(
+                capability="tool_call",
+                supported=False,
+                detail="No tool call and no valid response",
+            )
+        except Exception as exc:
+            return CapabilityTestResult(
+                capability="tool_call",
+                supported=False,
+                detail=str(exc),
+            )

--- a/api/providers/capabilities/vision.py
+++ b/api/providers/capabilities/vision.py
@@ -1,0 +1,60 @@
+"""模型视觉能力检测器。
+
+向模型发送一张包含文字 "Sonetto" 的测试图片，
+要求模型读出图片中的文字，若响应包含 "Sonetto" 则视为有视觉能力。
+"""
+
+import base64
+from pathlib import Path
+
+from langchain_core.messages import HumanMessage
+
+from api.providers import Provider
+from api.providers.capabilities.base import CapabilityTester, CapabilityTestResult
+
+_PROMPT = "What text is shown in this image? Reply with only the text."
+
+
+class VisionTester(CapabilityTester):
+    """检测模型是否支持多模态视觉输入。"""
+
+    def __init__(self, image_path: Path):
+        self.image_path = image_path
+
+    @property
+    def capability_name(self) -> str:
+        return "vision"
+
+    async def test(self, provider: Provider, model_name: str) -> CapabilityTestResult:
+        try:
+            llm = provider.create_llm(model_name, temperature=0)
+
+            with open(self.image_path, "rb") as f:
+                image_bytes = f.read()
+            image_b64 = base64.b64encode(image_bytes).decode("utf-8")
+
+            message = HumanMessage(
+                content=[
+                    {"type": "text", "text": _PROMPT},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{image_b64}"},
+                    },
+                ]
+            )
+
+            response = await llm.ainvoke([message])
+            raw = response.content if hasattr(response, "content") else str(response)
+            text = raw if isinstance(raw, str) else str(raw)
+            supported = "Sonetto".lower() in text.lower()
+            return CapabilityTestResult(
+                capability="vision",
+                supported=supported,
+                detail=None if supported else "Response did not contain expected text 'Sonetto'",
+            )
+        except Exception as exc:
+            return CapabilityTestResult(
+                capability="vision",
+                supported=False,
+                detail=str(exc),
+            )

--- a/api/providers/vision.py
+++ b/api/providers/vision.py
@@ -1,79 +1,42 @@
-"""模型视觉能力检测。
+"""模型视觉能力检测 — 兼容层，委托到 capabilities 包。"""
 
-保存提供商时自动检测每个模型是否具备视觉能力：
-1. 向模型发送一张包含文字 "Sonetto" 的测试图片
-2. 要求模型读出图片中的文字
-3. 若响应中包含 "Sonetto" 则视为有视觉能力，否则无
-"""
-
-import asyncio
-import base64
 from pathlib import Path
 
-from langchain_core.messages import HumanMessage
-
 from api.providers import Provider, ProviderConfig
-
-_PROMPT = "What text is shown in this image? Reply with only the text."
+from api.providers.capabilities.vision import VisionTester
+from api.providers.openai_provider import OpenAIProvider
 
 
 async def test_model_vision(
     provider: Provider, model_name: str, image_path: Path
 ) -> bool:
-    """检测单个模型是否具备视觉能力。
-
-    向模型发送一张包含 "Sonetto" 文字的测试图片，要求读出文字。
-    若报错或响应不包含 "Sonetto" 则认为该模型无视觉能力。
-    """
-    try:
-        llm = provider.create_llm(model_name, temperature=0)
-
-        with open(image_path, "rb") as f:
-            image_bytes = f.read()
-        image_b64 = base64.b64encode(image_bytes).decode("utf-8")
-
-        message = HumanMessage(
-            content=[
-                {"type": "text", "text": _PROMPT},
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{image_b64}"},
-                },
-            ]
-        )
-
-        response = await llm.ainvoke([message])
-        raw = response.content if hasattr(response, "content") else str(response)
-        text = raw if isinstance(raw, str) else str(raw)
-        return "Sonetto".lower() in text.lower()
-    except Exception:
-        return False
+    """检测单个模型是否具备视觉能力（兼容旧接口）。"""
+    tester = VisionTester(image_path)
+    result = await tester.test(provider, model_name)
+    return result.supported
 
 
 async def detect_vision_capabilities(
     config: ProviderConfig, image_path: Path
 ) -> dict[str, bool]:
-    """批量检测提供商下所有模型的视觉能力。
+    """批量检测提供商下所有模型的视觉能力（兼容旧接口）。"""
+    import asyncio
 
-    并发测试 config.models 中的每个模型，返回 model_name → bool 的映射。
-    测试失败的模型视为无视觉能力。
-    """
     if not config.models:
         return {}
 
-    from api.providers.openai_provider import OpenAIProvider
-
     provider = OpenAIProvider(config)
+    tester = VisionTester(image_path)
 
-    tasks = [
-        test_model_vision(provider, model, image_path) for model in config.models
-    ]
+    tasks = [tester.test(provider, model) for model in config.models]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     vision: dict[str, bool] = {}
     for model, result in zip(config.models, results):
         if isinstance(result, bool):
-            vision[model] = result
+            vision[model] = bool(result)
+        elif hasattr(result, "supported"):
+            vision[model] = result.supported
         else:
             vision[model] = False
 

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -397,6 +397,34 @@ async def _run_agent_turn(
                 "payload": {"code": "AGENT_ERROR", "message": str(e)},
             }
         )
+        # 运行时能力修正：检测是否因能力不足导致错误，触发重测
+        if provider_id and model_name and hasattr(app_state, "provider_manager"):
+            try:
+                mgr = app_state.provider_manager
+                config = mgr.get_config(provider_id)
+                if config is not None:
+                    err_str = str(e).lower()
+                    needs_retest = []
+                    if "vision" in err_str or "image" in err_str or "multimodal" in err_str:
+                        needs_retest.append("vision")
+                    if "tool" in err_str or "function call" in err_str:
+                        needs_retest.append("tool_call")
+                    if "json" in err_str or "structure" in err_str or "parse" in err_str:
+                        needs_retest.append("structured_output")
+                    if needs_retest:
+                        from api.providers.capabilities import get_all_testers, test_model_capabilities
+                        testers = [
+                            t for t in get_all_testers()
+                            if t.capability_name in needs_retest
+                        ]
+                        if testers:
+                            results = await test_model_capabilities(config, model_name, testers)
+                            model_caps = config.model_capabilities.get(model_name, {})
+                            model_caps.update(results)
+                            config.model_capabilities[model_name] = model_caps
+                            mgr.save_config(config)
+            except Exception as retest_err:
+                print(f"[capability-retest] Error during retest: {retest_err}", file=sys.stderr)
     finally:
         session._active_task = None
         context_usage = await _calculate_context_usage(

--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -1,4 +1,4 @@
-"""REST API — 提供商 CRUD 与连接测试。"""
+"""REST API — 提供商 CRUD、连接测试、能力检测。"""
 
 from pathlib import Path
 
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from api.providers import ProviderConfig
-from api.providers.vision import detect_vision_capabilities
+from api.providers.capabilities import get_all_testers, test_model_capabilities
 from api.dependencies import get_llm
 
 router = APIRouter()
@@ -46,6 +46,11 @@ class TestConnectionBody(BaseModel):
     provider_type: str = "openai"
 
 
+class TestCapabilityBody(BaseModel):
+    model_name: str
+    capability: str | None = None  # None = 测试所有能力
+
+
 # ── HELPERS ─────────────────────────────────────────────
 
 
@@ -74,6 +79,18 @@ async def _refresh_app_llm(request: Request) -> None:
             print("[provider] LLM became unavailable \u2014 LTM consumer stopped")
 
 
+def _get_testers() -> list:
+    """获取可用的能力检测器列表。"""
+    from api.providers.capabilities.vision import VisionTester
+    from api.providers.capabilities.tool_call import ToolCallTester
+    from api.providers.capabilities.structured_output import StructuredOutputTester
+
+    testers = [ToolCallTester(), StructuredOutputTester()]
+    if IMAGE_PATH.exists():
+        testers.append(VisionTester(IMAGE_PATH))
+    return testers
+
+
 # ── CRUD ────────────────────────────────────────────────
 
 
@@ -95,7 +112,7 @@ def get_provider(provider_id: str, request: Request):
 
 @router.post("/providers")
 async def create_provider(body: ProviderCreateBody, request: Request):
-    """新增提供商，并自动检测每个模型的视觉能力。"""
+    """新增提供商，自动检测能力。"""
     mgr = _get_manager(request)
     if mgr.get_config(body.id) is not None:
         raise HTTPException(
@@ -113,13 +130,18 @@ async def create_provider(body: ProviderCreateBody, request: Request):
         context_window=body.context_window,
     )
 
-    # 先写入基础配置（不含 vision）
+    # 先写入基础配置
     mgr.save_config(config)
 
-    # 检测视觉能力并更新配置
-    if config.models and IMAGE_PATH.exists():
-        vision = await detect_vision_capabilities(config, IMAGE_PATH)
-        config.model_vision = vision
+    # 自动检测所有能力
+    if config.models:
+        testers = _get_testers()
+        for model in config.models:
+            try:
+                results = await test_model_capabilities(config, model, testers)
+                config.model_capabilities[model] = results
+            except Exception:
+                pass
         mgr.save_config(config)
 
     await _refresh_app_llm(request)
@@ -128,7 +150,7 @@ async def create_provider(body: ProviderCreateBody, request: Request):
 
 @router.put("/providers/{provider_id}")
 async def update_provider(provider_id: str, body: ProviderUpdateBody, request: Request):
-    """更新提供商配置（部分字段），并重新检测视觉能力。"""
+    """更新提供商配置（部分字段），不再自动检测能力。"""
     mgr = _get_manager(request)
     config = mgr.get_config(provider_id)
     if config is None:
@@ -138,13 +160,18 @@ async def update_provider(provider_id: str, body: ProviderUpdateBody, request: R
     for field, value in update_data.items():
         setattr(config, field, value)
 
-    # 先写入更新（不含 vision）
     mgr.save_config(config)
 
-    # 检测视觉能力并更新配置
-    if config.models and IMAGE_PATH.exists():
-        vision = await detect_vision_capabilities(config, IMAGE_PATH)
-        config.model_vision = vision
+    # 自动检测能力（仅对新模型或尚未检测的模型）
+    if config.models:
+        testers = _get_testers()
+        for model in config.models:
+            if model not in config.model_capabilities or not config.model_capabilities[model]:
+                try:
+                    results = await test_model_capabilities(config, model, testers)
+                    config.model_capabilities[model] = results
+                except Exception:
+                    pass
         mgr.save_config(config)
 
     await _refresh_app_llm(request)
@@ -241,3 +268,53 @@ async def discover_models_for_existing(provider_id: str, request: Request):
         return {"models": model_names}
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+
+
+# ── 能力检测 ─────────────────────────────────────────────
+
+
+@router.post("/providers/{provider_id}/test-capability")
+async def test_single_capability(provider_id: str, body: TestCapabilityBody, request: Request):
+    """测试指定模型的单个或所有能力，并保存结果。"""
+    mgr = _get_manager(request)
+    config = mgr.get_config(provider_id)
+    if config is None:
+        raise HTTPException(status_code=404, detail="Provider not found")
+
+    if body.model_name not in config.models:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Model '{body.model_name}' is not in provider's model list",
+        )
+
+    testers = _get_testers()
+    if body.capability:
+        testers = [t for t in testers if t.capability_name == body.capability]
+        if not testers:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown capability '{body.capability}'",
+            )
+
+    results = await test_model_capabilities(config, body.model_name, testers)
+
+    # 保存到 model_capabilities
+    if body.capability:
+        # 单项测试：只更新一个能力
+        model_caps = config.model_capabilities.get(body.model_name, {})
+        model_caps[body.capability] = results[body.capability]
+        if body.model_name not in config.model_capabilities:
+            config.model_capabilities[body.model_name] = {}
+        config.model_capabilities[body.model_name].update(model_caps)
+    else:
+        # 全量测试：替换整个模型的记录
+        config.model_capabilities[body.model_name] = results
+
+    mgr.save_config(config)
+    return {"capabilities": results}
+
+
+@router.post("/providers/{provider_id}/test-all-capabilities")
+async def test_all_capabilities(provider_id: str, body: TestCapabilityBody, request: Request):
+    """测试指定模型的所有能力。兼容旧端点路径。"""
+    return await test_single_capability(provider_id, body, request)

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -145,6 +145,18 @@ export const api = {
       method: 'POST',
     }),
 
+  testCapability: (id: string, body: { model_name: string; capability?: string }) =>
+    request<{ capabilities: Record<string, boolean> }>(`/providers/${id}/test-capability`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  testAllCapabilities: (id: string, body: { model_name: string }) =>
+    request<{ capabilities: Record<string, boolean> }>(`/providers/${id}/test-all-capabilities`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
   // ── News ──
 
   listNews: () =>

--- a/web/src/components/CapabilityBadges.vue
+++ b/web/src/components/CapabilityBadges.vue
@@ -1,0 +1,33 @@
+<template>
+  <span class="cap-badges">
+    <span v-if="capabilities?.vision === true" class="cap-icon" title="支持视觉">🖼️</span>
+    <span v-else-if="capabilities?.vision === false" class="cap-icon unsupported" title="不支持视觉">🖼️✗</span>
+    <span v-if="capabilities?.tool_call === true" class="cap-icon" title="支持工具调用">⚙️</span>
+    <span v-else-if="capabilities?.tool_call === false" class="cap-icon unsupported" title="不支持工具调用">⚙️✗</span>
+    <span v-if="capabilities?.structured_output === true" class="cap-icon" title="支持结构化输出">📋</span>
+    <span v-else-if="capabilities?.structured_output === false" class="cap-icon unsupported" title="不支持结构化输出">📋✗</span>
+  </span>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  capabilities: Record<string, boolean> | undefined
+}>()
+</script>
+
+<style scoped>
+.cap-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  margin-left: 2px;
+  vertical-align: middle;
+}
+.cap-icon {
+  font-size: 10px;
+  line-height: 1;
+}
+.cap-icon.unsupported {
+  opacity: 0.35;
+}
+</style>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -389,6 +389,7 @@ export interface ProviderConfig {
   enabled: boolean
   context_window?: number
   model_vision?: Record<string, boolean>
+  model_capabilities?: Record<string, Record<string, boolean>>
 }
 
 export interface ListProvidersResponse {

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -111,7 +111,10 @@ const isSubagent = computed(() => {
 const selectedModelHasVision = computed(() => {
   if (!selectedProviderId.value || !selectedModelName.value) return false
   const provider = providers.value.find(p => p.id === selectedProviderId.value)
-  return provider?.model_vision?.[selectedModelName.value] === true
+  if (!provider) return false
+  // 同时检查新老两种存储方式
+  return provider.model_vision?.[selectedModelName.value] === true
+    || provider.model_capabilities?.[selectedModelName.value]?.vision === true
 })
 
 const chatInputRef = ref<InstanceType<typeof ChatInput> | null>(null)

--- a/web/src/views/ProvidersView.vue
+++ b/web/src/views/ProvidersView.vue
@@ -37,7 +37,7 @@
             <div class="card-models-title">模型（{{ p.models.length }}）</div>
             <div class="card-models-tags">
               <span v-for="m in p.models" :key="m" class="model-tag">
-                {{ m }}<Icon v-if="p.model_vision?.[m] === true" name="image-cog" :size="12" class="vision-dot" title="支持视觉" />
+                {{ m }}<CapabilityBadges :capabilities="getModelCapabilities(p, m)" />
               </span>
               <span v-if="p.models.length === 0" class="model-tag empty">未配置</span>
             </div>
@@ -114,12 +114,27 @@
       <div v-if="discoveredModels.length > 0" class="form-section">
         <label class="form-label">选择模型（{{ selectedModels.length }}/{{ discoveredModels.length }}）</label>
         <div class="model-list">
-          <label v-for="m in discoveredModels" :key="m" class="model-item">
-            <input type="checkbox" :value="m" :checked="selectedModels.includes(m)" @change="toggleModel(m)" />
-            {{ m }}
-            <span v-if="editingModelVision[m] === true" class="vision-badge">视觉</span>
-            <span v-else-if="editingModelVision[m] === false" class="vision-badge no-vision">无视觉</span>
-          </label>
+          <div v-for="m in discoveredModels" :key="m" class="model-item">
+            <label class="model-checkbox-label">
+              <input type="checkbox" :value="m" :checked="selectedModels.includes(m)" @change="toggleModel(m)" />
+              <span class="model-name-text">{{ m }}</span>
+              <span v-if="editingModelCapabilities[m]?.vision === true" class="cap-badge" title="视觉">🖼️</span>
+              <span v-else-if="editingModelCapabilities[m]?.vision === false" class="cap-badge no-cap" title="无视觉">🖼️✗</span>
+              <span v-if="editingModelCapabilities[m]?.tool_call === true" class="cap-badge" title="工具调用">⚙️</span>
+              <span v-else-if="editingModelCapabilities[m]?.tool_call === false" class="cap-badge no-cap" title="无工具调用">⚙️✗</span>
+              <span v-if="editingModelCapabilities[m]?.structured_output === true" class="cap-badge" title="结构化输出">📋</span>
+              <span v-else-if="editingModelCapabilities[m]?.structured_output === false" class="cap-badge no-cap" title="无结构化输出">📋✗</span>
+            </label>
+            <div class="model-actions">
+              <button
+                type="button"
+                class="btn-test-cap"
+                :disabled="testingCap !== null"
+                @click.stop="testModelCapabilities(m)"
+                :title="testingCap === m ? '测试中...' : (testingCap !== null ? '请等待当前检测完成' : '测试能力')"
+              >{{ testingCap === m ? '⏳' : '🔍' }}</button>
+            </div>
+          </div>
         </div>
         <button type="button" class="btn sm" @click="selectAllModels">全选</button>
         <button type="button" class="btn sm" @click="selectedModels = []">取消全选</button>
@@ -140,6 +155,7 @@ import { api } from '@/api'
 import type { ProviderConfig, TestConnectionResponse } from '@/types'
 import { computed, onMounted, ref } from 'vue'
 import Icon from '@/components/Icon.vue'
+import CapabilityBadges from '@/components/CapabilityBadges.vue'
 
 // ── 预设提供商列表 ──
 const presets = [
@@ -204,6 +220,28 @@ async function handleTest() {
   }
 }
 
+// ── 能力检测 ──
+const editingModelCapabilities = ref<Record<string, Record<string, boolean>>>({})
+const testingCap = ref<string | null>(null)
+
+function getModelCapabilities(provider: ProviderConfig, model: string): Record<string, boolean> | undefined {
+  return provider.model_capabilities?.[model] ?? (provider.model_vision ? { vision: provider.model_vision[model] } as Record<string, boolean> : undefined)
+}
+
+async function testModelCapabilities(model: string) {
+  if (testingCap.value !== null) return
+  if (discovering.value) return  // 拉取中不可检测
+  testingCap.value = model
+  try {
+    const res = await api.testAllCapabilities(editingId.value, { model_name: model })
+    editingModelCapabilities.value[model] = res.capabilities
+  } catch (e: any) {
+    console.error('能力测试失败', e)
+  } finally {
+    testingCap.value = null
+  }
+}
+
 // ── 拉取模型 ──
 const discovering = ref(false)
 const discoveredModels = ref<string[]>([])
@@ -231,6 +269,11 @@ async function handleDiscover() {
   } catch (e: any) {
     formError.value = e.message
   } finally {
+    // 清除已不存在模型的旧能力数据
+    const newSet = new Set(discoveredModels.value)
+    for (const m of Object.keys(editingModelCapabilities.value)) {
+      if (!newSet.has(m)) delete editingModelCapabilities.value[m]
+    }
     discovering.value = false
   }
 }
@@ -267,6 +310,7 @@ function startAdd() {
   discoveredModels.value = []
   selectedModels.value = []
   editingModelVision.value = {}
+  editingModelCapabilities.value = {}
   formError.value = ''
   testOk.value = false
 }
@@ -284,6 +328,15 @@ function startEdit(p: ProviderConfig) {
   }
   discoveredModels.value = [...p.models]
   selectedModels.value = [...p.models]
+  // 合并 model_capabilities 和向后兼容的 model_vision
+  editingModelCapabilities.value = {}
+  for (const m of p.models) {
+    const caps: Record<string, boolean> = { ...(p.model_capabilities?.[m] || {}) }
+    if (p.model_vision?.[m] !== undefined && caps.vision === undefined) {
+      caps.vision = p.model_vision[m]
+    }
+    editingModelCapabilities.value[m] = caps
+  }
   editingModelVision.value = p.model_vision ?? {}
   formError.value = ''
   testOk.value = false
@@ -622,25 +675,72 @@ select.input { cursor: pointer; }
 .msg.ok { background: #d1fae5; color: #065f46; }
 .msg.error { background: #fee2e2; color: #991b1b; }
 
+/* ── 能力标记 ── */
+.cap-badge {
+  font-size: 10px;
+  margin-left: 2px;
+}
+.cap-badge.no-cap {
+  opacity: 0.35;
+}
+
 .model-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  max-height: 240px;
+  gap: 2px;
+  max-height: 300px;
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 8px;
 }
 .model-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px;
+  border-radius: 4px;
   font-size: 13px;
   font-family: 'SF Mono', 'Consolas', monospace;
-  padding: 4px 6px;
-  cursor: pointer;
-  border-radius: 4px;
 }
 .model-item:hover { background: var(--bg-secondary); }
-.model-item input { margin-right: 8px; }
+.model-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+}
+.model-checkbox-label input { margin: 0; flex-shrink: 0; }
+.model-name-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.model-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.btn-test-cap {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+}
+.btn-test-cap:hover {
+  opacity: 1;
+}
+.btn-test-cap:disabled {
+  opacity: 0.2;
+  cursor: not-allowed;
+}
 
 .form-actions {
   display: flex;


### PR DESCRIPTION
## 模块 2 — 通用能力检测框架

- `CapabilityTester` 抽象接口 + 三个检测器（VisionTester、ToolCallTester、StructuredOutputTester）
- 新增 API 端点：`POST /providers/{id}/test-capability`、`POST /providers/{id}/test-all-capabilities`
- 保存配置时自动检测所有能力（仅对新模型或尚未检测的模型）
- 运行时出错时自动重测并更正能力标记
- 前端模型列表显示 🖼️ ⚙️ 📋 能力标记和 🔍 测试按钮
- 新增 `CapabilityBadges.vue` 子组件

文件变更（新增）：`api/providers/capabilities/`（5 文件）、`web/src/components/CapabilityBadges.vue`
文件变更（修改）：`api/providers/__init__.py`、`api/providers/vision.py`、`api/routes/chat.py`、`api/routes/providers.py`、`web/src/api/index.ts`、`web/src/types/index.ts`、`web/src/views/ChatView.vue`、`web/src/views/ProvidersView.vue`