### PR TITLE
feat: 通用能力检测框架 (M2)

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -20,6 +20,7 @@ class ProviderConfig:
     enabled: bool = True
     context_window: int = 256_000
     model_vision: dict[str, bool] = field(default_factory=dict)
+    model_capabilities: dict[str, dict[str, bool]] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         d = asdict(self)

--- a/api/providers/capabilities/__init__.py
+++ b/api/providers/capabilities/__init__.py
@@ -1,0 +1,36 @@
+"""通用能力检测框架 — 注册检测器与辅助函数。"""
+
+from pathlib import Path
+
+from api.providers import ProviderConfig
+from api.providers.capabilities.base import CapabilityTester  # noqa: F401
+from api.providers.capabilities.base import CapabilityTestResult  # noqa: F401
+from api.providers.capabilities.vision import VisionTester
+from api.providers.capabilities.tool_call import ToolCallTester
+from api.providers.capabilities.structured_output import StructuredOutputTester
+from api.providers.openai_provider import OpenAIProvider
+
+
+def get_all_testers(image_path: Path | None = None) -> list[CapabilityTester]:
+    """返回所有可用的能力检测器。"""
+    testers: list[CapabilityTester] = [
+        ToolCallTester(),
+        StructuredOutputTester(),
+    ]
+    if image_path and image_path.exists():
+        testers.append(VisionTester(image_path))
+    return testers
+
+
+async def test_model_capabilities(
+    config: ProviderConfig,
+    model_name: str,
+    testers: list[CapabilityTester],
+) -> dict[str, bool]:
+    """对单个模型运行所有检测器，返回能力名 → 是否支持的映射。"""
+    provider = OpenAIProvider(config)
+    results: dict[str, bool] = {}
+    for tester in testers:
+        result = await tester.test(provider, model_name)
+        results[result.capability] = result.supported
+    return results

--- a/api/providers/capabilities/base.py
+++ b/api/providers/capabilities/base.py
@@ -1,0 +1,28 @@
+"""能力检测基础类型 — CapabilityTester 接口与 CapabilityTestResult。"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class CapabilityTestResult:
+    """单个模型的能力检测结果。"""
+
+    capability: str          # "vision" | "tool_call" | "structured_output"
+    supported: bool          # 是否支持该能力
+    detail: str | None = None  # 失败原因/补充信息
+
+
+class CapabilityTester(ABC):
+    """所有能力检测器必须实现的接口。"""
+
+    @property
+    @abstractmethod
+    def capability_name(self) -> str:
+        """能力名称标识，例如 'vision'、'tool_call'、'structured_output'。"""
+        ...
+
+    @abstractmethod
+    async def test(self, provider, model_name: str) -> CapabilityTestResult:
+        """检测指定模型是否支持该能力。"""
+        ...

--- a/api/providers/capabilities/structured_output.py
+++ b/api/providers/capabilities/structured_output.py
@@ -1,0 +1,56 @@
+"""模型结构化输出能力检测器。
+
+请求 response_format: {type: "json_object"} 看模型能否返回合法 JSON。
+"""
+
+from langchain_core.messages import HumanMessage
+
+from api.providers import Provider
+from api.providers.capabilities.base import CapabilityTester, CapabilityTestResult
+
+_PROMPT = 'Output a JSON object with one key "name" set to "test". Reply with ONLY valid JSON.'
+
+
+class StructuredOutputTester(CapabilityTester):
+    """检测模型是否支持 JSON 结构化输出。"""
+
+    @property
+    def capability_name(self) -> str:
+        return "structured_output"
+
+    async def test(self, provider: Provider, model_name: str) -> CapabilityTestResult:
+        try:
+            llm = provider.create_llm(
+                model_name,
+                temperature=0,
+                model_kwargs={"response_format": {"type": "json_object"}},
+            )
+
+            response = await llm.ainvoke([HumanMessage(content=_PROMPT)])
+            raw = response.content if hasattr(response, "content") else str(response)
+            text = raw if isinstance(raw, str) else str(raw)
+
+            import json
+            data = json.loads(text.strip().removeprefix("```json").removesuffix("```").strip())
+            if isinstance(data, dict) and "name" in data:
+                return CapabilityTestResult(
+                    capability="structured_output",
+                    supported=True,
+                )
+            return CapabilityTestResult(
+                capability="structured_output",
+                supported=False,
+                detail=f"Response did not contain expected key: {text[:200]}",
+            )
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            return CapabilityTestResult(
+                capability="structured_output",
+                supported=False,
+                detail=str(exc)[:200],
+            )
+        except Exception as exc:
+            return CapabilityTestResult(
+                capability="structured_output",
+                supported=False,
+                detail=str(exc)[:200],
+            )

--- a/api/providers/capabilities/tool_call.py
+++ b/api/providers/capabilities/tool_call.py
@@ -1,0 +1,59 @@
+"""模型工具调用能力检测器。
+
+向模型发一条带虚假 tool_choice 的消息，看模型能否正常响应。
+"""
+
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+
+from api.providers import Provider
+from api.providers.capabilities.base import CapabilityTester, CapabilityTestResult
+
+
+@tool
+def _test_tool(query: str) -> str:
+    """A test tool for capability detection."""
+    return f"echo: {query}"
+
+
+class ToolCallTester(CapabilityTester):
+    """检测模型是否支持工具/函数调用。"""
+
+    @property
+    def capability_name(self) -> str:
+        return "tool_call"
+
+    async def test(self, provider: Provider, model_name: str) -> CapabilityTestResult:
+        try:
+            llm = provider.create_llm(model_name, temperature=0).bind_tools([_test_tool])
+
+            response = await llm.ainvoke([
+                HumanMessage(content="Say 'ping' using the test tool.")
+            ])
+
+            # 检查响应是否包含工具调用
+            if hasattr(response, "tool_calls") and response.tool_calls:
+                return CapabilityTestResult(
+                    capability="tool_call",
+                    supported=True,
+                )
+
+            # 部分模型会拒绝调用但返回有效文本，也算支持工具调用
+            if hasattr(response, "content") and response.content:
+                return CapabilityTestResult(
+                    capability="tool_call",
+                    supported=True,
+                    detail="Model responded with text instead of tool call, but did not error",
+                )
+
+            return CapabilityTestResult(
+                capability="tool_call",
+                supported=False,
+                detail="No tool call and no valid response",
+            )
+        except Exception as exc:
+            return CapabilityTestResult(
+                capability="tool_call",
+                supported=False,
+                detail=str(exc),
+            )

--- a/api/providers/capabilities/vision.py
+++ b/api/providers/capabilities/vision.py
@@ -1,0 +1,60 @@
+"""模型视觉能力检测器。
+
+向模型发送一张包含文字 "Sonetto" 的测试图片，
+要求模型读出图片中的文字，若响应包含 "Sonetto" 则视为有视觉能力。
+"""
+
+import base64
+from pathlib import Path
+
+from langchain_core.messages import HumanMessage
+
+from api.providers import Provider
+from api.providers.capabilities import CapabilityTester, CapabilityTestResult
+
+_PROMPT = "What text is shown in this image? Reply with only the text."
+
+
+class VisionTester(CapabilityTester):
+    """检测模型是否支持多模态视觉输入。"""
+
+    def __init__(self, image_path: Path):
+        self.image_path = image_path
+
+    @property
+    def capability_name(self) -> str:
+        return "vision"
+
+    async def test(self, provider: Provider, model_name: str) -> CapabilityTestResult:
+        try:
+            llm = provider.create_llm(model_name, temperature=0)
+
+            with open(self.image_path, "rb") as f:
+                image_bytes = f.read()
+            image_b64 = base64.b64encode(image_bytes).decode("utf-8")
+
+            message = HumanMessage(
+                content=[
+                    {"type": "text", "text": _PROMPT},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{image_b64}"},
+                    },
+                ]
+            )
+
+            response = await llm.ainvoke([message])
+            raw = response.content if hasattr(response, "content") else str(response)
+            text = raw if isinstance(raw, str) else str(raw)
+            supported = "Sonetto".lower() in text.lower()
+            return CapabilityTestResult(
+                capability="vision",
+                supported=supported,
+                detail=None if supported else "Response did not contain expected text 'Sonetto'",
+            )
+        except Exception as exc:
+            return CapabilityTestResult(
+                capability="vision",
+                supported=False,
+                detail=str(exc),
+            )

--- a/api/providers/vision.py
+++ b/api/providers/vision.py
@@ -1,79 +1,42 @@
-"""模型视觉能力检测。
+"""模型视觉能力检测 — 兼容层，委托到 capabilities 包。"""
 
-保存提供商时自动检测每个模型是否具备视觉能力：
-1. 向模型发送一张包含文字 "Sonetto" 的测试图片
-2. 要求模型读出图片中的文字
-3. 若响应中包含 "Sonetto" 则视为有视觉能力，否则无
-"""
-
-import asyncio
-import base64
 from pathlib import Path
 
-from langchain_core.messages import HumanMessage
-
-from api.providers import Provider, ProviderConfig
-
-_PROMPT = "What text is shown in this image? Reply with only the text."
+from api.providers import ProviderConfig
+from api.providers.capabilities.vision import VisionTester
+from api.providers.openai_provider import OpenAIProvider
 
 
 async def test_model_vision(
-    provider: Provider, model_name: str, image_path: Path
+    provider: "api.providers.Provider", model_name: str, image_path: Path
 ) -> bool:
-    """检测单个模型是否具备视觉能力。
-
-    向模型发送一张包含 "Sonetto" 文字的测试图片，要求读出文字。
-    若报错或响应不包含 "Sonetto" 则认为该模型无视觉能力。
-    """
-    try:
-        llm = provider.create_llm(model_name, temperature=0)
-
-        with open(image_path, "rb") as f:
-            image_bytes = f.read()
-        image_b64 = base64.b64encode(image_bytes).decode("utf-8")
-
-        message = HumanMessage(
-            content=[
-                {"type": "text", "text": _PROMPT},
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{image_b64}"},
-                },
-            ]
-        )
-
-        response = await llm.ainvoke([message])
-        raw = response.content if hasattr(response, "content") else str(response)
-        text = raw if isinstance(raw, str) else str(raw)
-        return "Sonetto".lower() in text.lower()
-    except Exception:
-        return False
+    """检测单个模型是否具备视觉能力（兼容旧接口）。"""
+    tester = VisionTester(image_path)
+    result = await tester.test(provider, model_name)
+    return result.supported
 
 
 async def detect_vision_capabilities(
     config: ProviderConfig, image_path: Path
 ) -> dict[str, bool]:
-    """批量检测提供商下所有模型的视觉能力。
+    """批量检测提供商下所有模型的视觉能力（兼容旧接口）。"""
+    import asyncio
 
-    并发测试 config.models 中的每个模型，返回 model_name → bool 的映射。
-    测试失败的模型视为无视觉能力。
-    """
     if not config.models:
         return {}
 
-    from api.providers.openai_provider import OpenAIProvider
-
     provider = OpenAIProvider(config)
+    tester = VisionTester(image_path)
 
-    tasks = [
-        test_model_vision(provider, model, image_path) for model in config.models
-    ]
+    tasks = [tester.test(provider, model) for model in config.models]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     vision: dict[str, bool] = {}
     for model, result in zip(config.models, results):
         if isinstance(result, bool):
-            vision[model] = result
+            vision[model] = bool(result)
+        elif hasattr(result, "supported"):
+            vision[model] = result.supported
         else:
             vision[model] = False
 

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -397,6 +397,31 @@ async def _run_agent_turn(
                 "payload": {"code": "AGENT_ERROR", "message": str(e)},
             }
         )
+        # 运行时能力修正
+        if provider_id and model_name and hasattr(app_state, "provider_manager"):
+            try:
+                _mgr = app_state.provider_manager
+                _cfg = _mgr.get_config(provider_id)
+                if _cfg is not None:
+                    _err = str(e).lower()
+                    _need = []
+                    if "vision" in _err or "image" in _err or "multimodal" in _err:
+                        _need.append("vision")
+                    if "tool" in _err or "function call" in _err:
+                        _need.append("tool_call")
+                    if "json" in _err or "structure" in _err or "parse" in _err:
+                        _need.append("structured_output")
+                    if _need:
+                        from api.providers.capabilities import get_all_testers, test_model_capabilities
+                        _testers = [t for t in get_all_testers() if t.capability_name in _need]
+                        if _testers:
+                            _res = await test_model_capabilities(_cfg, model_name, _testers)
+                            _mc = _cfg.model_capabilities.get(model_name, {})
+                            _mc.update(_res)
+                            _cfg.model_capabilities[model_name] = _mc
+                            _mgr.save_config(_cfg)
+            except Exception:
+                pass
     finally:
         session._active_task = None
         context_usage = await _calculate_context_usage(

--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from api.providers import ProviderConfig
-from api.providers.vision import detect_vision_capabilities
+from api.providers.capabilities import get_all_testers, test_model_capabilities
 from api.dependencies import get_llm
 
 router = APIRouter()
@@ -241,3 +241,55 @@ async def discover_models_for_existing(provider_id: str, request: Request):
         return {"models": model_names}
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+
+# ── 能力检测 ─────────────────────────────────────────────
+
+
+class TestCapabilityBody(BaseModel):
+    model_name: str
+    capability: str | None = None  # None = 测试所有能力
+
+
+@router.post("/providers/{provider_id}/test-capability")
+async def test_single_capability(provider_id: str, body: TestCapabilityBody, request: Request):
+    """测试指定模型的单个或所有能力，并保存结果。"""
+    mgr = _get_manager(request)
+    config = mgr.get_config(provider_id)
+    if config is None:
+        raise HTTPException(status_code=404, detail="Provider not found")
+
+    if body.model_name not in config.models:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Model '{body.model_name}' is not in provider's model list",
+        )
+
+    testers = _get_testers()
+    if body.capability:
+        testers = [t for t in testers if t.capability_name == body.capability]
+        if not testers:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown capability '{body.capability}'",
+            )
+
+    results = await test_model_capabilities(config, body.model_name, testers)
+
+    # 保存到 model_capabilities
+    if body.capability:
+        model_caps = config.model_capabilities.get(body.model_name, {})
+        model_caps[body.capability] = results[body.capability]
+        if body.model_name not in config.model_capabilities:
+            config.model_capabilities[body.model_name] = {}
+        config.model_capabilities[body.model_name].update(model_caps)
+    else:
+        config.model_capabilities[body.model_name] = results
+
+    mgr.save_config(config)
+    return {"capabilities": results}
+
+
+@router.post("/providers/{provider_id}/test-all-capabilities")
+async def test_all_capabilities(provider_id: str, body: TestCapabilityBody, request: Request):
+    """测试指定模型的所有能力。兼容旧端点路径。"""
+    return await test_single_capability(provider_id, body, request)

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -145,6 +145,18 @@ export const api = {
       method: 'POST',
     }),
 
+  testCapability: (id: string, body: { model_name: string; capability?: string }) =>
+    request<{ capabilities: Record<string, boolean> }>(`/providers/${id}/test-capability`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  testAllCapabilities: (id: string, body: { model_name: string }) =>
+    request<{ capabilities: Record<string, boolean> }>(`/providers/${id}/test-all-capabilities`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
   // ── News ──
 
   listNews: () =>

--- a/web/src/components/CapabilityBadges.vue
+++ b/web/src/components/CapabilityBadges.vue
@@ -1,0 +1,33 @@
+<template>
+  <span class="cap-badges">
+    <span v-if="caps?.vision === true" class="cap-icon" title="支持视觉">🖼️</span>
+    <span v-else-if="caps?.vision === false" class="cap-icon unsupported" title="不支持视觉">🖼️✗</span>
+    <span v-if="caps?.tool_call === true" class="cap-icon" title="支持工具调用">⚙️</span>
+    <span v-else-if="caps?.tool_call === false" class="cap-icon unsupported" title="不支持工具调用">⚙️✗</span>
+    <span v-if="caps?.structured_output === true" class="cap-icon" title="支持结构化输出">📋</span>
+    <span v-else-if="caps?.structured_output === false" class="cap-icon unsupported" title="不支持结构化输出">📋✗</span>
+  </span>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  capabilities: Record<string, boolean> | undefined
+}>()
+</script>
+
+<style scoped>
+.cap-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  margin-left: 2px;
+  vertical-align: middle;
+}
+.cap-icon {
+  font-size: 10px;
+  line-height: 1;
+}
+.cap-icon.unsupported {
+  opacity: 0.35;
+}
+</style>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -389,6 +389,7 @@ export interface ProviderConfig {
   enabled: boolean
   context_window?: number
   model_vision?: Record<string, boolean>
+  model_capabilities?: Record<string, Record<string, boolean>>
 }
 
 export interface ListProvidersResponse {

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -111,7 +111,9 @@ const isSubagent = computed(() => {
 const selectedModelHasVision = computed(() => {
   if (!selectedProviderId.value || !selectedModelName.value) return false
   const provider = providers.value.find(p => p.id === selectedProviderId.value)
-  return provider?.model_vision?.[selectedModelName.value] === true
+  if (!provider) return false
+  return provider.model_vision?.[selectedModelName.value] === true
+    || provider.model_capabilities?.[selectedModelName.value]?.vision === true
 })
 
 const chatInputRef = ref<InstanceType<typeof ChatInput> | null>(null)

--- a/web/src/views/ProvidersView.vue
+++ b/web/src/views/ProvidersView.vue
@@ -140,6 +140,7 @@ import { api } from '@/api'
 import type { ProviderConfig, TestConnectionResponse } from '@/types'
 import { computed, onMounted, ref } from 'vue'
 import Icon from '@/components/Icon.vue'
+import CapabilityBadges from '@/components/CapabilityBadges.vue'
 
 // ── 预设提供商列表 ──
 const presets = [


### PR DESCRIPTION
## 模块 2：通用能力检测框架

关联 Issue: #221

### 功能
- `CapabilityTester` 抽象接口 + 三个检测器（VisionTester、ToolCallTester、StructuredOutputTester）
- 新增 API 端点：`POST /providers/{id}/test-capability`、`POST /providers/{id}/test-all-capabilities`
- 保存配置时自动检测所有三项能力
- 运行时出错时自动重测并更正能力标记
- 前端模型列表显示 🖼️ ⚙️ 📋 能力标记和 🔍 测试按钮

### 文件变更（14 文件）
- **新增：** `api/providers/capabilities/`（5 文件）、`web/src/components/CapabilityBadges.vue`
- **修改：** `api/providers/__init__.py`、`api/providers/vision.py`、`api/routes/chat.py`、`api/routes/providers.py`、`web/src/api/index.ts`、`web/src/types/index.ts`、`web/src/views/ChatView.vue`、`web/src/views/ProvidersView.vue`

### 合并说明
👉 建议在 [#218 (M1)](https://github.com/Miso2233/SonettoHere/pull/218) 合并后再合并此 PR。
👉 合并前请阅读 [#221 的合并注意事项](https://github.com/Miso2233/SonettoHere/issues/221)