### PR TITLE
fix(api): 修复 _validate_session_id 中路径表达式告警

### DIFF
--- a/api/session/const_store.py
+++ b/api/session/const_store.py
@@ -3,6 +3,7 @@
 提供将会话状态（元数据 + 对话消息）序列化为 YAML 文件并重新加载的能力。
 """
 
+import re
 import time
 from pathlib import Path
 
@@ -90,8 +91,13 @@ def deserialize_messages(data: list[dict]) -> list:
 # ── 文件 I/O ──────────────────────────────────────────────────
 
 
+_SAFE_ID_RE = re.compile(r"^[\w-]+$")
+
+
 def _validate_session_id(session_id: str) -> str:
-    """校验 session_id 不含路径遍历字符，确保结果路径在 _CONST_DIR 内。"""
+    """校验 session_id 格式安全且结果路径在 _CONST_DIR 内。"""
+    if not _SAFE_ID_RE.match(session_id):
+        raise ValueError(f"Invalid session_id: contains unsafe characters")
     filepath = (_CONST_DIR / f"{session_id}.yaml").resolve()
     const_dir = _CONST_DIR.resolve()
     if not str(filepath).startswith(str(const_dir)):


### PR DESCRIPTION
## Summary
- CodeQL #37 在之前新增的 `_validate_session_id` 中仍然标记了路径表达式
- 改为先通过正则 `^[\w-]+$` 校验 session_id 格式（只允许字母数字和下划线、连字符），通过后再拼接路径
- 此时 CodeQL 可识别到校验在前、路径使用在后，消除告警

## Test plan
- UUID hex 格式 → 通过
- UUID with hyphens → 通过
- 路径遍历 `../../etc/passwd` → `contains unsafe characters`
- 绝对路径 `/etc/passwd` → `contains unsafe characters`
- 点号 `foo.bar` → `contains unsafe characters`

Closes #37