### PR TITLE
fix(useChat): 修复 tool_name 格式化字符串注入漏洞

### DIFF
--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -297,7 +297,7 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
 
     case 'tool_start': {
       const tsEvent = event as { type: 'tool_start'; payload: { call_id: string; tool_name: string; input: string } }
-      console.log(`[useChat] tool_start: "${tsEvent.payload.tool_name}"`, { input: tsEvent.payload.input, call_id: tsEvent.payload.call_id, session: sid })
+      console.log('[useChat] tool_start:', tsEvent.payload.tool_name, { input: tsEvent.payload.input, call_id: tsEvent.payload.call_id, session: sid })
       turn.events.push({
         kind: 'tool',
         name: tsEvent.payload.tool_name,


### PR DESCRIPTION
## Summary

- 修复 CodeQL 高危告警 `js/tainted-format-string`（alert #32）
- 将用户可控的 `tool_name` 移出 `console.log` 的 format string 位置
- 防止包含 `%s` 等格式说明符时导致日志乱码或信息泄露

## Test plan

- [ ] 确认 `tool_start` 事件仍正常打印日志
- [ ] 确认 CodeQL 告警 #32 自动关闭

Closes #32