### PR TITLE
fix: 添加 typeof 守卫修复 CodeQL 动态方法调用告警

### DIFF
--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -268,7 +268,7 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
   // 后台记忆 consumer 事件可能在 done 事件之后到达（currentTurn 已清空），
   // 必须在 const turn = ch.currentTurn 守卫之前处理，通过 turn_id 自行查找目标。
   const memoryHandler = memoryHandlers.get(event.type as MemoryEventType)
-  if (memoryHandler) {
+  if (typeof memoryHandler === 'function') {
     memoryHandler(ch, sid, event)
     return
   }
@@ -277,7 +277,7 @@ function handleEventForChannel(sid: string, event: ServerEvent) {
   if (!turn) return
 
   const turnHandler = turnHandlers.get(event.type)
-  if (turnHandler) {
+  if (typeof turnHandler === 'function') {
     turnHandler(ch, sid, turn, event)
   }
 }


### PR DESCRIPTION
## 问题

CodeQL 检测到 **js/unvalidated-dynamic-method-call** (High) 告警：
`web/src/composables/useChat.ts` 中，从 WebSocket 消息解析的 `event.type`
经过 `Map.get()` 查找后直接被调用，若返回值非函数则会抛出 `TypeError`。

## 修复

在两个 `Map.get()` 调用处将 `if (handler)` 改为 `if (typeof handler === 'function')`：

- `turnHandlers.get(event.type)` → `turnHandler` 调用处（line 279-282）
- `memoryHandlers.get(event.type as MemoryEventType)` → `memoryHandler` 调用处（line 270-273）

## 影响范围

- 不影响业务逻辑（所有已注册 handler 本身就是函数）
- 编译通过，零运行时行为变更

Closes #34