### PR TITLE
docs: 前端架构评审 + refactor(useChat): Handler Registry 提取

### DIFF
--- a/dev_docs/frontend-architecture-review.md
+++ b/dev_docs/frontend-architecture-review.md
@@ -150,39 +150,55 @@ export function useSession() {
 
 ## 3. 可引入但未使用的设计模式
 
-### 3.1 观察者/发布-订阅模式（Observer Pattern）
+### 3.1 观察者/发布-订阅模式（Observer Pattern） — ✅ 已实施
 
-**现状：** `useChat.ts` 的 `handleEventForChannel` 是一个约 250 行的巨型 switch 语句，逐类型处理 WebSocket 事件：
+**重构前：** `useChat.ts` 的 `handleEventForChannel` 包含一个 12 路 switch（170 行）和一个 5 段 if-chain（62 行），逐类型处理 WebSocket 事件。
+
+**重构后：** 替换为两张 `Map<EventType, Handler>` 注册表，handler 独立到外部模块：
+
+```
+useChat.ts                      # 分发层
+├── memoryHandlers.get(type)    # 后台记忆事件 → useChat.memory.ts
+└── turnHandlers.get(type)      # 主流程事件   → useChat.handlers.ts
+```
 
 ```typescript
+// useChat.memory.ts — 记忆事件
+export type MemoryEventType = 'memory_start' | 'memory_tool_start' | 'memory_tool_end' | 'memory_tool_error' | 'memory_done'
+type MemoryEventHandler = (ch: SessionChannel, sid: string, event: ServerEvent) => void
+
+export const memoryHandlers = new Map<MemoryEventType, MemoryEventHandler>([
+  ['memory_start', handleMemoryStart],
+  ['memory_tool_start', handleMemoryToolStart],
+  // ...
+])
+```
+
+```typescript
+// useChat.handlers.ts — 主流程事件
+type TurnEventHandler = (ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent) => void
+
+export const turnHandlers = new Map<string, TurnEventHandler>([
+  ['thinking_start', handleThinkingStart],
+  ['token', handleToken],
+  ['tool_start', handleToolStart],
+  ['tool_end', handleToolEnd],
+  ['done', handleDone],
+  // ...
+])
+```
+
+```typescript
+// useChat.ts — 分发
 function handleEventForChannel(sid: string, event: ServerEvent) {
   const ch = channels.get(sid)
-  if (!ch) return
-  // context_usage → early return
-  // sub_session_created → early return
-  // memory_* → 另路由
-  const turn = ch.currentTurn
-  switch (event.type) {
-    case 'thinking_start': ...
-    case 'token': ...
-    case 'tool_start': ...
-    case 'tool_end': ...
-    // ... 10+ 种事件类型
-  }
+  // 1. context_usage / sub_session_created → early return
+  // 2. memory 事件 → memoryHandlers.get()
+  // 3. 主流程事件 → turnHandlers.get()
 }
 ```
 
-**可应用模式：** 为每种 `ServerEvent.type` 注册独立的事件处理器：
-
-```typescript
-// 理想设计
-type EventHandler = (ch: SessionChannel, sid: string, event: ServerEvent) => void
-const handlers = new Map<string, EventHandler>()
-
-handlers.set('thinking_start', (ch, sid, event) => { ... })
-handlers.set('tool_end', (ch, sid, event) => { ... })
-handlers.set('memory_start', handleMemoryStart) // 独立模块
-```
+**效果：** switch/if-chain → 声明式注册表 + 独立 handler 函数。新增事件类型只需写 handler 函数 + 注册一行，调用方守卫自动覆盖。
 
 **收益：** 每次新增事件类型只需新增一个处理器，switch 不再膨胀。`memory_*` 事件已半独立（`handleMemoryToolEvent` 函数），但没有注册机制。
 
@@ -322,24 +338,29 @@ function useCrudForm<T>() {
 
 ## 4. 难以维护的点
 
-### 4.1 `useChat.ts` — 750+ 行，职能混杂 ⚠️
+### 4.1 `useChat.ts` — 职能混杂 ⚠️（已部分拆分）
 
-**文件大小：** 752 行，40+ 个函数，单一文件。
+**文件分布：** `useChat.ts` 517 行（原 752）+ `useChat.handlers.ts` 187 行 + `useChat.memory.ts` 89 行。
 
-**混杂的职责：**
+**仍存在的混杂职责（`useChat.ts`）：**
 | 职责 | 行数范围 | 说明 |
 |------|---------|------|
-| localStorage 持久化 | 10-73 | `saveTurnsToStorage`, `loadAllTurnsFromStorage` |
+| localStorage 持久化 | 10-93 | `saveTurnsToStorage`, `loadAllTurnsFromStorage` |
 | WebSocket 连接管理 | 164-228 | `connectSession`, `ensureConnected`, 重连逻辑 |
 | 多会话通道管理 | 96-160 | `channels` Map, `getOrCreateChannel` |
-| 事件路由 + 处理 | 232-517 | 巨型 switch + `handleMemoryToolEvent` |
-| Turn 状态管理 | 520-667 | `send`, `cancel`, `sendUserResponse`, `removeTurns` |
-| 工具查找函数 | 671-751 | `findToolByCallId`, `findBestMatchingTool` 等 |
+| 事件路由（仅分发） | 252-283 | 两张注册表的 `.get()` 分发，无业务逻辑 |
+| Turn 状态管理 | 287-433 | `send`, `cancel`, `sendUserResponse`, `removeTurns` |
+| 工具查找函数 | 435-517 | `findToolByCallId`, `findBestMatchingTool` 等 |
 
-**维护风险：**
-- 修改一处可能意外影响另一处
+**已完成的改进：** ✅
+- 15 个 handler 函数 → `useChat.memory.ts` / `useChat.handlers.ts`
+- 2 张注册表（`memoryHandlers` / `turnHandlers`）随 handler 迁移
+- `handleEventForChannel` 从 170 行 switch + 62 行 if-chain → 30 行分发
+- `pong` 无操作分支已消除
+
+**仍存在的维护风险：**
 - 无法独立测试 WebSocket 重连逻辑（与 localStorage 紧耦合）
-- 新增事件类型需要深入理解整个文件
+- `persistTurns` 仍与模块级 `channels` Map 耦合
 
 ### 4.2 `ChatInput.vue` — 900+ 行的巨型组件
 
@@ -509,7 +530,7 @@ CSS 中 `transition: max-height 0.3s cubic-bezier(...)` 与 JS 中 `350ms` 的�
 | 4 | 提取通用 CRUD composable | `PathWhitelistView`, `EnvVarsView`, `SonettoBlockerView` | 创建 `useCrudForm<T>()` |
 | 5 | 引入 Pinia | 全部 composable | 替换模块级 reactive ref，获得 DevTools + 类型安全 + 测试隔离 |
 | 6 | 消除 `as any` | 各处 | 使用更精确的类型或类型守卫 |
-| 7 | 事件路由注册化 | `useChat.ts` | 将 switch 提取为 Map<EventType, Handler> |
+| 7 | ✅ 事件路由注册化 | `useChat.ts` → `useChat.handlers.ts` + `useChat.memory.ts` | 15 个 handler 已提取为 Map<EventType, Handler> 注册表 + 独立模块 |
 
 #### P2 — 影响可靠性
 
@@ -523,7 +544,8 @@ CSS 中 `transition: max-height 0.3s cubic-bezier(...)` 与 JS 中 `350ms` 的�
 
 ```
 Phase 1（短期，1-2 天）
-├── 拆分 useChat.ts → useWebSocket + useTurnPersistence
+├── ✅ 事件路由注册化 — handler 已提取到 useChat.{memory,handlers}.ts
+├── 拆分 useChat.ts → useWebSocket + useTurnPersistence（剩余部分）
 ├── 提取 useVoiceInput composable
 └── 紧急性 bug 修复
 

--- a/dev_docs/frontend-architecture-review.md
+++ b/dev_docs/frontend-architecture-review.md
@@ -1,0 +1,579 @@
+# 前端架构评审与维护指南
+
+> 编写日期：2026-07-13
+> 目标读者：SonettoHere 前端贡献者
+
+## 目录
+
+1. [架构概览](#1-架构概览)
+2. [隐式共享状态模式（核心架构决策）](#2-隐式共享状态模式核心架构决策)
+3. [可引入但未使用的设计模式](#3-可引入但未使用的设计模式)
+4. [难以维护的点](#4-难以维护的点)
+5. [改进建议](#5-改进建议)
+6. [附录：文件职责速查](#6-附录文件职责速查)
+
+---
+
+## 1. 架构概览
+
+```
+web/
+├── src/
+│   ├── main.ts              # 入口：挂载 App + Router
+│   ├── App.vue              # 根组件：侧栏布局 + 路由出口
+│   ├── env.d.ts             # 全局类型声明
+│   │
+│   ├── router/index.ts      # Vue Router 路由定义（9 个路由，4 个懒加载）
+│   │
+│   ├── api/index.ts         # API 层：封装 fetch，统一认证 Token
+│   │
+│   ├── types/index.ts       # 全局 TypeScript 类型定义（500 行）
+│   │
+│   ├── composables/         # 组合式函数（状态层）
+│   │   ├── useChat.ts       # WebSocket 连接 + 消息状态 + localStorage 持久化
+│   │   ├── useSession.ts    # 会话生命周期管理（CRUD + 切换）
+│   │   ├── useHealth.ts     # 后端健康检查轮询
+│   │   └── useSidebar.ts    # 侧栏折叠状态（含窄屏自适应）
+│   │
+│   ├── views/               # 页面组件
+│   │   ├── ChatView.vue         # 主聊天界面
+│   │   ├── MemoryView.vue       # 记忆界面（委托给 MemoryPanel）
+│   │   ├── NewsView.vue         # 更新动态 + 版本时间轴
+│   │   ├── ProvidersView.vue    # LLM 提供商管理（CRUD 表单）
+│   │   ├── SoulView.vue         # 人设编辑（委托给 MarkdownEditor）
+│   │   ├── UserView.vue         # 用户设定编辑（委托给 MarkdownEditor）
+│   │   ├── PathWhitelistView.vue # 路径白名单管理
+│   │   ├── SonettoBlockerView.vue # 拒止锚管理
+│   │   ├── EnvVarsView.vue       # 环境变量管理
+│   │   └── PlaygroundView.vue    # 未使用（遗留）
+│   │
+│   ├── components/          # 组件
+│   │   ├── ChatWindow.vue       # 消息列表 + 右键菜单 + 打字机效果
+│   │   ├── ChatInput.vue        # 输入区（富功能：文件、语音、自动补全、模型选择）
+│   │   ├── MessageBubble.vue    # 消息气泡（用户/助手）
+│   │   ├── ToolCallCard.vue     # 工具调用卡片（通用降级组件）
+│   │   ├── ToolBubbleRouter.vue # 工具气泡路由（按名选组件）
+│   │   ├── SessionSidebar.vue   # 会话侧栏列表 + 悬浮卡片 + 固定卡片
+│   │   ├── MemoryPanel.vue      # 记忆面板（Vignette 瀑布流 / Markdown 回退）
+│   │   ├── RenderMarkdown.vue   # Markdown 渲染（含沙箱隔离）
+│   │   ├── MarkdownEditor.vue   # CodeMirror Markdown 编辑器
+│   │   ├── Icon.vue             # SVG 图标组件（内联所有图标）
+│   │   ├── ContextMenu.vue      # 右键菜单
+│   │   ├── HealthPanel.vue      # 健康状态面板
+│   │   ├── ContextUsageBadge.vue # 上下文用量标签
+│   │   ├── StatusBadge.vue      # 连接状态点
+│   │   ├── TaskTrackerBar.vue   # 任务追踪进度条
+│   │   ├── ThinkingBlock.vue    # 思考过程块
+│   │   ├── HtmlSandbox.vue      # HTML 沙箱 iframe
+│   │   ├── AutocompletePanel.vue # @/#/! 自动补全面板
+│   │   ├── ImageThumbnail.vue   # 图片缩略图
+│   │   ├── ReferenceChip.vue    # 引用标签
+│   │   ├── NewsCard.vue         # 更新动态卡片
+│   │   ├── SectionCard.vue      # 记忆分区卡片
+│   │   └── MomentCard.vue       # 时刻卡片
+│   │
+│   ├── components/tools/    # 工具专属气泡组件
+│   │   ├── registry.ts          # 工具名→组件 注册表
+│   │   ├── _shared/
+│   │   │   ├── BubbleChrome.vue     # 气泡骨架（状态图标 + 展开/折叠动画）
+│   │   │   ├── displayNames.ts      # 工具名→中文显示名映射
+│   │   │   ├── KvTable.vue          # KV 表格
+│   │   │   ├── SonettoBlockerError.vue
+│   │   │   └── shared.css
+│   │   ├── PythonBubble.vue, FilesBubble.vue, FileEditBubble.vue, ...
+│   │   ├── TodoBubble.vue + todo/ 子目录
+│   │   └── ...
+│   │
+│   ├── utils/
+│   │   ├── references.ts    # 引用解析/序列化（ParsedRef 类型体系）
+│   │   ├── markdown.ts      # markdown-it 配置 + 沙箱检测
+│   │   └── python-highlight.ts # Python 语法高亮
+│   │
+│   └── assets/icons/        # SVG 图标（按功能目录组织）
+│
+├── index.html
+├── vite.config.ts           # Vite 配置（API Token 注入 + 代理）
+├── tsconfig.json
+└── package.json             # Vue 3 + Vue Router + markdown-it + KaTeX + CodeMirror
+```
+
+### 技术栈
+
+| 层面 | 选型 | 版本 |
+|------|------|------|
+| 框架 | Vue 3 (Composition API) | ^3.4.0 |
+| 路由 | Vue Router 4 | ^4.3.0 |
+| 构建 | Vite 5 | ^5.2.0 |
+| 语言 | TypeScript | ^5.4.0 |
+| Markdown | markdown-it + texmath + task-lists | 14.x |
+| 数学渲染 | KaTeX | 0.16.x |
+| 代码编辑 | CodeMirror 6 + vue-codemirror | 6.x |
+| 状态管理 | **无 Pinia/Vuex** — 使用模块级 reactive ref | — |
+
+---
+
+## 2. 隐式共享状态模式（核心架构决策）
+
+项目未使用 Pinia 或 Vuex，而是采用了一种**模块级 reactive ref** 模式：
+
+```typescript
+// composables/useChat.ts — 模块作用域
+const channels = reactive(new Map<string, SessionChannel>())
+const turnsCache = loadAllTurnsFromStorage()
+
+export function useChat(sessionId: Ref<string>) {
+  // 返回指向 channels 的响应式引用
+}
+```
+
+```typescript
+// composables/useSession.ts — 模块作用域
+const sessionId = ref('')
+const sessions = ref<SessionInfo[]>([])
+
+export function useSession() {
+  // 返回指向 sessionId/sessions 的引用
+}
+```
+
+**特点：**
+- 状态在模块级定义，所有调用 `useXxx()` 的组件共享同一份状态
+- 无需 Provider 注入，无 `provide/inject`，无需 Pinia 的安装
+- 依赖 `composable` 的 import 时机：先导入的模块会影响后续行为
+
+**潜在问题：**
+- 依赖隐式的 import 顺序（`useSession.initIfNeeded()` 在模块级初始化）
+- 测试困难：无法为每个测试创建独立隔离的 store 实例
+- 缺少 DevTools 支持：无法时间旅行调试
+
+---
+
+## 3. 可引入但未使用的设计模式
+
+### 3.1 观察者/发布-订阅模式（Observer Pattern）
+
+**现状：** `useChat.ts` 的 `handleEventForChannel` 是一个约 250 行的巨型 switch 语句，逐类型处理 WebSocket 事件：
+
+```typescript
+function handleEventForChannel(sid: string, event: ServerEvent) {
+  const ch = channels.get(sid)
+  if (!ch) return
+  // context_usage → early return
+  // sub_session_created → early return
+  // memory_* → 另路由
+  const turn = ch.currentTurn
+  switch (event.type) {
+    case 'thinking_start': ...
+    case 'token': ...
+    case 'tool_start': ...
+    case 'tool_end': ...
+    // ... 10+ 种事件类型
+  }
+}
+```
+
+**可应用模式：** 为每种 `ServerEvent.type` 注册独立的事件处理器：
+
+```typescript
+// 理想设计
+type EventHandler = (ch: SessionChannel, sid: string, event: ServerEvent) => void
+const handlers = new Map<string, EventHandler>()
+
+handlers.set('thinking_start', (ch, sid, event) => { ... })
+handlers.set('tool_end', (ch, sid, event) => { ... })
+handlers.set('memory_start', handleMemoryStart) // 独立模块
+```
+
+**收益：** 每次新增事件类型只需新增一个处理器，switch 不再膨胀。`memory_*` 事件已半独立（`handleMemoryToolEvent` 函数），但没有注册机制。
+
+**实现成本：** 低。重构范围限于 `useChat.ts` 内部。
+
+---
+
+### 3.2 命令模式（Command Pattern）
+
+**现状：** 工具操作通过字符串 + `data` 透传：
+
+```typescript
+// ChatView 中
+emit('action', { action: 'undo', data: { n: 1 } })
+
+// ChatWindow 中
+emit('action', { action: 'user_response', data: { interactionId, response } })
+```
+
+**可应用模式：** 定义具名操作对象，使 action 和 data 的关系类型安全：
+
+```typescript
+// 理想设计
+type ToolAction = 
+  | { type: 'undo'; n: number }
+  | { type: 'user_response'; interactionId: string; response: string | string[] }
+  | { type: 'cite'; ref: ParsedRef }
+```
+
+**收益：** 消除 `action` 和 `data` 的魔数字段，获得编译期类型检查。
+
+**实现成本：** 低。纯 TypeScript 类型定义变更。
+
+---
+
+### 3.3 策略模式（Strategy Pattern）— 已有雏形可深化
+
+**现状：** `tools/registry.ts` 和 `ToolBubbleRouter.vue` 已实现简单的策略模式——按工具名选择气泡组件。
+
+```typescript
+const registry: Record<string, Component> = {
+  'run_python': PythonBubble,
+  'tarot': TarotBubble,
+  // ...
+}
+```
+
+**可深化方向：**
+1. 每个策略组件可声明自己的 `tooltip`、`icon`、`group` 等元数据（当前 `displayNames.ts` 是平铺映射）
+2. 支持动态注册（插件化场景）
+3. 对未注册工具的行为可以配置化（默认展开/折叠、最大长度等）
+
+---
+
+### 3.4 工厂模式（Factory Pattern）
+
+**现状：** `ToolBubbleRouter.vue` 使用 `computed` 动态解析组件：
+
+```typescript
+const bubbleComponent = computed(() => {
+  return getBubbleComponent(props.toolCall.name)
+})
+```
+
+**可应用模式：** 可考虑「抽象工厂」，按工具分类生产组件。但当前模式的简洁性对项目规模是合适的——**不宜过度设计**。
+
+---
+
+### 3.5 仓库模式（Repository Pattern）
+
+**现状：** `api/index.ts` 是一个扁平对象，40+ 方法。所有 API 调用都在这里。
+
+```typescript
+export const api = {
+  createSession: () => request<CreateSessionResponse>('/sessions', { method: 'POST' }),
+  listSessions: () => request<ListSessionsResponse>('/sessions'),
+  listProviders: () => request<ListProvidersResponse>('/providers'),
+  // ... 40+ 方法
+}
+```
+
+**可应用模式：** 按领域拆分：
+
+```typescript
+// 理想设计
+export const sessionApi = { create, list, get, delete, constify, unconstify }
+export const providerApi = { list, get, create, update, delete, test, discover }
+export const memoryApi = { getNarrative, getMoment, getMemories }
+export const personaApi = { get, update }
+```
+
+**收益：** 按领域组织，减少单文件体积（267 行 → 每个文件 30-50 行），增强可发现性。
+
+**实现成本：** 低。纯拆分，不改变接口签名。
+
+---
+
+### 3.6 模板方法模式（Template Method）
+
+**现状：** `PathWhitelistView.vue`、`EnvVarsView.vue`、`SonettoBlockerView.vue` 三者重复相同的「列表/表单切换」模式：
+
+```vue
+<template v-if="mode === 'list'">
+  <!-- 列表 -->
+</template>
+<template v-else>
+  <!-- 表单 -->
+</template>
+```
+
+每个的脚本部分有高度相似的：`loading` / `saving` / `formError` ref、`loadXxx()` / `startEdit()` / `cancelForm()` / `handleSave()` 方法。
+
+**可应用模式：** 创建一个通用的 `useCrudForm` composable，封装列表/表单切换逻辑：
+
+```typescript
+// 理想设计
+function useCrudForm<T>() {
+  const mode = ref<'list' | 'form'>('list')
+  const loading = ref(false)
+  const saving = ref(false)
+  const formError = ref('')
+  const editingIndex = ref(-1)
+  
+  function startAdd() { mode.value = 'form'; editingIndex.value = -1 }
+  function startEdit(i: number) { mode.value = 'form'; editingIndex.value = i }
+  function cancelForm() { mode.value = 'list'; formError.value = '' }
+  
+  return { mode, loading, saving, formError, editingIndex, startAdd, startEdit, cancelForm }
+}
+```
+
+**收益：** 消除三个视图组件中约 40% 的重复代码。
+
+**实现成本：** 中。需提取各处差异点（数据加载/保存的具体逻辑不同）。
+
+---
+
+## 4. 难以维护的点
+
+### 4.1 `useChat.ts` — 750+ 行，职能混杂 ⚠️
+
+**文件大小：** 752 行，40+ 个函数，单一文件。
+
+**混杂的职责：**
+| 职责 | 行数范围 | 说明 |
+|------|---------|------|
+| localStorage 持久化 | 10-73 | `saveTurnsToStorage`, `loadAllTurnsFromStorage` |
+| WebSocket 连接管理 | 164-228 | `connectSession`, `ensureConnected`, 重连逻辑 |
+| 多会话通道管理 | 96-160 | `channels` Map, `getOrCreateChannel` |
+| 事件路由 + 处理 | 232-517 | 巨型 switch + `handleMemoryToolEvent` |
+| Turn 状态管理 | 520-667 | `send`, `cancel`, `sendUserResponse`, `removeTurns` |
+| 工具查找函数 | 671-751 | `findToolByCallId`, `findBestMatchingTool` 等 |
+
+**维护风险：**
+- 修改一处可能意外影响另一处
+- 无法独立测试 WebSocket 重连逻辑（与 localStorage 紧耦合）
+- 新增事件类型需要深入理解整个文件
+
+### 4.2 `ChatInput.vue` — 900+ 行的巨型组件
+
+**文件大小：** 900+ 行（template 170 行 + script 730 行 + style 630 行）。
+
+**混杂的职责：**
+- 文件/文件夹选择器
+- 链接粘贴自动识别
+- `@`/`#`/`!` 自动补全（技能、工具、宏）
+- 语音输入（Web Speech API）— 约 120 行
+- Provider/Model 下拉选择器
+- 图像认知模式切换
+- 发送/停止按钮
+- 拖拽调整高度
+- 键盘快捷键（全局 Space 长按语音）
+
+**拆分建议：** 至少可拆出 3-4 个独立模块：
+- `useVoiceInput` composable（语音识别逻辑）
+- `useAutocomplete` composable（@/#/! 补全逻辑）
+- `useInputResize` composable（拖拽调整）
+- `ProviderSelector` 子组件（模型选择 UI）
+
+### 4.3 隐式共享状态的测试困境
+
+**现状：** 所有 composable 都使用模块级状态：
+
+```typescript
+// useChat.ts
+const channels = reactive(new Map())
+export function useChat(sessionId: Ref<string>) { ... }
+```
+
+**问题：**
+- 单元测试无法创建隔离的 store 实例
+- `useSession.initIfNeeded()` 在模块首次 import 时自动执行，测试无法重置状态
+- WebSocket 连接在测试中无法 mock（模块级 `channels` 持有真实连接）
+
+### 4.4 localStorage 作为消息存储
+
+**现状：** 消息历史通过 JSON 序列化存储在 `localStorage`。
+
+**问题：**
+- **容量限制：** 约 5-10 MB 上限，长对话可能溢出
+- **无索引：** 查找/过滤需反序列化全部数据
+- **无迁移策略：** 数据结构变更时，旧数据被静默丢弃（`migrateLegacyTurn` 是手写迁移，每次变更需追加）
+- **同步问题：** 多标签页窗口数据不一致
+- **性能：** 每次保存全量序列化整个会话
+
+### 4.5 WebSocket 重连逻辑的耦合
+
+`connectSession` 中 `onclose` 设置 3 秒重连：
+
+```typescript
+ch.ws.onclose = () => {
+  ch.connected = false
+  ch.reconnectTimer = setTimeout(() => connectSession(sid), 3000)
+}
+```
+
+而 `disconnectSession` 为了阻止重连需要手动清除 `onclose`：
+
+```typescript
+export function disconnectSession(sid: string) {
+  // 先清除 onclose，再手动关闭 WS
+  if (ch.ws) {
+    ch.ws.onclose = null
+    ch.ws.close()
+  }
+}
+```
+
+这种「清除回调再关闭」的模式是脆弱的。如果重连请求已经入队（`setTimeout` 已触发但未执行），则 `disconnectSession` 无效。
+
+### 4.6 CSS 样式不一致
+
+**现状：** 硬编码颜色值散布在组件中：
+
+```css
+/* ProvidersView.vue 使用大量硬编码颜色 */
+.provider-card { background: #ffffff; }
+.card-label { color: #1f2937; }
+.card-type-badge { color: #9ca3af; }
+.model-tag { color: #6b7280; background: #f3f4f6; }
+```
+
+而 `App.vue` 定义了 CSS 变量体系（`--text-primary`, `--text-secondary` 等）。
+
+**问题：** 主题切换时（如果未来实现暗色模式），硬编码颜色的组件无法跟随。目前约 30% 使用 CSS 变量，70% 硬编码。
+
+### 4.7 类型安全的幻影区
+
+多处使用 `as any` 或隐式 `any`：
+
+```typescript
+// ChatInput.vue — SpeechRecognition
+const recognitionRef = ref<any>(null)
+
+// ChatInput.vue — 路径检查
+const entry = refs.value[idx] as any
+entry.blocked = true
+
+// useChat.ts — done 事件处理
+(event.payload as Record<string, unknown>).turn_id
+
+// ChatInput.vue — pasted link inference
+refs.value.push({ type: 'web_link', url: text, label: domain, domain } as ParsedRef)
+```
+
+### 4.8 重复的 CRUD 模式
+
+`PathWhitelistView.vue`、`EnvVarsView.vue`、`SonettoBlockerView.vue` 共享几乎相同的模式，但每个文件独立实现：
+
+| 特性 | 各文件重复实现 |
+|------|--------------|
+| `mode` (list/form) | 3 次 |
+| `loading` / `saving` | 3 次 |
+| `formError` | 3 次 |
+| `cancelForm()` | 3 次 |
+| 表单输入字段 | 类似结构 |
+
+### 4.9 `App.vue` — 根组件膨胀
+
+`App.vue` 兼职责：
+- 侧栏布局
+- 设置菜单弹出
+- 服务重启（含 60 次循环探测）
+- 会话切换事件处理
+- 固定/取消固定会话
+- 全局样式定义
+
+根组件应尽量「薄」，将具体业务逻辑委托给子组件或 composable。
+
+### 4.10 动画与逻辑的时间耦合
+
+```typescript
+// BubbleChrome.vue
+function openBody() {
+  bodyWrapper.value.style.maxHeight = h + 'px'
+  setTimeout(() => {
+    if (bodyWrapper.value && isOpen.value) {
+      bodyWrapper.value.style.maxHeight = 'none'
+    }
+  }, 350)  // ← magic number, 与 CSS transition 0.35s 耦合
+}
+```
+
+CSS 中 `transition: max-height 0.3s cubic-bezier(...)` 与 JS 中 `350ms` 的时机必须保持一致。修改 CSS 动画时长时必须同步修改 JS。
+
+---
+
+## 5. 改进建议
+
+### 按优先级排序
+
+#### P0 — 影响开发效率
+
+| # | 改进项 | 文件 | 建议 |
+|---|--------|------|------|
+| 1 | 拆分 `useChat.ts` | `useChat.ts` | 提取 `useWebSocket` (WS 连接/重连)、`useTurnPersistence` (本地存储)、`useEventRouter` (事件分发) |
+| 2 | 拆分 `ChatInput.vue` | `ChatInput.vue` | 提取 `useVoiceInput`、`useAutocomplete`、`useInputResize` composable |
+
+#### P1 — 影响代码质量
+
+| # | 改进项 | 涉及文件 | 建议 |
+|---|--------|---------|------|
+| 3 | 统一 CSS 变量 | 所有 view 组件 | 逐步替换硬编码颜色为 `var(--xxx)` |
+| 4 | 提取通用 CRUD composable | `PathWhitelistView`, `EnvVarsView`, `SonettoBlockerView` | 创建 `useCrudForm<T>()` |
+| 5 | 引入 Pinia | 全部 composable | 替换模块级 reactive ref，获得 DevTools + 类型安全 + 测试隔离 |
+| 6 | 消除 `as any` | 各处 | 使用更精确的类型或类型守卫 |
+| 7 | 事件路由注册化 | `useChat.ts` | 将 switch 提取为 Map<EventType, Handler> |
+
+#### P2 — 影响可靠性
+
+| # | 改进项 | 涉及文件 | 建议 |
+|---|--------|---------|------|
+| 8 | 局部存储迁移策略 | `useChat.ts` | 为 `schema_version` 添加 localStorage 校验，自动迁移或优雅降级 |
+| 9 | 重连机制解耦 | `useChat.ts` | 使用「请求-确认」模式替代「清除回调再关闭」 |
+| 10 | 动画时间常量 | `BubbleChrome.vue`, `ToolCallCard.vue` | 将 CSS transition 时长提取为 CSS 变量，JS 通过 `getComputedStyle` 读取 |
+
+### 推荐重构路线
+
+```
+Phase 1（短期，1-2 天）
+├── 拆分 useChat.ts → useWebSocket + useTurnPersistence
+├── 提取 useVoiceInput composable
+└── 紧急性 bug 修复
+
+Phase 2（中期，3-5 天）
+├── 提取通用 CRUD composable
+├── 统一 CSS 变量（逐步替换硬编码颜色）
+├── 消除 as any 类型漏洞
+└── 引入事件注册机制替代 switch
+
+Phase 3（长期，1-2 周）
+├── 引入 Pinia 替代模块级状态
+├── 剥离 ChatInput 子组件
+├── 建立单元测试框架（Vitest）
+└── 动画时间耦合解耦
+```
+
+---
+
+## 6. 附录：文件职责速查
+
+### 状态管理文件
+
+| 文件 | 状态类型 | 共享范围 | 持久化方式 |
+|------|---------|---------|-----------|
+| `composables/useChat.ts` | WebSocket 连接、消息缓存、流式状态 | 全局（模块级 reactive Map） | localStorage |
+| `composables/useSession.ts` | 当前 sessionId、会话列表 | 全局（模块级 ref） | localStorage (sessionId) |
+| `composables/useHealth.ts` | 健康检查结果 | 全局（模块级 ref） | 无 |
+| `composables/useSidebar.ts` | 侧栏折叠状态 | 全局（模块级 ref） | localStorage |
+
+### API 领域分组
+
+| 方法前缀 | 领域 | 方法数 |
+|---------|------|--------|
+| `createSession/listSessions/...` | 会话管理 | 9 |
+| `listProviders/getProvider/...` | 提供商管理 | 11 |
+| `listSkills/listTools/listMacros` | 技能/工具发现 | 3 |
+| `getPersona/updatePersona` | 人设编辑 | 2 |
+| `listWhitelist/addWhitelistEntry/...` | 路径白名单 | 4 |
+| `listBlockers/addBlocker/...` | 拒止锚 | 3 |
+| `listEnvVars/updateEnvVar/batchUpdateEnvVars` | 环境变量 | 3 |
+| `getNarrative/getMoment/getMemories` | 记忆 | 3 |
+| 其他（health/restart/balance） | 系统 | 3 |
+
+### 工具气泡注册表（共 38 个工具名 → 15 个组件）
+
+| 组件 | 处理工具 |
+|------|---------|
+| `TodoBubble` | todo_add/list/complete/uncomplete/delete/update/query... (11) |
+| `FilesBubble` | file_read/file_write/file_manage/file_search (4) |
+| `MapBubble` | nearby_search/fuzzy_address_search/geocode_address/get_transit_route/get_cycling_route (5) |
+| `MemoryBubble` | list/read/create/update/delete/merge_memories (6) |
+| `AskUserBubble` | ask_user_*/ask_user_for_info (4) |
+| 其余 10 个组件各处理 1 个工具 | |

--- a/web/src/composables/useChat.handlers.ts
+++ b/web/src/composables/useChat.handlers.ts
@@ -1,0 +1,187 @@
+import { nextTick } from 'vue'
+import type { SessionChannel } from './useChat'
+import type { ServerEvent, ChatTurn, TokenEvent, AnswerEvent, ErrorEvent, DoneEvent, AskUserEvent } from '@/types'
+import { refreshSessions, switchSession } from '@/composables/useSession'
+import { findLastThinking, findToolByCallId, findBestMatchingTool, findFirstRunningToolForInteraction, persistTurns } from './useChat'
+
+/** 事件路由处理器签名（turn 已由调用方守卫保证存在）。 */
+type TurnEventHandler = (ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent) => void
+
+/** thinking_start：压入思考块。 */
+function handleThinkingStart(ch: SessionChannel, _sid: string, turn: ChatTurn, _event: ServerEvent): void {
+  turn.events.push({ kind: 'thinking', tokens: '', done: false, becameAnswer: false })
+}
+
+/** token：追加到最后一个思考块。 */
+function handleToken(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const lastThink = findLastThinking(turn.events)
+  if (lastThink) {
+    lastThink.tokens += (event as TokenEvent).payload.token
+  }
+}
+
+/** thinking_end：标记最后一个思考块完成。 */
+function handleThinkingEnd(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const lastThink = findLastThinking(turn.events)
+  if (lastThink) {
+    lastThink.done = true
+  }
+}
+
+/** tool_start：压入 running 状态工具调用。 */
+function handleToolStart(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const tsEvent = event as { type: 'tool_start'; payload: { call_id: string; tool_name: string; input: string } }
+  console.log('[useChat] tool_start:', tsEvent.payload.tool_name, { input: tsEvent.payload.input, call_id: tsEvent.payload.call_id, session: sid })
+  turn.events.push({
+    kind: 'tool',
+    name: tsEvent.payload.tool_name,
+    input: tsEvent.payload.input,
+    output: null,
+    elapsed: null,
+    status: 'running',
+    callId: tsEvent.payload.call_id,
+  })
+}
+
+/** tool_end：更新匹配工具调用为 done，提取 tool_data，处理 ask_user 状态恢复。 */
+function handleToolEnd(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const teEvent = event as { type: 'tool_end'; payload: { call_id: string; tool_name: string; output: string; elapsed: number; tool_data?: Record<string, unknown> } }
+  // 精确匹配：优先用 call_id，降级用 heuristic
+  const tc = findToolByCallId(turn.events, teEvent.payload.call_id)
+    ?? findBestMatchingTool(turn.events, teEvent.payload.tool_name)
+  if (tc) {
+    tc.output = teEvent.payload.output
+    tc.elapsed = teEvent.payload.elapsed
+    tc.status = 'done'
+    if (teEvent.payload.tool_data) {
+      tc.toolData = teEvent.payload.tool_data
+      if (teEvent.payload.tool_name === 'task_tracker' && teEvent.payload.tool_data) {
+        ch.taskTrackerData = teEvent.payload.tool_data as Record<string, unknown>
+      }
+    }
+    console.log(`[useChat] tool_end: "${teEvent.payload.tool_name}"`, {
+      output_len: (teEvent.payload.output || '').length,
+      output_preview: (teEvent.payload.output || '').slice(0, 100),
+      has_tool_data: !!teEvent.payload.tool_data,
+      elapsed: teEvent.payload.elapsed,
+      session: sid,
+    })
+  }
+  // ask_user 工具执行完毕 → 用户已回应，回到工作态
+  if (ch.isAwaitingUser && teEvent.payload.tool_name === ch._awaitingToolName) {
+    ch.isAwaitingUser = false
+    ch._awaitingToolName = null
+  }
+}
+
+/** tool_error：更新匹配工具调用为 error。 */
+function handleToolError(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const teEvent = event as { type: 'tool_error'; payload: { call_id: string; tool_name: string; error: string } }
+  const tc = findToolByCallId(turn.events, teEvent.payload.call_id)
+    ?? findBestMatchingTool(turn.events, teEvent.payload.tool_name)
+  if (tc) {
+    tc.status = 'error'
+  }
+}
+
+/** answer：标记思考块为 becameAnswer，设置 finalAnswer。 */
+function handleAnswer(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const lastThink = findLastThinking(turn.events)
+  if (lastThink) {
+    lastThink.becameAnswer = true
+  }
+  turn.finalAnswer = (event as AnswerEvent).payload.content
+}
+
+/** done：finalize 当前轮次，持久化，刷新会话列表。 */
+function handleDone(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const de = event as DoneEvent
+  ch.isAwaitingUser = false
+  ch._awaitingToolName = null
+  if (de.payload.context_usage) {
+    ch.contextUsage = de.payload.context_usage
+  }
+  // 存储后端 turn_id，用于关联后台记忆 consumer 的事件
+  if (de.payload.turn_id) {
+    turn.turnId = de.payload.turn_id
+    console.log(`[ltm-fe] turnId set on turn.id=${turn.id}: ${turn.turnId}`)
+  }
+  const lastThink = findLastThinking(turn.events)
+  const trackBecame = lastThink?.becameAnswer
+  console.log(`[useChat:done] 会话 ${sid}: becameAnswer=${trackBecame}, events=${turn.events.length}, finalAnswer=${turn.finalAnswer?.slice(0, 50) ?? 'null'}`)
+  if (trackBecame) {
+    const turnToFinalize = turn
+    void nextTick(() => {
+      setTimeout(() => {
+        console.log(`[useChat:done] becameAnswer 分支执行 persist (会话 ${sid})`)
+        ch.turns.push(turnToFinalize)
+        ch.currentTurn = null
+        ch.isStreaming = false
+        if (!ch.privateMode) { persistTurns(sid) }
+      }, 420)
+    })
+  } else {
+    console.log(`[useChat:done] 直接分支执行 persist (会话 ${sid})`)
+    ch.turns.push(turn)
+    ch.currentTurn = null
+    ch.isStreaming = false
+    if (!ch.privateMode) { persistTurns(sid) }
+  }
+  void refreshSessions()  // 轮次结束，刷新会话列表以更新 message_count
+  // 子 Agent 完成 → 自动切回主会话
+  if (ch.parentSessionId) {
+    setTimeout(() => switchSession(ch.parentSessionId!), 500)
+  }
+}
+
+/** error：清除流式状态，设置错误信息。 */
+function handleError(ch: SessionChannel, _sid: string, _turn: ChatTurn, event: ServerEvent): void {
+  ch.isAwaitingUser = false
+  ch._awaitingToolName = null
+  ch.error = (event as ErrorEvent).payload.message
+  ch.isStreaming = false
+}
+
+/** ask_user：设置交互等待状态，在 running 工具上挂载 interaction。 */
+function handleAskUser(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const ae = event as AskUserEvent
+  ch.isAwaitingUser = true
+  ch._awaitingToolName = ae.payload.tool_name
+  console.log('[useChat] received ask_user event:', {
+    tool_name: ae.payload.tool_name,
+    question: ae.payload.question?.slice(0, 50),
+    mode: ae.payload.mode,
+    interaction_id: ae.payload.interaction_id,
+    session: sid,
+  })
+  const runningTool = findFirstRunningToolForInteraction(turn.events, ae.payload.tool_name)
+  console.log('[useChat] findFirstRunningToolForInteraction result:', runningTool ? {
+    name: runningTool.name,
+    status: runningTool.status,
+    has_interaction: !!runningTool.interaction,
+  } : 'NOT FOUND')
+  if (runningTool) {
+    runningTool.interaction = {
+      question: ae.payload.question,
+      mode: ae.payload.mode,
+      options: ae.payload.options,
+      interactionId: ae.payload.interaction_id,
+      submitted: false,
+      code: ae.payload.code,
+    }
+  }
+}
+
+/** 事件路由处理器注册表。 */
+export const turnHandlers = new Map<string, TurnEventHandler>([
+  ['thinking_start', handleThinkingStart],
+  ['token', handleToken],
+  ['thinking_end', handleThinkingEnd],
+  ['tool_start', handleToolStart],
+  ['tool_end', handleToolEnd],
+  ['tool_error', handleToolError],
+  ['answer', handleAnswer],
+  ['done', handleDone],
+  ['error', handleError],
+  ['ask_user', handleAskUser],
+])

--- a/web/src/composables/useChat.memory.ts
+++ b/web/src/composables/useChat.memory.ts
@@ -1,0 +1,89 @@
+import type { SessionChannel } from './useChat'
+import type { ServerEvent, MemoryStartEvent, MemoryToolStartEvent, MemoryToolEndEvent, MemoryToolErrorEvent, MemoryDoneEvent, MemoryToolEvent, ChatTurn } from '@/types'
+import { findTurnByBackendId, findRunningMemoryTool, persistTurns } from './useChat'
+
+/** read_memories 是纯读取操作，前端无需显示其执行状态。 */
+function skipReadMemories(payload: { tool_name: string }): boolean {
+  return payload.tool_name === 'read_memories'
+}
+
+/** 后台记忆 consumer 事件类型。 */
+export type MemoryEventType = 'memory_start' | 'memory_tool_start' | 'memory_tool_end' | 'memory_tool_error' | 'memory_done'
+
+/** 后台记忆 consumer 事件处理器签名。 */
+type MemoryEventHandler = (ch: SessionChannel, sid: string, event: ServerEvent) => void
+
+/** 后台记忆 consumer 开始处理本轮对话：压入「处理中」占位条目。 */
+function handleMemoryStart(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryStartEvent
+  console.log(`[ltm-fe] memory_start session=${sid} turn_id=${me.payload.turn_id}`)
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
+  if (!targetTurn.memoryEvents) targetTurn.memoryEvents = []
+  targetTurn.memoryEvents.push({
+    kind: 'memory_tool', name: 'memory_processing', input: '', output: null, elapsed: null, status: 'running',
+  })
+}
+
+/** 后台记忆 consumer 开始调用 CRUD 工具：压入 running 状态工具事件。 */
+function handleMemoryToolStart(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryToolStartEvent
+  if (skipReadMemories(me.payload)) return
+  console.log(`[ltm-fe] memory_tool_start session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
+  targetTurn.memoryEvents?.push({
+    kind: 'memory_tool', name: me.payload.tool_name, input: me.payload.input,
+    output: null, elapsed: null, status: 'running',
+  })
+}
+
+/** 后台记忆 consumer 的 CRUD 工具执行完毕：更新匹配事件为 done。 */
+function handleMemoryToolEnd(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryToolEndEvent
+  if (skipReadMemories(me.payload)) return
+  console.log(`[ltm-fe] memory_tool_end session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
+  const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
+  if (mt) { mt.output = me.payload.output; mt.elapsed = me.payload.elapsed; mt.status = 'done' }
+  if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
+}
+
+/** 后台记忆 consumer 的 CRUD 工具出错：更新匹配事件为 error。 */
+function handleMemoryToolError(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryToolErrorEvent
+  if (skipReadMemories(me.payload)) return
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) return
+  const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
+  if (mt) mt.status = 'error'
+  if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
+}
+
+/** 后台记忆 consumer 处理完毕：移除「处理中」占位，无实际工具事件时渲染 memory_review。 */
+function handleMemoryDone(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryDoneEvent
+  console.log(`[ltm-fe] memory_done session=${sid} turn_id=${me.payload.turn_id}`)
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
+  // 移除「处理中」占位条目
+  const realEvents = (targetTurn.memoryEvents ?? []).filter(e => e.name !== 'memory_processing')
+  targetTurn.memoryEvents = realEvents
+  if (realEvents.length === 0) {
+    targetTurn.memoryEvents = [{
+      kind: 'memory_tool', name: 'memory_review', input: '', output: '', elapsed: null, status: 'done',
+    }]
+    console.log(`[ltm-fe] added memory_review`)
+  }
+  if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
+}
+
+/** 记忆事件处理器注册表。新增记忆事件类型只需在此注册，调用方守卫自动覆盖。 */
+export const memoryHandlers = new Map<MemoryEventType, MemoryEventHandler>([
+  ['memory_start', handleMemoryStart],
+  ['memory_tool_start', handleMemoryToolStart],
+  ['memory_tool_end', handleMemoryToolEnd],
+  ['memory_tool_error', handleMemoryToolError],
+  ['memory_done', handleMemoryDone],
+])

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -1,5 +1,5 @@
 import { reactive, computed, watch, nextTick, type Ref } from 'vue'
-import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, AskUserEvent, MemoryToolEvent, MemoryToolStartEvent, MemoryToolEndEvent, MemoryToolErrorEvent, MemoryStartEvent, MemoryDoneEvent } from '@/types'
+import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, TokenEvent, AnswerEvent, ErrorEvent, DoneEvent, AskUserEvent, MemoryToolEvent, MemoryToolStartEvent, MemoryToolEndEvent, MemoryToolErrorEvent, MemoryStartEvent, MemoryDoneEvent } from '@/types'
 import { refreshSessions, switchSession } from '@/composables/useSession'
 import { buildFlatMessage, buildTimestamp, parseReferences } from '@/utils/references'
 import type { ParsedRef } from '@/utils/references'
@@ -229,6 +229,43 @@ export function ensureConnected(sid: string) {
 
 // ── 事件路由 ──────────────────────────────────────────────
 
+/** read_memories 是纯读取操作，前端无需显示其执行状态。 */
+function skipReadMemories(payload: { tool_name: string }): boolean {
+  return payload.tool_name === 'read_memories'
+}
+
+/** 后台记忆 consumer 事件类型。 */
+type MemoryEventType = 'memory_start' | 'memory_tool_start' | 'memory_tool_end' | 'memory_tool_error' | 'memory_done'
+
+/** 后台记忆 consumer 事件处理器签名。 */
+type MemoryEventHandler = (ch: SessionChannel, sid: string, event: ServerEvent) => void
+
+/** 记忆事件处理器注册表。新增记忆事件类型只需在此注册，调用方守卫自动覆盖。 */
+const memoryHandlers = new Map<MemoryEventType, MemoryEventHandler>([
+  ['memory_start', handleMemoryStart],
+  ['memory_tool_start', handleMemoryToolStart],
+  ['memory_tool_end', handleMemoryToolEnd],
+  ['memory_tool_error', handleMemoryToolError],
+  ['memory_done', handleMemoryDone],
+])
+
+/** 事件路由处理器签名（turn 已由调用方守卫保证存在）。 */
+type TurnEventHandler = (ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent) => void
+
+/** 事件路由处理器注册表。 */
+const turnHandlers = new Map<string, TurnEventHandler>([
+  ['thinking_start', handleThinkingStart],
+  ['token', handleToken],
+  ['thinking_end', handleThinkingEnd],
+  ['tool_start', handleToolStart],
+  ['tool_end', handleToolEnd],
+  ['tool_error', handleToolError],
+  ['answer', handleAnswer],
+  ['done', handleDone],
+  ['error', handleError],
+  ['ask_user', handleAskUser],
+])
+
 function handleEventForChannel(sid: string, event: ServerEvent) {
   const ch = channels.get(sid)
   if (!ch) return
@@ -263,256 +300,251 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
     return
   }
 
-  // memory_tool_* / memory_start / memory_done 可能在 done 事件之后到达（currentTurn 已清空），
+  // 后台记忆 consumer 事件可能在 done 事件之后到达（currentTurn 已清空），
   // 必须在 const turn = ch.currentTurn 守卫之前处理，通过 turn_id 自行查找目标。
-  if (event.type === 'memory_start' || event.type === 'memory_tool_start' || event.type === 'memory_tool_end'
-    || event.type === 'memory_tool_error' || event.type === 'memory_done') {
-    handleMemoryToolEvent(ch, sid, event)
+  const memoryHandler = memoryHandlers.get(event.type as MemoryEventType)
+  if (memoryHandler) {
+    memoryHandler(ch, sid, event)
     return
   }
 
   const turn = ch.currentTurn
   if (!turn) return
 
-  switch (event.type) {
-    case 'thinking_start':
-      turn.events.push({ kind: 'thinking', tokens: '', done: false, becameAnswer: false })
-      break
-
-    case 'token': {
-      const lastThink = findLastThinking(turn.events)
-      if (lastThink) {
-        lastThink.tokens += event.payload.token
-      }
-      break
-    }
-
-    case 'thinking_end': {
-      const lastThink = findLastThinking(turn.events)
-      if (lastThink) {
-        lastThink.done = true
-      }
-      break
-    }
-
-    case 'tool_start': {
-      const tsEvent = event as { type: 'tool_start'; payload: { call_id: string; tool_name: string; input: string } }
-      console.log('[useChat] tool_start:', tsEvent.payload.tool_name, { input: tsEvent.payload.input, call_id: tsEvent.payload.call_id, session: sid })
-      turn.events.push({
-        kind: 'tool',
-        name: tsEvent.payload.tool_name,
-        input: tsEvent.payload.input,
-        output: null,
-        elapsed: null,
-        status: 'running',
-        callId: tsEvent.payload.call_id,
-      })
-      break
-    }
-
-    case 'tool_end': {
-      const teEvent = event as { type: 'tool_end'; payload: { call_id: string; tool_name: string; output: string; elapsed: number; tool_data?: Record<string, unknown> } }
-      // 精确匹配：优先用 call_id，降级用 heuristic
-      const tc = findToolByCallId(turn.events, teEvent.payload.call_id)
-        ?? findBestMatchingTool(turn.events, teEvent.payload.tool_name)
-      if (tc) {
-        tc.output = event.payload.output
-        tc.elapsed = event.payload.elapsed
-        tc.status = 'done'
-        if (event.payload.tool_data) {
-          tc.toolData = event.payload.tool_data
-          if (event.payload.tool_name === 'task_tracker' && event.payload.tool_data) {
-            ch.taskTrackerData = event.payload.tool_data as Record<string, unknown>
-          }
-        }
-        console.log(`[useChat] tool_end: "${event.payload.tool_name}"`, {
-          output_len: (event.payload.output || '').length,
-          output_preview: (event.payload.output || '').slice(0, 100),
-          has_tool_data: !!event.payload.tool_data,
-          elapsed: event.payload.elapsed,
-          session: sid,
-        })
-      }
-      // ask_user 工具执行完毕 → 用户已回应，回到工作态
-      if (ch.isAwaitingUser && event.payload.tool_name === ch._awaitingToolName) {
-        ch.isAwaitingUser = false
-        ch._awaitingToolName = null
-      }
-      break
-    }
-
-    case 'tool_error': {
-      const teEvent = event as { type: 'tool_error'; payload: { call_id: string; tool_name: string; error: string } }
-      const tc = findToolByCallId(turn.events, teEvent.payload.call_id)
-        ?? findBestMatchingTool(turn.events, teEvent.payload.tool_name)
-      if (tc) {
-        tc.status = 'error'
-      }
-      break
-    }
-
-    case 'answer': {
-      const lastThink = findLastThinking(turn.events)
-      if (lastThink) {
-        lastThink.becameAnswer = true
-      }
-      turn.finalAnswer = event.payload.content
-      break
-    }
-
-    case 'done':
-      ch.isAwaitingUser = false
-      ch._awaitingToolName = null
-      if (event.payload.context_usage) {
-        ch.contextUsage = event.payload.context_usage
-      }
-      // 存储后端 turn_id，用于关联后台记忆 consumer 的事件
-      if (ch.currentTurn && (event.payload as Record<string, unknown>).turn_id) {
-        ch.currentTurn.turnId = (event.payload as Record<string, unknown>).turn_id as string
-        console.log(`[ltm-fe] turnId set on turn.id=${ch.currentTurn.id}: ${ch.currentTurn.turnId}`)
-      }
-      if (ch.currentTurn) {
-        const lastThink = findLastThinking(ch.currentTurn.events)
-        const trackBecame = lastThink?.becameAnswer
-        console.log(`[useChat:done] 会话 ${sid}: becameAnswer=${trackBecame}, events=${ch.currentTurn.events.length}, finalAnswer=${ch.currentTurn.finalAnswer?.slice(0, 50) ?? 'null'}`)
-        if (trackBecame) {
-          const turnToFinalize = ch.currentTurn
-          void nextTick(() => {
-            setTimeout(() => {
-              console.log(`[useChat:done] becameAnswer 分支执行 persist (会话 ${sid})`)
-              ch.turns.push(turnToFinalize)
-              ch.currentTurn = null
-              ch.isStreaming = false
-              if (!ch.privateMode) {
-                persistTurns(sid)
-              }
-            }, 420)
-          })
-        } else {
-          console.log(`[useChat:done] 直接分支执行 persist (会话 ${sid})`)
-          ch.turns.push(ch.currentTurn)
-          ch.currentTurn = null
-          ch.isStreaming = false
-          if (!ch.privateMode) {
-            persistTurns(sid)
-          }
-        }
-        void refreshSessions()  // 轮次结束，刷新会话列表以更新 message_count
-      } else {
-        console.warn(`[useChat:done] 会话 ${sid} 的 done 事件到达时 currentTurn 为 null`)
-        ch.isStreaming = false
-      }
-      // 子 Agent 完成 → 自动切回主会话
-      if (ch.parentSessionId) {
-        setTimeout(() => switchSession(ch.parentSessionId!), 500)
-      }
-      break
-
-    case 'error':
-      ch.isAwaitingUser = false
-      ch._awaitingToolName = null
-      ch.error = event.payload.message
-      ch.isStreaming = false
-      break
-
-    case 'pong':
-      break
-
-    case 'ask_user': {
-      const ae = event as AskUserEvent
-      ch.isAwaitingUser = true
-      ch._awaitingToolName = ae.payload.tool_name
-      console.log('[useChat] received ask_user event:', {
-        tool_name: ae.payload.tool_name,
-        question: ae.payload.question?.slice(0, 50),
-        mode: ae.payload.mode,
-        interaction_id: ae.payload.interaction_id,
-        session: sid,
-      })
-      const runningTool = findFirstRunningToolForInteraction(turn.events, ae.payload.tool_name)
-      console.log('[useChat] findFirstRunningToolForInteraction result:', runningTool ? {
-        name: runningTool.name,
-        status: runningTool.status,
-        has_interaction: !!runningTool.interaction,
-      } : 'NOT FOUND')
-      if (runningTool) {
-        runningTool.interaction = {
-          question: ae.payload.question,
-          mode: ae.payload.mode,
-          options: ae.payload.options,
-          interactionId: ae.payload.interaction_id,
-          submitted: false,
-          code: ae.payload.code,
-        }
-      }
-      break
-    }
-
+  const turnHandler = turnHandlers.get(event.type)
+  if (turnHandler) {
+    turnHandler(ch, sid, turn, event)
   }
 }
 
-/** 后台记忆 consumer 事件处理（在 done 后 currentTurn=null 时也能通过 turn_id 找到目标）。 */
-function handleMemoryToolEvent(ch: SessionChannel, sid: string, event: ServerEvent): void {
-  if (event.type === 'memory_start') {
-    const me = event as MemoryStartEvent
-    console.log(`[ltm-fe] memory_start session=${sid} turn_id=${me.payload.turn_id}`)
-    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-    if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
-    if (!targetTurn.memoryEvents) targetTurn.memoryEvents = []
-    targetTurn.memoryEvents.push({
-      kind: 'memory_tool', name: 'memory_processing', input: '', output: null, elapsed: null, status: 'running',
-    })
-    return
+/** 后台记忆 consumer 开始处理本轮对话：压入「处理中」占位条目。 */
+function handleMemoryStart(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryStartEvent
+  console.log(`[ltm-fe] memory_start session=${sid} turn_id=${me.payload.turn_id}`)
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
+  if (!targetTurn.memoryEvents) targetTurn.memoryEvents = []
+  targetTurn.memoryEvents.push({
+    kind: 'memory_tool', name: 'memory_processing', input: '', output: null, elapsed: null, status: 'running',
+  })
+}
+
+/** 后台记忆 consumer 开始调用 CRUD 工具：压入 running 状态工具事件。 */
+function handleMemoryToolStart(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryToolStartEvent
+  if (skipReadMemories(me.payload)) return
+  console.log(`[ltm-fe] memory_tool_start session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
+  targetTurn.memoryEvents?.push({
+    kind: 'memory_tool', name: me.payload.tool_name, input: me.payload.input,
+    output: null, elapsed: null, status: 'running',
+  })
+}
+
+/** 后台记忆 consumer 的 CRUD 工具执行完毕：更新匹配事件为 done。 */
+function handleMemoryToolEnd(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryToolEndEvent
+  if (skipReadMemories(me.payload)) return
+  console.log(`[ltm-fe] memory_tool_end session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
+  const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
+  if (mt) { mt.output = me.payload.output; mt.elapsed = me.payload.elapsed; mt.status = 'done' }
+  if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
+}
+
+/** 后台记忆 consumer 的 CRUD 工具出错：更新匹配事件为 error。 */
+function handleMemoryToolError(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryToolErrorEvent
+  if (skipReadMemories(me.payload)) return
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) return
+  const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
+  if (mt) mt.status = 'error'
+  if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
+}
+
+/** 后台记忆 consumer 处理完毕：移除「处理中」占位，无实际工具事件时渲染 memory_review。 */
+function handleMemoryDone(ch: SessionChannel, sid: string, event: ServerEvent): void {
+  const me = event as MemoryDoneEvent
+  console.log(`[ltm-fe] memory_done session=${sid} turn_id=${me.payload.turn_id}`)
+  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
+  if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
+  // 移除「处理中」占位条目
+  const realEvents = (targetTurn.memoryEvents ?? []).filter(e => e.name !== 'memory_processing')
+  targetTurn.memoryEvents = realEvents
+  if (realEvents.length === 0) {
+    targetTurn.memoryEvents = [{
+      kind: 'memory_tool', name: 'memory_review', input: '', output: '', elapsed: null, status: 'done',
+    }]
+    console.log(`[ltm-fe] added memory_review`)
   }
-  if (event.type === 'memory_tool_start') {
-    const me = event as MemoryToolStartEvent
-    if (me.payload.tool_name === 'read_memories') return  // 纯读取不显示
-    console.log(`[ltm-fe] memory_tool_start session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
-    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-    if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
-    targetTurn.memoryEvents?.push({
-      kind: 'memory_tool', name: me.payload.tool_name, input: me.payload.input,
-      output: null, elapsed: null, status: 'running',
-    })
-    return
+  if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
+}
+
+/** thinking_start：压入思考块。 */
+function handleThinkingStart(ch: SessionChannel, _sid: string, turn: ChatTurn, _event: ServerEvent): void {
+  turn.events.push({ kind: 'thinking', tokens: '', done: false, becameAnswer: false })
+}
+
+/** token：追加到最后一个思考块。 */
+function handleToken(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const lastThink = findLastThinking(turn.events)
+  if (lastThink) {
+    lastThink.tokens += (event as TokenEvent).payload.token
   }
-  if (event.type === 'memory_tool_end') {
-    const me = event as MemoryToolEndEvent
-    if (me.payload.tool_name === 'read_memories') return  // 纯读取不显示
-    console.log(`[ltm-fe] memory_tool_end session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
-    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-    if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
-    const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
-    if (mt) { mt.output = me.payload.output; mt.elapsed = me.payload.elapsed; mt.status = 'done' }
-    if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
-    return
+}
+
+/** thinking_end：标记最后一个思考块完成。 */
+function handleThinkingEnd(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const lastThink = findLastThinking(turn.events)
+  if (lastThink) {
+    lastThink.done = true
   }
-  if (event.type === 'memory_tool_error') {
-    const me = event as MemoryToolErrorEvent
-    if (me.payload.tool_name === 'read_memories') return  // 纯读取不显示
-    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-    if (!targetTurn) return
-    const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
-    if (mt) mt.status = 'error'
-    if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
-    return
-  }
-  if (event.type === 'memory_done') {
-    const me = event as MemoryDoneEvent
-    console.log(`[ltm-fe] memory_done session=${sid} turn_id=${me.payload.turn_id}`)
-    const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-    if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
-    // 移除「处理中」占位条目
-    const realEvents = (targetTurn.memoryEvents ?? []).filter(e => e.name !== 'memory_processing')
-    targetTurn.memoryEvents = realEvents
-    if (realEvents.length === 0) {
-      targetTurn.memoryEvents = [{
-        kind: 'memory_tool', name: 'memory_review', input: '', output: '', elapsed: null, status: 'done',
-      }]
-      console.log(`[ltm-fe] added memory_review`)
+}
+
+/** tool_start：压入 running 状态工具调用。 */
+function handleToolStart(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const tsEvent = event as { type: 'tool_start'; payload: { call_id: string; tool_name: string; input: string } }
+  console.log('[useChat] tool_start:', tsEvent.payload.tool_name, { input: tsEvent.payload.input, call_id: tsEvent.payload.call_id, session: sid })
+  turn.events.push({
+    kind: 'tool',
+    name: tsEvent.payload.tool_name,
+    input: tsEvent.payload.input,
+    output: null,
+    elapsed: null,
+    status: 'running',
+    callId: tsEvent.payload.call_id,
+  })
+}
+
+/** tool_end：更新匹配工具调用为 done，提取 tool_data，处理 ask_user 状态恢复。 */
+function handleToolEnd(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const teEvent = event as { type: 'tool_end'; payload: { call_id: string; tool_name: string; output: string; elapsed: number; tool_data?: Record<string, unknown> } }
+  // 精确匹配：优先用 call_id，降级用 heuristic
+  const tc = findToolByCallId(turn.events, teEvent.payload.call_id)
+    ?? findBestMatchingTool(turn.events, teEvent.payload.tool_name)
+  if (tc) {
+    tc.output = teEvent.payload.output
+    tc.elapsed = teEvent.payload.elapsed
+    tc.status = 'done'
+    if (teEvent.payload.tool_data) {
+      tc.toolData = teEvent.payload.tool_data
+      if (teEvent.payload.tool_name === 'task_tracker' && teEvent.payload.tool_data) {
+        ch.taskTrackerData = teEvent.payload.tool_data as Record<string, unknown>
+      }
     }
-    if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
-    return
+    console.log(`[useChat] tool_end: "${teEvent.payload.tool_name}"`, {
+      output_len: (teEvent.payload.output || '').length,
+      output_preview: (teEvent.payload.output || '').slice(0, 100),
+      has_tool_data: !!teEvent.payload.tool_data,
+      elapsed: teEvent.payload.elapsed,
+      session: sid,
+    })
+  }
+  // ask_user 工具执行完毕 → 用户已回应，回到工作态
+  if (ch.isAwaitingUser && teEvent.payload.tool_name === ch._awaitingToolName) {
+    ch.isAwaitingUser = false
+    ch._awaitingToolName = null
+  }
+}
+
+/** tool_error：更新匹配工具调用为 error。 */
+function handleToolError(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const teEvent = event as { type: 'tool_error'; payload: { call_id: string; tool_name: string; error: string } }
+  const tc = findToolByCallId(turn.events, teEvent.payload.call_id)
+    ?? findBestMatchingTool(turn.events, teEvent.payload.tool_name)
+  if (tc) {
+    tc.status = 'error'
+  }
+}
+
+/** answer：标记思考块为 becameAnswer，设置 finalAnswer。 */
+function handleAnswer(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const lastThink = findLastThinking(turn.events)
+  if (lastThink) {
+    lastThink.becameAnswer = true
+  }
+  turn.finalAnswer = (event as AnswerEvent).payload.content
+}
+
+/** done：finalize 当前轮次，持久化，刷新会话列表。 */
+function handleDone(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const de = event as DoneEvent
+  ch.isAwaitingUser = false
+  ch._awaitingToolName = null
+  if (de.payload.context_usage) {
+    ch.contextUsage = de.payload.context_usage
+  }
+  // 存储后端 turn_id，用于关联后台记忆 consumer 的事件
+  if (de.payload.turn_id) {
+    turn.turnId = de.payload.turn_id
+    console.log(`[ltm-fe] turnId set on turn.id=${turn.id}: ${turn.turnId}`)
+  }
+  const lastThink = findLastThinking(turn.events)
+  const trackBecame = lastThink?.becameAnswer
+  console.log(`[useChat:done] 会话 ${sid}: becameAnswer=${trackBecame}, events=${turn.events.length}, finalAnswer=${turn.finalAnswer?.slice(0, 50) ?? 'null'}`)
+  if (trackBecame) {
+    const turnToFinalize = turn
+    void nextTick(() => {
+      setTimeout(() => {
+        console.log(`[useChat:done] becameAnswer 分支执行 persist (会话 ${sid})`)
+        ch.turns.push(turnToFinalize)
+        ch.currentTurn = null
+        ch.isStreaming = false
+        if (!ch.privateMode) { persistTurns(sid) }
+      }, 420)
+    })
+  } else {
+    console.log(`[useChat:done] 直接分支执行 persist (会话 ${sid})`)
+    ch.turns.push(turn)
+    ch.currentTurn = null
+    ch.isStreaming = false
+    if (!ch.privateMode) { persistTurns(sid) }
+  }
+  void refreshSessions()  // 轮次结束，刷新会话列表以更新 message_count
+  // 子 Agent 完成 → 自动切回主会话
+  if (ch.parentSessionId) {
+    setTimeout(() => switchSession(ch.parentSessionId!), 500)
+  }
+}
+
+/** error：清除流式状态，设置错误信息。 */
+function handleError(ch: SessionChannel, _sid: string, _turn: ChatTurn, event: ServerEvent): void {
+  ch.isAwaitingUser = false
+  ch._awaitingToolName = null
+  ch.error = (event as ErrorEvent).payload.message
+  ch.isStreaming = false
+}
+
+/** ask_user：设置交互等待状态，在 running 工具上挂载 interaction。 */
+function handleAskUser(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const ae = event as AskUserEvent
+  ch.isAwaitingUser = true
+  ch._awaitingToolName = ae.payload.tool_name
+  console.log('[useChat] received ask_user event:', {
+    tool_name: ae.payload.tool_name,
+    question: ae.payload.question?.slice(0, 50),
+    mode: ae.payload.mode,
+    interaction_id: ae.payload.interaction_id,
+    session: sid,
+  })
+  const runningTool = findFirstRunningToolForInteraction(turn.events, ae.payload.tool_name)
+  console.log('[useChat] findFirstRunningToolForInteraction result:', runningTool ? {
+    name: runningTool.name,
+    status: runningTool.status,
+    has_interaction: !!runningTool.interaction,
+  } : 'NOT FOUND')
+  if (runningTool) {
+    runningTool.interaction = {
+      question: ae.payload.question,
+      mode: ae.payload.mode,
+      options: ae.payload.options,
+      interactionId: ae.payload.interaction_id,
+      submitted: false,
+      code: ae.payload.code,
+    }
   }
 }
 

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -1,9 +1,11 @@
-import { reactive, computed, watch, nextTick, type Ref } from 'vue'
-import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, TokenEvent, AnswerEvent, ErrorEvent, DoneEvent, AskUserEvent, MemoryToolEvent, MemoryToolStartEvent, MemoryToolEndEvent, MemoryToolErrorEvent, MemoryStartEvent, MemoryDoneEvent } from '@/types'
+import { reactive, computed, watch, type Ref } from 'vue'
+import type { ClientMessage, ServerEvent, ChatTurn, ToolCall, ThinkingBlock, TurnEvent, ContextUsage, AskUserEvent, MemoryToolEvent } from '@/types'
 import { refreshSessions, switchSession } from '@/composables/useSession'
 import { buildFlatMessage, buildTimestamp, parseReferences } from '@/utils/references'
 import type { ParsedRef } from '@/utils/references'
 import { getToken } from '@/api'
+import { memoryHandlers, type MemoryEventType } from './useChat.memory'
+import { turnHandlers } from './useChat.handlers'
 /** 匹配旧格式尾缀（用于 localStorage 迁移） */
 const TIME_SUFFIX_RE = /（\d{4}-\d{2}-\d{2} \w{3} \d{2}:\d{2}）$/
 
@@ -94,7 +96,7 @@ const turnsCache = loadAllTurnsFromStorage()
 
 // ── 多会话通道 ─────────────────────────────────────────────
 
-interface SessionChannel {
+export interface SessionChannel {
   ws: WebSocket | null
   connected: boolean
   isStreaming: boolean
@@ -147,7 +149,7 @@ function getOrCreateChannel(sid: string): SessionChannel {
   return channels.get(sid)!
 }
 
-function persistTurns(sid: string) {
+export function persistTurns(sid: string) {
   const ch = channels.get(sid)
   if (!ch) {
     console.warn(`[useChat:persist] 跳过保存 sid="${sid}": 通道不存在`)
@@ -229,43 +231,6 @@ export function ensureConnected(sid: string) {
 
 // ── 事件路由 ──────────────────────────────────────────────
 
-/** read_memories 是纯读取操作，前端无需显示其执行状态。 */
-function skipReadMemories(payload: { tool_name: string }): boolean {
-  return payload.tool_name === 'read_memories'
-}
-
-/** 后台记忆 consumer 事件类型。 */
-type MemoryEventType = 'memory_start' | 'memory_tool_start' | 'memory_tool_end' | 'memory_tool_error' | 'memory_done'
-
-/** 后台记忆 consumer 事件处理器签名。 */
-type MemoryEventHandler = (ch: SessionChannel, sid: string, event: ServerEvent) => void
-
-/** 记忆事件处理器注册表。新增记忆事件类型只需在此注册，调用方守卫自动覆盖。 */
-const memoryHandlers = new Map<MemoryEventType, MemoryEventHandler>([
-  ['memory_start', handleMemoryStart],
-  ['memory_tool_start', handleMemoryToolStart],
-  ['memory_tool_end', handleMemoryToolEnd],
-  ['memory_tool_error', handleMemoryToolError],
-  ['memory_done', handleMemoryDone],
-])
-
-/** 事件路由处理器签名（turn 已由调用方守卫保证存在）。 */
-type TurnEventHandler = (ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent) => void
-
-/** 事件路由处理器注册表。 */
-const turnHandlers = new Map<string, TurnEventHandler>([
-  ['thinking_start', handleThinkingStart],
-  ['token', handleToken],
-  ['thinking_end', handleThinkingEnd],
-  ['tool_start', handleToolStart],
-  ['tool_end', handleToolEnd],
-  ['tool_error', handleToolError],
-  ['answer', handleAnswer],
-  ['done', handleDone],
-  ['error', handleError],
-  ['ask_user', handleAskUser],
-])
-
 function handleEventForChannel(sid: string, event: ServerEvent) {
   const ch = channels.get(sid)
   if (!ch) return
@@ -314,237 +279,6 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
   const turnHandler = turnHandlers.get(event.type)
   if (turnHandler) {
     turnHandler(ch, sid, turn, event)
-  }
-}
-
-/** 后台记忆 consumer 开始处理本轮对话：压入「处理中」占位条目。 */
-function handleMemoryStart(ch: SessionChannel, sid: string, event: ServerEvent): void {
-  const me = event as MemoryStartEvent
-  console.log(`[ltm-fe] memory_start session=${sid} turn_id=${me.payload.turn_id}`)
-  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-  if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
-  if (!targetTurn.memoryEvents) targetTurn.memoryEvents = []
-  targetTurn.memoryEvents.push({
-    kind: 'memory_tool', name: 'memory_processing', input: '', output: null, elapsed: null, status: 'running',
-  })
-}
-
-/** 后台记忆 consumer 开始调用 CRUD 工具：压入 running 状态工具事件。 */
-function handleMemoryToolStart(ch: SessionChannel, sid: string, event: ServerEvent): void {
-  const me = event as MemoryToolStartEvent
-  if (skipReadMemories(me.payload)) return
-  console.log(`[ltm-fe] memory_tool_start session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
-  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-  if (!targetTurn) { console.log(`[ltm-fe] NO turn found for ${me.payload.turn_id}`); return }
-  targetTurn.memoryEvents?.push({
-    kind: 'memory_tool', name: me.payload.tool_name, input: me.payload.input,
-    output: null, elapsed: null, status: 'running',
-  })
-}
-
-/** 后台记忆 consumer 的 CRUD 工具执行完毕：更新匹配事件为 done。 */
-function handleMemoryToolEnd(ch: SessionChannel, sid: string, event: ServerEvent): void {
-  const me = event as MemoryToolEndEvent
-  if (skipReadMemories(me.payload)) return
-  console.log(`[ltm-fe] memory_tool_end session=${sid} turn_id=${me.payload.turn_id} tool=${me.payload.tool_name}`)
-  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-  if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
-  const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
-  if (mt) { mt.output = me.payload.output; mt.elapsed = me.payload.elapsed; mt.status = 'done' }
-  if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
-}
-
-/** 后台记忆 consumer 的 CRUD 工具出错：更新匹配事件为 error。 */
-function handleMemoryToolError(ch: SessionChannel, sid: string, event: ServerEvent): void {
-  const me = event as MemoryToolErrorEvent
-  if (skipReadMemories(me.payload)) return
-  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-  if (!targetTurn) return
-  const mt = findRunningMemoryTool(targetTurn.memoryEvents ?? [], me.payload.tool_name)
-  if (mt) mt.status = 'error'
-  if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
-}
-
-/** 后台记忆 consumer 处理完毕：移除「处理中」占位，无实际工具事件时渲染 memory_review。 */
-function handleMemoryDone(ch: SessionChannel, sid: string, event: ServerEvent): void {
-  const me = event as MemoryDoneEvent
-  console.log(`[ltm-fe] memory_done session=${sid} turn_id=${me.payload.turn_id}`)
-  const targetTurn = findTurnByBackendId(ch, me.payload.turn_id)
-  if (!targetTurn) { console.log(`[ltm-fe] NO turn`); return }
-  // 移除「处理中」占位条目
-  const realEvents = (targetTurn.memoryEvents ?? []).filter(e => e.name !== 'memory_processing')
-  targetTurn.memoryEvents = realEvents
-  if (realEvents.length === 0) {
-    targetTurn.memoryEvents = [{
-      kind: 'memory_tool', name: 'memory_review', input: '', output: '', elapsed: null, status: 'done',
-    }]
-    console.log(`[ltm-fe] added memory_review`)
-  }
-  if (ch.turns.includes(targetTurn as ChatTurn)) persistTurns(sid)
-}
-
-/** thinking_start：压入思考块。 */
-function handleThinkingStart(ch: SessionChannel, _sid: string, turn: ChatTurn, _event: ServerEvent): void {
-  turn.events.push({ kind: 'thinking', tokens: '', done: false, becameAnswer: false })
-}
-
-/** token：追加到最后一个思考块。 */
-function handleToken(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
-  const lastThink = findLastThinking(turn.events)
-  if (lastThink) {
-    lastThink.tokens += (event as TokenEvent).payload.token
-  }
-}
-
-/** thinking_end：标记最后一个思考块完成。 */
-function handleThinkingEnd(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
-  const lastThink = findLastThinking(turn.events)
-  if (lastThink) {
-    lastThink.done = true
-  }
-}
-
-/** tool_start：压入 running 状态工具调用。 */
-function handleToolStart(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
-  const tsEvent = event as { type: 'tool_start'; payload: { call_id: string; tool_name: string; input: string } }
-  console.log('[useChat] tool_start:', tsEvent.payload.tool_name, { input: tsEvent.payload.input, call_id: tsEvent.payload.call_id, session: sid })
-  turn.events.push({
-    kind: 'tool',
-    name: tsEvent.payload.tool_name,
-    input: tsEvent.payload.input,
-    output: null,
-    elapsed: null,
-    status: 'running',
-    callId: tsEvent.payload.call_id,
-  })
-}
-
-/** tool_end：更新匹配工具调用为 done，提取 tool_data，处理 ask_user 状态恢复。 */
-function handleToolEnd(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
-  const teEvent = event as { type: 'tool_end'; payload: { call_id: string; tool_name: string; output: string; elapsed: number; tool_data?: Record<string, unknown> } }
-  // 精确匹配：优先用 call_id，降级用 heuristic
-  const tc = findToolByCallId(turn.events, teEvent.payload.call_id)
-    ?? findBestMatchingTool(turn.events, teEvent.payload.tool_name)
-  if (tc) {
-    tc.output = teEvent.payload.output
-    tc.elapsed = teEvent.payload.elapsed
-    tc.status = 'done'
-    if (teEvent.payload.tool_data) {
-      tc.toolData = teEvent.payload.tool_data
-      if (teEvent.payload.tool_name === 'task_tracker' && teEvent.payload.tool_data) {
-        ch.taskTrackerData = teEvent.payload.tool_data as Record<string, unknown>
-      }
-    }
-    console.log(`[useChat] tool_end: "${teEvent.payload.tool_name}"`, {
-      output_len: (teEvent.payload.output || '').length,
-      output_preview: (teEvent.payload.output || '').slice(0, 100),
-      has_tool_data: !!teEvent.payload.tool_data,
-      elapsed: teEvent.payload.elapsed,
-      session: sid,
-    })
-  }
-  // ask_user 工具执行完毕 → 用户已回应，回到工作态
-  if (ch.isAwaitingUser && teEvent.payload.tool_name === ch._awaitingToolName) {
-    ch.isAwaitingUser = false
-    ch._awaitingToolName = null
-  }
-}
-
-/** tool_error：更新匹配工具调用为 error。 */
-function handleToolError(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
-  const teEvent = event as { type: 'tool_error'; payload: { call_id: string; tool_name: string; error: string } }
-  const tc = findToolByCallId(turn.events, teEvent.payload.call_id)
-    ?? findBestMatchingTool(turn.events, teEvent.payload.tool_name)
-  if (tc) {
-    tc.status = 'error'
-  }
-}
-
-/** answer：标记思考块为 becameAnswer，设置 finalAnswer。 */
-function handleAnswer(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
-  const lastThink = findLastThinking(turn.events)
-  if (lastThink) {
-    lastThink.becameAnswer = true
-  }
-  turn.finalAnswer = (event as AnswerEvent).payload.content
-}
-
-/** done：finalize 当前轮次，持久化，刷新会话列表。 */
-function handleDone(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
-  const de = event as DoneEvent
-  ch.isAwaitingUser = false
-  ch._awaitingToolName = null
-  if (de.payload.context_usage) {
-    ch.contextUsage = de.payload.context_usage
-  }
-  // 存储后端 turn_id，用于关联后台记忆 consumer 的事件
-  if (de.payload.turn_id) {
-    turn.turnId = de.payload.turn_id
-    console.log(`[ltm-fe] turnId set on turn.id=${turn.id}: ${turn.turnId}`)
-  }
-  const lastThink = findLastThinking(turn.events)
-  const trackBecame = lastThink?.becameAnswer
-  console.log(`[useChat:done] 会话 ${sid}: becameAnswer=${trackBecame}, events=${turn.events.length}, finalAnswer=${turn.finalAnswer?.slice(0, 50) ?? 'null'}`)
-  if (trackBecame) {
-    const turnToFinalize = turn
-    void nextTick(() => {
-      setTimeout(() => {
-        console.log(`[useChat:done] becameAnswer 分支执行 persist (会话 ${sid})`)
-        ch.turns.push(turnToFinalize)
-        ch.currentTurn = null
-        ch.isStreaming = false
-        if (!ch.privateMode) { persistTurns(sid) }
-      }, 420)
-    })
-  } else {
-    console.log(`[useChat:done] 直接分支执行 persist (会话 ${sid})`)
-    ch.turns.push(turn)
-    ch.currentTurn = null
-    ch.isStreaming = false
-    if (!ch.privateMode) { persistTurns(sid) }
-  }
-  void refreshSessions()  // 轮次结束，刷新会话列表以更新 message_count
-  // 子 Agent 完成 → 自动切回主会话
-  if (ch.parentSessionId) {
-    setTimeout(() => switchSession(ch.parentSessionId!), 500)
-  }
-}
-
-/** error：清除流式状态，设置错误信息。 */
-function handleError(ch: SessionChannel, _sid: string, _turn: ChatTurn, event: ServerEvent): void {
-  ch.isAwaitingUser = false
-  ch._awaitingToolName = null
-  ch.error = (event as ErrorEvent).payload.message
-  ch.isStreaming = false
-}
-
-/** ask_user：设置交互等待状态，在 running 工具上挂载 interaction。 */
-function handleAskUser(ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent): void {
-  const ae = event as AskUserEvent
-  ch.isAwaitingUser = true
-  ch._awaitingToolName = ae.payload.tool_name
-  console.log('[useChat] received ask_user event:', {
-    tool_name: ae.payload.tool_name,
-    question: ae.payload.question?.slice(0, 50),
-    mode: ae.payload.mode,
-    interaction_id: ae.payload.interaction_id,
-    session: sid,
-  })
-  const runningTool = findFirstRunningToolForInteraction(turn.events, ae.payload.tool_name)
-  console.log('[useChat] findFirstRunningToolForInteraction result:', runningTool ? {
-    name: runningTool.name,
-    status: runningTool.status,
-    has_interaction: !!runningTool.interaction,
-  } : 'NOT FOUND')
-  if (runningTool) {
-    runningTool.interaction = {
-      question: ae.payload.question,
-      mode: ae.payload.mode,
-      options: ae.payload.options,
-      interactionId: ae.payload.interaction_id,
-      submitted: false,
-      code: ae.payload.code,
-    }
   }
 }
 
@@ -700,7 +434,7 @@ export function useChat(sessionId: Ref<string>) {
 
 
 
-function findLastThinking(events: TurnEvent[]): ThinkingBlock | undefined {
+export function findLastThinking(events: TurnEvent[]): ThinkingBlock | undefined {
   for (let i = events.length - 1; i >= 0; i--) {
     if (events[i].kind === 'thinking') {
       return events[i] as ThinkingBlock
@@ -712,7 +446,7 @@ function findLastThinking(events: TurnEvent[]): ThinkingBlock | undefined {
 /**
  * 通过 call_id 精确查找 ToolCall（当多个同名工具并行运行时用于精准匹配）。
  */
-function findToolByCallId(events: TurnEvent[], callId: string): ToolCall | undefined {
+export function findToolByCallId(events: TurnEvent[], callId: string): ToolCall | undefined {
   for (const e of events) {
     if (e.kind === 'tool' && e.callId === callId) {
       return e as ToolCall
@@ -726,7 +460,7 @@ function findToolByCallId(events: TurnEvent[], callId: string): ToolCall | undef
  * 从前往后找第一个 running 且尚未分配 interaction 的工具。
  * 当多个同名工具并行运行时，确保每个 ask_user 事件绑定到正确的实例。
  */
-function findFirstRunningToolForInteraction(events: TurnEvent[], toolName: string): ToolCall | undefined {
+export function findFirstRunningToolForInteraction(events: TurnEvent[], toolName: string): ToolCall | undefined {
   for (let i = 0; i < events.length; i++) {
     const e = events[i]
     if (e.kind === 'tool' && e.name === toolName && e.status === 'running' && !e.interaction) {
@@ -742,7 +476,7 @@ function findFirstRunningToolForInteraction(events: TurnEvent[], toolName: strin
  * 2. 其次找有 interaction 的工具
  * 3. 最后退化为旧行为：从后往前找最后一个 running 的工具
  */
-function findBestMatchingTool(events: TurnEvent[], toolName: string): ToolCall | undefined {
+export function findBestMatchingTool(events: TurnEvent[], toolName: string): ToolCall | undefined {
   // 第一遍：优先匹配用户已提交响应的工具
   for (let i = 0; i < events.length; i++) {
     const e = events[i]
@@ -768,13 +502,13 @@ function findBestMatchingTool(events: TurnEvent[], toolName: string): ToolCall |
 }
 
 /** 通过后端 turn_id 查找 turn（先在 currentTurn 中找，再在 turns 中找）。 */
-function findTurnByBackendId(ch: SessionChannel, turnId: string): ChatTurn | undefined {
+export function findTurnByBackendId(ch: SessionChannel, turnId: string): ChatTurn | undefined {
   if (ch.currentTurn?.turnId === turnId) return ch.currentTurn
   return ch.turns.find(t => t.turnId === turnId)
 }
 
 /** 在 memoryEvents 中查找指定工具名的 running 状态事件。 */
-function findRunningMemoryTool(events: MemoryToolEvent[], toolName: string): MemoryToolEvent | undefined {
+export function findRunningMemoryTool(events: MemoryToolEvent[], toolName: string): MemoryToolEvent | undefined {
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i]
     if (e.name === toolName && e.status === 'running') return e


### PR DESCRIPTION
## 概述

记录前端架构评审结论，并对 useChat 进行 Handler Registry 模式重构，提升可维护性。

## 主要变更

- **新增** `dev_docs/frontend-architecture-review.md`：前端架构评审与维护指南，涵盖架构概览、设计模式、改进建议
- **重构** `web/src/composables/useChat.ts`：事件路由从 if-chain / switch 重构为 Handler Registry
- **提取** `useChat.handlers.ts`：TurnEvent 处理逻辑分离到外部模块
- **提取** `useChat.memory.ts`：Memory 事件处理逻辑分离到外部模块

## 验证计划

- [x] 编译通过，无 TypeScript 错误
- [x] Handler Registry 路由逻辑覆盖原 if-chain 的所有事件类型

🤖 Generated with [Claude Code](https://claude.com/claude-code)