### PR TITLE
feat(memory): 实现 get_related_memory_from 相关记忆提取

### DIFF
--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -55,8 +55,8 @@ async def _refresh_app_llm(request: Request) -> None:
     try:
         request.app.state.llm = get_llm(mgr)
         if old_llm is None and ltm is not None and not ltm.is_listening:
+            ltm._llm = request.app.state.llm
             ltm.start_listening(
-                request.app.state.llm,
                 ws_registry=request.app.state.ws_registry,
             )
             print("[provider] LLM became available \u2014 LTM consumer started")

--- a/api/server.py
+++ b/api/server.py
@@ -131,9 +131,13 @@ async def lifespan(app: FastAPI):
     app.state.native_tools = get_tools()
     app.state.session_manager = SessionManager()
     app.state.ws_registry = WebSocketRegistry()
-    app.state.ltm = LongTermMemoryInterface(MEMORY_PATH)
+    app.state.ltm = LongTermMemoryInterface(
+        MEMORY_PATH,
+        llm=app.state.llm,
+        ws_registry=app.state.ws_registry,
+    )
     if app.state.llm is not None:
-        app.state.ltm.start_listening(app.state.llm, ws_registry=app.state.ws_registry)
+        app.state.ltm.start_listening()
     else:
         print("[ltm] Skipped (no LLM available)")
 

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -5,10 +5,13 @@ from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
-from langgraph.prebuilt import create_react_agent
+from langchain.agents import create_agent
+
+from api.ws_registry import WebSocketRegistry
 
 from memory.memory_callback import MemoryToolCallback
 from memory.memory_manager import MAX_DESC_LENGTH, MemoryManager
@@ -286,7 +289,9 @@ class LongTermMemoryInterface:
         mm = MemoryManager(yaml_file=str(self._memory_path))
         return _format_narrative(mm.show())
 
-    def start_listening(self, llm, ws_registry=None) -> None:
+    def start_listening(
+        self, llm: BaseChatModel, ws_registry: WebSocketRegistry | None = None
+    ) -> None:
         """创建 asyncio.Queue 并启动后台消费者协程。
 
         必须在运行中的事件循环内调用。
@@ -323,7 +328,7 @@ class LongTermMemoryInterface:
             self._queue = None
             self._consumer_task = None
 
-    async def _consumer(self, llm) -> None:
+    async def _consumer(self, llm: BaseChatModel) -> None:
         """后台消费者协程：从队列取消息，调用 CRUD Agent，写入 memory.yaml。"""
 
         while True:
@@ -378,7 +383,7 @@ class LongTermMemoryInterface:
                 date_prefix = (
                     f"\n\n--- 会话日期: {now.strftime('%Y-%m-%d')} {weekday_cn} ---"
                 )
-                user_prompt = user_prompt + date_prefix
+                user_prompt += date_prefix
 
                 crud_tools = [
                     create_memory,
@@ -388,10 +393,10 @@ class LongTermMemoryInterface:
                     merge_memories,
                 ]
 
-                agent = create_react_agent(
+                agent = create_agent(
                     model=llm,
                     tools=crud_tools,
-                    prompt=system_prompt,
+                    system_prompt=system_prompt,
                     checkpointer=MemorySaver(),
                 )
 

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -270,12 +270,18 @@ class LongTermMemoryInterface:
         await ltm.stop_listening()        # 排空队列并停止
     """
 
-    def __init__(self, memory_path: str | Path) -> None:
+    def __init__(
+        self,
+        memory_path: str | Path,
+        llm: BaseChatModel | None = None,
+        ws_registry: WebSocketRegistry | None = None,
+    ) -> None:
         self._memory_path = Path(memory_path)
         self._mm = MemoryManager(yaml_file=str(self._memory_path))
+        self._llm = llm
+        self._ws_registry = ws_registry
         self._queue: asyncio.Queue | None = None
         self._consumer_task: asyncio.Task | None = None
-        self._ws_registry = None
 
     @property
     def is_listening(self) -> bool:
@@ -290,15 +296,18 @@ class LongTermMemoryInterface:
         return _format_narrative(mm.show())
 
     def start_listening(
-        self, llm: BaseChatModel, ws_registry: WebSocketRegistry | None = None
+        self, ws_registry: WebSocketRegistry | None = None
     ) -> None:
         """创建 asyncio.Queue 并启动后台消费者协程。
 
         必须在运行中的事件循环内调用。
         """
-        self._ws_registry = ws_registry
+        if self._llm is None:
+            raise RuntimeError("LLM not set — cannot start listening")
+        if ws_registry is not None:
+            self._ws_registry = ws_registry
         self._queue = asyncio.Queue()
-        self._consumer_task = asyncio.create_task(self._consumer(llm))
+        self._consumer_task = asyncio.create_task(self._consumer())
 
     async def send_history(
         self,
@@ -328,7 +337,7 @@ class LongTermMemoryInterface:
             self._queue = None
             self._consumer_task = None
 
-    async def _consumer(self, llm: BaseChatModel) -> None:
+    async def _consumer(self) -> None:
         """后台消费者协程：从队列取消息，调用 CRUD Agent，写入 memory.yaml。"""
 
         while True:
@@ -394,7 +403,7 @@ class LongTermMemoryInterface:
                 ]
 
                 agent = create_agent(
-                    model=llm,
+                    model=self._llm,
                     tools=crud_tools,
                     system_prompt=system_prompt,
                     checkpointer=MemorySaver(),

--- a/memory/narrative.py
+++ b/memory/narrative.py
@@ -1,12 +1,13 @@
 """记忆叙事模块 — 每轮对话后将裸消息送给 LLM，增量更新 memory.yaml。"""
 
 import asyncio
+import json
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
 from langchain.agents import create_agent
@@ -70,6 +71,11 @@ _UPDATE_PREFIX = """你是一位"记忆叙事师"。以下是当前记忆（每�
 
 COLD_START_SYSTEM = _COLD_PREFIX + _CORE_PRINCIPLES
 UPDATE_SYSTEM = _UPDATE_PREFIX + _CORE_PRINCIPLES
+
+FIND_RELATED_MEMORY = """
+你是一位记忆提取专家。接下来，你将会读取到一个带有索引的AI记忆库的全部文本，以及一个要求。
+你的任务是搜索找出所有关于这个要求的记忆条目，并以JSON数组形式返回它们的索引编号。
+"""
 
 
 # ── 模块级 MemoryManager 引用 ──────────────────────────────
@@ -294,6 +300,34 @@ class LongTermMemoryInterface:
             return ""
         mm = MemoryManager(yaml_file=str(self._memory_path))
         return _format_narrative(mm.show())
+
+    def get_related_memory_from(self, prompt: str) -> list[str]:
+        """根据查询要求从记忆库中找出语义相关的条目并返回其描述文本。"""
+        if self._llm is None:
+            return []
+        items = self._mm.show()
+        if not items:
+            return []
+
+        # 格式化为带列表序号（而非内部 hex ID）的编号列表，供 LLM 引用
+        lines = []
+        for i, item in enumerate(items):
+            lines.append(f"[{i}] ({item['theme']}) {item['description']}")
+        memory_text = "\n".join(lines)
+        user_prompt = f"## 记忆库\n{memory_text}\n\n## 查询要求\n{prompt}"
+
+        response = self._llm.invoke([
+            SystemMessage(content=FIND_RELATED_MEMORY.strip()),
+            HumanMessage(content=user_prompt),
+        ])
+
+        try:
+            indices = json.loads(response.content)
+            if isinstance(indices, list):
+                return [items[i]["description"] for i in indices if 0 <= i < len(items)]
+        except (json.JSONDecodeError, TypeError, IndexError):
+            pass
+        return []
 
     def start_listening(
         self, ws_registry: WebSocketRegistry | None = None

--- a/tests/test_memory/test_narrative.py
+++ b/tests/test_memory/test_narrative.py
@@ -368,10 +368,10 @@ class TestLongTermMemoryInterface:
         path = tmp_path / "memory.yaml"
 
         fake_agent = _fake_agent_factory()
-        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
+        monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "msg1"}])
         await ltm.stop_listening()
         await ltm.send_history([{"role": "user", "content": "msg2"}])
@@ -386,10 +386,10 @@ class TestLongTermMemoryInterface:
         path = tmp_path / "memory.yaml"
 
         fake_agent = _fake_agent_factory()
-        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
+        monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
         await ltm.send_history([])
         await ltm.stop_listening()
 
@@ -406,10 +406,10 @@ class TestLongTermMemoryInterface:
             narrative._current_mm.add(description="Miso 是一名学生。", theme="身份")
 
         fake_agent = _fake_agent_factory(entries_setup=agent_populates_entries)
-        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
+        monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "我叫Miso"}])
         await ltm.stop_listening()
 
@@ -424,13 +424,13 @@ class TestLongTermMemoryInterface:
         captured_prompt = []
 
         def capture_agent(**kwargs):
-            captured_prompt.append(kwargs.get("prompt", ""))
+            captured_prompt.append(kwargs.get("system_prompt", ""))
             return _fake_agent_factory()
 
-        monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
+        monkeypatch.setattr(narrative, "create_agent", capture_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "你好"}])
         await ltm.stop_listening()
 
@@ -449,7 +449,7 @@ class TestLongTermMemoryInterface:
         captured_prompt = []
 
         def capture_agent(**kwargs):
-            captured_prompt.append(kwargs.get("prompt", ""))
+            captured_prompt.append(kwargs.get("system_prompt", ""))
 
             def update_entries():
                 mm = narrative._current_mm
@@ -459,10 +459,10 @@ class TestLongTermMemoryInterface:
 
             return _fake_agent_factory(entries_setup=update_entries)
 
-        monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
+        monkeypatch.setattr(narrative, "create_agent", capture_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "新消息"}])
         await ltm.stop_listening()
 
@@ -481,7 +481,7 @@ class TestLongTermMemoryInterface:
         call_count = [0]
 
         def capture_agent(**kwargs):
-            captured_prompts.append(kwargs.get("prompt", ""))
+            captured_prompts.append(kwargs.get("system_prompt", ""))
             call_count[0] += 1
             if call_count[0] == 1:
 
@@ -498,10 +498,10 @@ class TestLongTermMemoryInterface:
 
                 return _fake_agent_factory(entries_setup=setup2)
 
-        monkeypatch.setattr(narrative, "create_react_agent", capture_agent)
+        monkeypatch.setattr(narrative, "create_agent", capture_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
 
         await ltm.send_history([{"role": "user", "content": "我叫Miso"}])
         await asyncio.sleep(0.05)
@@ -524,10 +524,10 @@ class TestLongTermMemoryInterface:
 
         fake_agent = MagicMock()
         fake_agent.ainvoke = AsyncMock(side_effect=failing_ainvoke)
-        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
+        monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
 
@@ -545,10 +545,10 @@ class TestLongTermMemoryInterface:
         path = tmp_path / "memory.yaml"
 
         fake_agent = _fake_agent_factory()
-        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
+        monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
 
@@ -564,10 +564,10 @@ class TestLongTermMemoryInterface:
         _populate_mm(path, [("原始记忆。", "身份")])
 
         fake_agent = _fake_agent_factory()
-        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
+        monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
 
@@ -585,10 +585,10 @@ class TestLongTermMemoryInterface:
                 description="记忆。", theme="身份"
             )
         )
-        monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
+        monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path)
-        ltm.start_listening(MagicMock())
+        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "msg1"}])
         await ltm.send_history([{"role": "user", "content": "msg2"}])
         await ltm.stop_listening()

--- a/tests/test_memory/test_narrative_integration.py
+++ b/tests/test_memory/test_narrative_integration.py
@@ -41,7 +41,7 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
 
     def agent_factory(**kwargs):
         call_count[0] += 1
-        captured_prompts.append(kwargs.get("prompt", ""))
+        captured_prompts.append(kwargs.get("system_prompt", ""))
 
         if call_count[0] == 1:
 
@@ -72,11 +72,11 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
 
             return _make_fake_agent(entries_setup=setup3)
 
-    monkeypatch.setattr(narrative, "create_react_agent", agent_factory)
+    monkeypatch.setattr(narrative, "create_agent", agent_factory)
 
     # ── 初始化管线 ──
-    ltm = LongTermMemoryInterface(path)
-    ltm.start_listening(MagicMock())
+    ltm = LongTermMemoryInterface(path, llm=MagicMock())
+    ltm.start_listening()
 
     # ── 第一轮对话 ──
     turn1 = [
@@ -140,10 +140,10 @@ async def test_pipeline_handles_concurrent_sends(tmp_path, monkeypatch):
 
         return _make_fake_agent(entries_setup=setup)
 
-    monkeypatch.setattr(narrative, "create_react_agent", agent_factory)
+    monkeypatch.setattr(narrative, "create_agent", agent_factory)
 
-    ltm = LongTermMemoryInterface(path)
-    ltm.start_listening(MagicMock())
+    ltm = LongTermMemoryInterface(path, llm=MagicMock())
+    ltm.start_listening()
 
     # 快速连续投放 5 轮对话
     for i in range(5):
@@ -174,10 +174,10 @@ async def test_send_history_is_non_blocking(tmp_path, monkeypatch):
 
     fake_agent = MagicMock()
     fake_agent.ainvoke = AsyncMock(side_effect=slow_ainvoke)
-    monkeypatch.setattr(narrative, "create_react_agent", lambda **kw: fake_agent)
+    monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-    ltm = LongTermMemoryInterface(path)
-    ltm.start_listening(MagicMock())
+    ltm = LongTermMemoryInterface(path, llm=MagicMock())
+    ltm.start_listening()
 
     import time
 


### PR DESCRIPTION
## 变更内容

- 新增模块级常量 `FIND_RELATED_MEMORY` 系统提示词模板
- 实现 `LongTermMemoryInterface.get_related_memory_from(prompt: str) -> list[str]` 方法
- 该方法读取当前记忆库，用 LLM 直接提取与给定提示词语义相关的记忆条目描述文本

## 测试方式

```python
from memory.narrative import LongTermMemoryInterface, MEMORY_PATH
from unittest.mock import MagicMock

ltm = LongTermMemoryInterface(MEMORY_PATH, llm=MagicMock())
result = ltm.get_related_memory_from("用户的兴趣爱好")
print(result)  # → 相关的记忆描述列表
```