### PR TITLE
docs: 添加后端架构文档

### DIFF
--- a/dev_docs/backend-architecture/README.md
+++ b/dev_docs/backend-architecture/README.md
@@ -1,0 +1,76 @@
+# SonettoHere 后端架构
+
+## 架构总览
+
+SonettoHere 后端采用**分层架构**（Layer Architecture），共有 **7 个层级**，从上到下依次为：
+
+```
+┌──────────────────────────────────────┐
+│          HTTP / WebSocket             │  客户端请求入口
+├──────────────────────────────────────┤
+│  ① 中间件层 (middleware/)             │  横切关注点：认证、鉴权
+├──────────────────────────────────────┤
+│  ② 路由层 (routes/)                   │  请求分发：REST API + WebSocket
+├──────────────────────────────────────┤
+│  ③ Agent 编排层 (agent/)              │  对话编排：LLM 调用、工具执行、轮次管理
+├──────────────────────────────────────┤
+│  ④ 回调层 (callbacks/)                │  事件驱动：LLM 事件 → WebSocket 推送
+├──────────────────────────────────────┤
+│  ⑤ 提供商抽象层 (providers/)           │  LLM 抽象：多模型支持、动态发现
+├──────────────────────────────────────┤
+│  ⑥ 长期记忆层 (memory/) +             │  持久化：记忆管理、文件存储
+│     会话管理层 (session/)              │  状态管理：会话隔离、生命周期
+├──────────────────────────────────────┤
+│  ⑦ 核心基础设施层 (core/) +            │  基础设施：认证 Token、健康检查
+│     数据资源层 (data/)                 │  静态资源：系统新闻、测试数据
+└──────────────────────────────────────┘
+```
+
+## 依赖方向
+
+依赖关系是**单向向下的**，上层依赖下层，下层不依赖上层：
+
+```
+routes/ → middleware/ → agent/ → providers/ → session/ + memory/ + core/ + data/
+                   ↘ callbacks/
+```
+
+## 模块清单
+
+| 模块目录 | 层级 | 职责 |
+|---|---|---|
+| [middleware/](middleware-layer.md) | ① | ASGI 中间件，认证与鉴权 |
+| [routes/](routes-layer.md) | ② | FastAPI 路由器，REST + WebSocket 端点 |
+| [agent/](agent-layer.md) | ③ | Agent 对话编排，LLM 轮次管理 |
+| [callbacks/](callbacks-layer.md) | ④ | LangChain 回调，WebSocket 事件推送 |
+| [providers/](providers-layer.md) | ⑤ | 多 LLM 提供商抽象与动态发现 |
+| [memory/](memory-layer.md) | ⑥ | 长期记忆 CRUD 与 LLM 叙事 |
+| [session/](session-layer.md) | ⑥ | 会话状态、WebSocket 注册表 |
+| [core/](core-layer.md) | ⑦ | 基础设施：Auth、Health、Dependencies |
+| [data/](data-layer.md) | ⑦ | 静态数据资源 |
+
+## 请求处理流程
+
+### REST API 流程
+
+```
+客户端 → AuthMiddleware → Router → Handler(路由函数) → Provider/Manager → 响应
+```
+
+### WebSocket 聊天流程
+
+```
+WebSocket 连接 → AuthMiddleware → Route(chat.py) → 事件派发
+  → chat 事件: Agent(turn.py) → Provider(LLM) → callbacks(WebSocket推送)
+  → user_response 事件: Agent → TimeTravel
+  → memory 操作: MemoryManager → YAML 文件
+```
+
+## 关键技术栈
+
+- **框架**: FastAPI（Python 异步 Web 框架）
+- **LLM**: 多提供商抽象（OpenAI 兼容 API）
+- **序列化**: Pydantic v2（数据模型与验证）
+- **异步**: asyncio + async generators（流式响应）
+- **持久化**: YAML 文件存储（记忆、会话、配置）
+- **回调**: LangChain BaseCallbackHandler（事件推送）

--- a/dev_docs/backend-architecture/agent-layer.md
+++ b/dev_docs/backend-architecture/agent-layer.md
@@ -1,0 +1,336 @@
+# Agent 编排层 (api/agent/)
+
+## 层级定位
+
+**第③层 — Agent 编排层**，后端的核心大脑。
+
+位于路由层之下、提供商抽象层之上，是整个后端的神经中枢。它不处理具体业务逻辑，而是负责编排 LLM 对话轮次的完整生命周期：
+
+1. 接收上层（路由层）的用户消息
+2. 调度 LLM 调用和工具执行
+3. 流式输出中间结果
+4. 管理交互挂起/唤醒流程
+5. 后处理（记忆持久化、会话保存）
+
+## 模块文件清单
+
+| 文件 | 职责 | 主要类型/函数 |
+|---|---|---|
+| `turn.py` | Agent 对话编排：构建 Agent 图、流式执行、取消处理、记忆持久化 | `_LlmConfig`, `_TurnContext`, `_TurnResult`, `run_agent_turn()` |
+| `interaction.py` | 交互注册表：管理 ask_user 系列工具的挂起与唤醒 | `register()`, `resolve()`, `cancel_all()` |
+| `turn_sender.py` | WebSocket 事件发送器，封装一轮对话中所有前端消息 | `WsEventSender` |
+| `context_usage.py` | 上下文窗口 token 用量估算（基于 tiktoken） | `count_tokens()`, `estimate_context_usage()` |
+| `time_traveler.py` | 对话轮次撤回（基于 RemoveMessage 机制） | `undo_rounds()`, `undo_last_round()`, `undo_all()` |
+
+### 核心数据结构
+
+**`_LlmConfig`** — LLM 实例及上下文窗口配置：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `llm` | `BaseChatModel` | LangChain 聊天模型实例 |
+| `model_name` | `str` | 当前使用的模型名称（如 `gpt-4o`、`deepseek-chat`） |
+| `max_tokens` | `int` | 模型最大上下文窗口大小（token 数） |
+
+**`_TurnContext`** — 一轮 Agent 执行所需的全部上下文（构建后不可变）：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `system_prompt` | `str` | 当前会话的系统提示词 |
+| `agent` | `Sonetto` | 编译后的 LangGraph Agent |
+| `inputs` | `dict[str, list[HumanMessage]]` | 本轮输入消息 |
+| `config` | `dict[str, Any]` | 运行配置（`thread_id`、`callbacks`、`recursion_limit`） |
+
+**`_TurnResult`** — 一轮 Agent 执行的结果：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `final_answer` | `str` | Agent 产出的最终文本回答（空串表示无回答） |
+| `turn_id` | `str` | UUID hex，用于关联记忆事件 |
+| `error` | `str \| None` | 执行过程中抛出的异常；成功时为 `None` |
+
+## 职责描述
+
+### 1. 编排 LLM 对话轮次
+
+- 解析 LLM 配置（模型选择、上下文窗口参数）
+- 构建 LangGraph Agent 图（`Sonetto`），注入工具、系统提示、checkpointer
+- 流式执行 Agent 图，收集最终回答
+- 后处理：消息计数、LTM 持久化、Const 会话保存、Sub-agent 回调
+
+### 2. 管理工具调用与交互流程
+
+- 提供 `interaction.py` 交互注册表，使工具函数能挂起等待用户确认
+- 使用 `asyncio.Future` 实现挂起/唤醒，保证非阻塞
+- 任务取消时统一清理所有挂起的交互
+
+### 3. 流式输出处理
+
+- 基于 `graph.astream_events()` 逐事件消费 Agent 图输出
+- LLM token 通过回调层实时推送到前端
+- 工具执行结束自动推送上下文用量更新
+
+### 4. Token 用量估算
+
+- 基于 `tiktoken` 估算对话上下文的 token 消耗
+- 支持图片 token 估算（多模态场景）
+- 提供系统提示词细分（`breakdown`），便于前端可视化
+
+## 关键代码片段
+
+### Agent 图构建（`turn.py`）
+
+```python
+async def _build_turn_context(
+    tools: list,
+    session: SessionState,
+    ws: WebSocket,
+    llm_conf: _LlmConfig,
+    user_message: str,
+    image_recognition: bool,
+    image_refs: list[str] | None,
+) -> _TurnContext:
+    """构建 Agent 图、输入消息和执行配置。"""
+    system_prompt = build_system_prompt()
+    ws_callback = WebSocketCallback(ws)
+
+    agent = build_agent(
+        model=llm_conf.llm,
+        tools=tools,
+        system_prompt=system_prompt,
+        checkpointer=session.checkpointer,
+    )
+    session.set_graph(agent)
+
+    # 多模态输入处理
+    if image_recognition and image_refs:
+        content_parts: list[dict] = [{"type": "text", "text": user_message}]
+        for img_path in image_refs:
+            # ... 图片加载与 base64 编码 ...
+        inputs = {"messages": [HumanMessage(content=content_parts)]}
+    else:
+        inputs = {"messages": [HumanMessage(content=user_message)]}
+
+    config = {
+        "configurable": {"thread_id": session.session_id},
+        "callbacks": [ws_callback],
+        "recursion_limit": 120,
+    }
+
+    return _TurnContext(system_prompt, agent, inputs, config)
+```
+
+### 流式执行（`turn.py`）
+
+```python
+async def _stream_turn(
+    graph: Sonetto,
+    inputs: dict[str, list[HumanMessage]],
+    config: dict[str, Any],
+    sender: WsEventSender,
+    session: SessionState,
+    system_prompt: str,
+    model_name: str | None = None,
+    max_tokens: int = 256_000,
+) -> str:
+    """流式执行 Agent 图，返回最终回答。"""
+    final_answer = ""
+    async for event in graph.astream_events(inputs, config=config, version="v2"):
+        if event.get("event") == "on_chain_end" and event.get("name") == "agent":
+            final_answer = _get_final_answer(event)
+        # 工具执行完毕，推送上下文用量
+        if event.get("event") == "on_chain_end" and event.get("name") == "tools":
+            usage = await estimate_context_usage_from_session(...)
+            await sender.context_usage(usage)
+
+    # 兜底：从 checkpoint 提取
+    if not final_answer:
+        # ... checkpoint 读取逻辑 ...
+    return final_answer
+```
+
+### 交互注册表（`interaction.py`）
+
+**挂起机制** — 工具函数通过 `register()` 创建 Future 并返回 `interaction_id`：
+
+```python
+# 全局待处理交互表：interaction_id → Future
+_pending: dict[str, asyncio.Future] = {}
+
+def register() -> tuple[str, asyncio.Future]:
+    """注册一次待处理的用户交互，返回 (interaction_id, future)。"""
+    interaction_id = uuid.uuid4().hex
+    future: asyncio.Future = asyncio.Future()
+    _pending[interaction_id] = future
+    return interaction_id, future
+```
+
+**唤醒机制** — 前端通过 WebSocket 送达 `user_response` 事件，路由层调用 `resolve()`：
+
+```python
+def resolve(interaction_id: str, response) -> bool:
+    """用用户响应结果唤醒并解决挂起的 Future。返回是否成功。"""
+    future = _pending.get(interaction_id)
+    if not future or future.done():
+        return False
+    future.set_result(response)
+    return True
+```
+
+**任务取消清理** — 当 Agent 任务被取消时，统一将所有挂起的交互标记为已完成：
+
+```python
+def cancel_all(reason: str | None = None):
+    """将所有挂起的交互 Future 以取消原因标记为已完成。"""
+    if reason is None:
+        reason = "用户取消了该工具调用"
+    formatted = format_error(reason)
+    for interaction_id, future in list(_pending.items()):
+        if not future.done():
+            future.set_result(formatted)
+        _pending.pop(interaction_id, None)
+```
+
+### 轮次撤回（`time_traveler.py`）
+
+基于 LangGraph 的 `RemoveMessage` 机制，通过 `update_state` 删除 checkpoint 中的历史消息：
+
+```python
+async def undo_rounds(graph, config, n: int = 1) -> int:
+    state = await graph.aget_state(config)
+    messages = state.values.get("messages", [])
+
+    human_indices = [i for i, m in enumerate(messages) if m.type == "human"]
+    if len(human_indices) < n:
+        to_delete = messages  # 不够 n 轮就全部删除
+    else:
+        cutoff = human_indices[-n]
+        to_delete = messages[cutoff:]
+
+    await graph.aupdate_state(
+        config, {"messages": [RemoveMessage(id=m.id) for m in to_delete]}
+    )
+    return len(to_delete)
+```
+
+## 数据流 — 完整聊天轮次
+
+```
+用户消息
+    │
+    ▼
+路由层 (routes/chat.py)
+    │ 解析 WebSocket 事件类型 → chat
+    │
+    ▼
+run_agent_turn()                    ← 顶层编排入口
+    │
+    ├── 阶段 1: _resolve_llm()
+    │   │  provider_manager.create_llm() / 回退 default_llm
+    │   │  返回 _LlmConfig (llm + model_name + max_tokens)
+    │   ▼
+    ├── 阶段 2: _build_turn_context()
+    │   │  build_system_prompt() → system_prompt
+    │   │  WebSocketCallback(ws) → 注入 LangChain 事件链路
+    │   │  build_agent() → graph (LangGraph CompiledStateGraph)
+    │   │  处理多模态输入（图片 base64 编码）
+    │   │  返回 _TurnContext (system_prompt, agent, inputs, config)
+    │   ▼
+    ├── 阶段 3: _execute_agent_turn()
+    │   │  ┌─ context_usage 初始用量推送
+    │   │  │       │
+    │   │  │       ▼
+    │   │  │  _stream_turn()
+    │   │  │       │
+    │   │  │       ▼
+    │   │  │  graph.astream_events()  ──→  回调层 (WebSocketCallback)
+    │   │  │       │                          │
+    │   │  │       │                          ├── on_llm_start  → "thinking_start"
+    │   │  │       │                          ├── on_llm_new_token → "token" (流式文本)
+    │   │  │       │                          ├── on_llm_end    → "thinking_end"
+    │   │  │       │                          ├── on_tool_start → "tool_start"
+    │   │  │       │                          ├── on_tool_end   → "tool_end" (+ tool_data)
+    │   │  │       │                          └── on_tool_error → "tool_error"
+    │   │  │       │
+    │   │  │       ▼
+    │   │  │  on_chain_end("agent") → final_answer 提取
+    │   │  │  on_chain_end("tools") → context_usage 刷新 → sender
+    │   │  │
+    │   │  │  * CancelledError → interaction.cancel_all() → _inject_cancel_tool_messages()
+    │   │  │  * Exception      → sender.error("AGENT_ERROR", ...)
+    │   │  │
+    │   │  └─ sender.done(turn_id, context_usage)  ← 轮次结束
+    │   ▼
+    └── 阶段 4: _postprocess_turn()
+        │  session.increment_messages()
+        │  ltm.send_history_from_session()     ← 记忆持久化（非私密模式）
+        │  save_const_session()                ← Const 会话保存
+        │  处理 Sub-agent pending 回调结果
+        ▼
+    _TurnResult (final_answer, turn_id, error)
+        │
+        ▼
+    路由层 → WebSocket 响应完成
+```
+
+## 设计要点
+
+### 事件驱动
+
+- 整个编排层基于事件驱动：LangGraph `astream_events()` 产生事件流 → 回调层转换为 WebSocket 事件 → 前端实时渲染
+- 工具执行与 LLM 生成通过 LangGraph 图结构自然编排，无需手动调度
+
+### 异步流式
+
+- 全程异步：`async for` 消费事件，`await` 发送 WebSocket 消息
+- 流式 token 通过 `on_llm_new_token` 实时推送，用户边看边等
+- `WsEventSender` 封装统一的消息结构 `{"type": ..., "payload": ...}`
+
+### 可中断
+
+- `asyncio.CancelledError` 捕获后执行优雅取消流程：
+  1. 取消所有挂起的用户交互（`interaction.cancel_all()`）
+  2. 为孤立的 `tool_calls` 注入格式化的 `ToolMessage`（checkpoint 一致性）
+  3. 通知前端对应工具气泡进入错误状态
+- `_inject_cancel_tool_messages()` 确保下一条消息不会触发 `"tool_calls without corresponding ToolMessage"` 错误
+
+### 关注点分离
+
+- `run_agent_turn()` 为唯一公共入口，内部按 4 个阶段分步执行
+- 各阶段独立为私有函数（`_resolve_llm`, `_build_turn_context`, `_execute_agent_turn`, `_postprocess_turn`），职责单一
+- 数据对象（`_LlmConfig`, `_TurnContext`, `_TurnResult`）在各阶段之间传递，避免共享可变状态
+
+## 设计约定评估
+
+### 依赖方向
+
+**约定**：Agent 编排层（第③层）可依赖第⑤⑥⑦层，不可依赖第②层或第④层。
+
+**评估结果**：基本合规，但有**一处轻微违例**：
+
+**违规项：`turn.py` 直接导入 `WebSocketCallback`**
+- `turn.py` 第 18 行：`from api.callbacks.websocket_callback import WebSocketCallback`
+- 这是第③层直接导入第④层的符号，违反"下层不依赖上层"（实际是平行层级的逆向依赖）
+- **影响**：虽然目前无循环导入风险（回调层不依赖 agent 层），但这种依赖模糊了层级边界。如果未来重构回调层，agent 层需相应修改。
+
+**改进建议**：
+1. **接口注入**：`_build_turn_context()` 应将 `WebSocketCallback` 作为参数接收，而非自行构造
+2. 或在 `turn.py` 中定义回调接口协议（Protocol），由路由层注入具体实现，彻底切断直接导入
+
+### 异常处理边界
+
+**约定**：编排层应捕获所有异常，不向上抛裸异常。
+
+**评估结果**：合规。`_execute_agent_turn()` 中：
+- `CancelledError` → 优雅取消流程
+- `Exception` → 捕获后 `sender.error()`，存入 `_TurnResult.error`
+- `finally` → 始终清理 `active_task` 并推送 `done` 事件
+
+### 数据流完整性
+
+**约定**：每一轮对话的执行上下文应在轮次结束时完整持久化。
+
+**评估结果**：合规。`_postprocess_turn()` 中：
+- 非私密模式 → LTM 持久化
+- Const 会话 → `save_const_session()`
+- 消息计数 → `session.increment_messages()`

--- a/dev_docs/backend-architecture/callbacks-layer.md
+++ b/dev_docs/backend-architecture/callbacks-layer.md
@@ -1,0 +1,333 @@
+# 回调层 (api/callbacks/)
+
+## 层级定位
+
+**第④层 — 回调层**，事件驱动机制。
+
+位于 Agent 编排层之下、提供商抽象层之上。该层不参与业务逻辑或对话编排，仅做一件事：**监听 LangChain 事件，转换为结构化 JSON，推送前端 WebSocket**。
+
+回调层是连接"后端 LLM 执行"与"前端实时渲染"的桥梁，承担着低延迟、高吞吐的事件转发任务。
+
+## 模块文件清单
+
+| 文件 | 职责 | 主要类型/函数 |
+|---|---|---|
+| `websocket_callback.py` | LangChain → WebSocket JSON 事件推送 | `WebSocketCallback(BaseCallbackHandler)` |
+| `tool_extractors.py` | 工具输出数据提取器，注册/调度模式 | `register()`, `register_prefix()`, `_dispatch()` |
+
+### 核心数据结构
+
+**`WebSocketCallback`** — LangChain 回调处理器，继承 `BaseCallbackHandler`：
+
+| 属性 | 类型 | 说明 |
+|---|---|---|
+| `_ws` | `WebSocket` | 底层 WebSocket 连接 |
+| `_thinking_started` | `bool` | LLM 思考阶段标志，用于配对 `thinking_start` / `thinking_end` |
+| `_tool_start_time` | `dict[str, float]` | run_id → 开始时间戳，用于计算工具执行耗时 |
+| `_tool_names` | `dict[str, str]` | run_id → 工具名称 |
+| `_tool_inputs` | `dict[str, str]` | run_id → 工具输入原文 |
+
+**提取器签名**（`tool_extractors.py`）：
+
+```python
+Handler = Callable[[str, dict[str, Any], str | None], dict[str, Any] | None]
+# (tool_name, parsed_json, tool_input) → 前端数据 dict 或 None
+```
+
+## 职责描述
+
+### 1. 监听 LangChain LLM/工具调用事件
+
+通过继承 `BaseCallbackHandler` 并覆写事件方法，接入 LangChain 的执行链路：
+
+| 事件 | 触发时机 | 推送事件类型 |
+|---|---|---|
+| `on_llm_start` | LLM 开始生成 | `thinking_start` |
+| `on_llm_new_token` | LLM 生成新的 token | `token` |
+| `on_llm_end` | LLM 生成完成 | `thinking_end` |
+| `on_tool_start` | 工具开始执行 | `tool_start` |
+| `on_tool_end` | 工具执行完成 | `tool_end` + 可选 `tool_error` |
+| `on_tool_error` | 工具执行异常 | `tool_error` |
+
+### 2. 实时推送到前端 WebSocket
+
+所有事件统一包装为 `{"type": ..., "payload": ...}` 格式，通过 `ws.send_json()` 推送。
+
+### 3. 工具输出结构化提取
+
+`tool_extractors.py` 实现 Registry + Dispatch 模式，将工具输出 JSON 转换为前端气泡组件所需的结构化数据。
+
+## 关键代码片段
+
+### 事件处理器（`websocket_callback.py`）
+
+**LLM 事件** — 流式 token 的核心路径：
+
+```python
+class WebSocketCallback(BaseCallbackHandler):
+    def __init__(self, ws: WebSocket):
+        super().__init__()
+        self._ws = ws
+        self._thinking_started = False
+        self._tool_start_time: dict[str, float] = {}
+        self._tool_names: dict[str, str] = {}
+        self._tool_inputs: dict[str, str] = {}
+
+    async def on_llm_start(self, serialized, prompts, **kwargs):
+        self._thinking_started = True
+        await self._ws.send_json({
+            "type": "thinking_start",
+            "payload": {"timestamp": time.time()},
+        })
+
+    async def on_llm_new_token(self, token: str, **kwargs):
+        await self._ws.send_json({
+            "type": "token",
+            "payload": {"token": token},
+        })
+
+    async def on_llm_end(self, response, **kwargs):
+        if self._thinking_started:
+            self._thinking_started = False
+            await self._ws.send_json({
+                "type": "thinking_end",
+                "payload": {"timestamp": time.time()},
+            })
+```
+
+**工具事件** — 工具调用全生命周期跟踪：
+
+```python
+    async def on_tool_start(self, serialized, input_str, **kwargs):
+        tool_name = serialized.get("name", "unknown")
+        run_id = str(kwargs.get("run_id", ""))
+        self._tool_start_time[run_id] = time.time()
+        self._tool_names[run_id] = tool_name
+        self._tool_inputs[run_id] = input_str
+
+        await self._ws.send_json({
+            "type": "tool_start",
+            "payload": {
+                "call_id": run_id,
+                "tool_name": tool_name,
+                "input": input_str[:500],
+            },
+        })
+
+    async def on_tool_end(self, output, **kwargs):
+        run_id = str(kwargs.get("run_id", ""))
+        elapsed = time.time() - self._tool_start_time.pop(run_id, time.time())
+        tool_name = self._tool_names.pop(run_id, "unknown")
+        tool_input = self._tool_inputs.pop(run_id, None)
+
+        out_str = _extract_content(output)
+
+        # 检测 format_error 响应 → 路由到 tool_error
+        try:
+            parsed = json.loads(out_str)
+            if isinstance(parsed, dict) and parsed.get("success") is False:
+                # 推送 tool_error 事件
+                return
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # 提取工具专属结构化数据
+        tool_data = self._extract_tool_data(tool_name, output, tool_input)
+
+        await self._ws.send_json({
+            "type": "tool_end",
+            "payload": {
+                "call_id": run_id,
+                "tool_name": tool_name,
+                "output": out_str[:300],
+                "elapsed": round(elapsed, 2),
+                "tool_data": tool_data,
+            },
+        })
+```
+
+### 注册/调度机制（`tool_extractors.py`）
+
+**Registry 模式** — 装饰器注册 + 运行时调度：
+
+```python
+# Registry
+_REGISTRY: dict[str, Handler] = {}
+_PREFIX_REGISTRY: list[tuple[str, Handler]] = []
+
+def register(tool_name: str) -> Callable[[Handler], Handler]:
+    """精确匹配注册装饰器。"""
+    def decorator(fn: Handler) -> Handler:
+        _REGISTRY[tool_name] = fn
+        return fn
+    return decorator
+
+def register_prefix(prefix: str) -> Callable[[Handler], Handler]:
+    """前缀匹配注册装饰器（如 todo_*）。"""
+    def decorator(fn: Handler) -> Handler:
+        _PREFIX_REGISTRY.append((prefix, fn))
+        return fn
+    return decorator
+
+# Dispatch
+def _dispatch(tool_name, parsed, tool_input=None):
+    handler = _REGISTRY.get(tool_name)
+    if handler:
+        return handler(tool_name, parsed, tool_input)
+
+    for prefix, handler in _PREFIX_REGISTRY:
+        if tool_name.startswith(prefix):
+            return handler(tool_name, parsed, tool_input)
+
+    return None
+```
+
+**典型提取器示例** — Todo 系列工具使用精确匹配和前缀匹配组合：
+
+```python
+@register("todo_list")
+def _extract_todo_list(_tool_name, parsed, _tool_input=None):
+    """返回 tool_type=task_list, total, tasks。"""
+    data = _get_data(parsed)
+    if data is None:
+        return None
+    return {"tool_type": "task_list", "total": data.get("total"), "tasks": data.get("tasks", [])}
+
+@register_prefix("todo_")
+def _extract_todo_generic(tool_name, parsed, _tool_input=None):
+    """前缀匹配兜底：todo_create, todo_update, todo_delete 等均由此处理。"""
+    data = _get_data(parsed)
+    if data is None:
+        return None
+    return {"tool_type": "single_task", ...}
+```
+
+## 事件流程
+
+```
+LangChain 执行链路               WebSocketCallback               前端
+─────────────────               ────────────────               ────
+
+LLM 开始生成
+    │
+    ├── on_llm_start()  ──────→  {"type":"thinking_start"}  ──→ 显示思考状态
+    │
+    ├── on_llm_new_token()  ──→  {"type":"token"}            ──→ 追加流式文本
+    │         ... (多次)
+    │
+    ├── on_llm_end()      ──────→  {"type":"thinking_end"}   ──→ 隐藏思考状态
+    │
+工具开始执行
+    │
+    ├── on_tool_start()   ──────→  {"type":"tool_start"}     ──→ 显示工具气泡(loading)
+    │
+    ├── on_tool_end()     ──────→  {"type":"tool_end"}       ──→ 更新工具气泡(完成)
+    │                             附 tool_data(结构化数据)
+    │
+    └── on_tool_error()   ──────→  {"type":"tool_error"}     ──→ 工具气泡(错误)
+
+*tool_end 中检测到 format_error (success=false) 时也路由到 tool_error
+```
+
+## 设计要点
+
+### 松耦合
+
+- `WebSocketCallback` 通过 `BaseCallbackHandler` 接口与 LangChain 集成，不依赖任何 Agent 编排细节
+- 提取器系统通过装饰器注册，新增工具只需添加新装饰器函数，无需修改调度逻辑
+- `WsEventSender`（位于 agent 层）和 `WebSocketCallback`（位于 callbacks 层）共享同一 `WebSocket` 实例，但职责互补：前者发送编排层事件（`context_usage`、`answer`、`done`），后者发送 LangChain 事件（`token`、`tool_start/end`）
+
+### 可扩展
+
+- 工具提取器支持精确匹配（`register("exact_name")`）和前缀匹配（`register_prefix("prefix_")`）两种模式
+- 目前内置 20+ 个提取器，覆盖 Todo、文件系统、天气、地图、塔罗、搜索、记忆等工具域
+- 新工具只需添加装饰函数，无需修改其他代码
+
+### 不阻塞主流程
+
+- 所有 `ws.send_json()` 为异步调用，`await` 不会阻塞 LangChain 事件循环
+- `_dispatch()` 提取器是纯同步函数，执行极快，不涉及 IO
+- 工具输出摘取前 300 字符以防大数据量阻塞 WebSocket
+
+## 分层边界
+
+回调层严格遵守 **"只做事件转换和推送，不处理业务逻辑"** 的边界原则：
+
+| 职责范围内 | 职责范围外 |
+|---|---|
+| LangChain 事件 → JSON 序列化 | LLM 调用参数构造 |
+| 工具输出 → 结构化解构 | 工具执行结果验证 |
+| 错误检测 → 事件路由（tool_error） | 对话状态管理 |
+| 耗时统计 | 消息持久化 |
+| 字符串截断（防大数据推送） | 用户鉴权 |
+
+## 设计约定评估
+
+### 分层纯净度
+
+**约定**：回调层应仅依赖 LangChain SDK 和 FastAPI WebSocket，不依赖后端的业务模块（session、memory、tools 等）。
+
+**评估结果**：**合规**。`websocket_callback.py` 的导入链清晰：
+- `fastapi.WebSocket` — 框架基础
+- `langchain_core.callbacks.BaseCallbackHandler` — LangChain SDK
+- `langchain_core.outputs.LLMResult` — LangChain 类型
+- `.tool_extractors` — 同层模块引用
+
+无任何对 `api/session/`、`api/memory/`、`tools/`、`agent/` 的导入。
+
+### 职责单一
+
+**约定**：一个文件只做一件事。
+
+**评估结果**：**合规**。
+- `websocket_callback.py` 只做事件推送
+- `tool_extractors.py` 只做结构化数据提取
+
+`tool_extractors.py` 包含大量提取函数（20+ 个），但这些都属于"同一个职责"——工具输出到前端气泡数据的映射。通过装饰器注册机制保持扩展点统一。
+
+### 事件完整性
+
+**约定**：LLM 事件必须有始有终（成对推送）。
+
+**评估结果**：`thinking_start` / `thinking_end` 通过 `_thinking_started` 标志保证配对，**合规**。
+工具事件（`tool_start` / `tool_end`）通过 `run_id` 关联，`_tool_start_time` / `_tool_names` / `_tool_inputs` 三个字典均在 `on_tool_end` 中 `pop` 清理，**合规**。
+
+### 错误路由正确性
+
+**约定**：工具执行失败应走 `tool_error` 事件，而非 `tool_end`。
+
+**评估结果**：**合规**。`on_tool_end` 中有专门的检测逻辑：
+```python
+# 检测 format_error 响应 → 路转到 tool_error
+try:
+    parsed = json.loads(out_str)
+    if isinstance(parsed, dict) and parsed.get("success") is False:
+        error_msg = parsed.get("error", "操作执行失败")
+        await self._ws.send_json({"type": "tool_error", ...})
+        return  # 不继续发送 tool_end
+except (json.JSONDecodeError, TypeError):
+    pass
+```
+
+同时在 `on_tool_error` 中也有独立的 `tool_error` 事件处理路线。
+
+### 可维护性
+
+**评估结果**：提取器系统存在一些**重复模式**值得关注：
+
+1. **重复的 AST 解析逻辑**：`file_manage`、`file_search`、`file_edit`、`run_python` 等提取器中多次出现从 `tool_input` 中 `ast.literal_eval` 解析操作类型的逻辑。可提取为公共辅助函数：
+   ```python
+   def _parse_tool_input(tool_input: str | None) -> dict[str, Any] | None:
+       """从工具输入字符串解析出参数字典。"""
+       if not tool_input:
+           return None
+       try:
+           parsed = ast.literal_eval(tool_input)
+           return parsed if isinstance(parsed, dict) else None
+       except (ValueError, SyntaxError, TypeError):
+           return None
+   ```
+
+2. **嵌套的 POI/卡片遍历逻辑**：`nearby_search`、`fuzzy_address_search`、`get_transit_route`、`get_cycling_route`、`tarot`、`holiday_calendar` 等提取器中都包含手动多级遍历。对于稳定的嵌套结构，可考虑声明式转换模式（如 `dataclass` + `asdict` 映射）。
+
+这些是代码组织层面的优化建议，不构成分层违规。

--- a/dev_docs/backend-architecture/core-layer.md
+++ b/dev_docs/backend-architecture/core-layer.md
@@ -1,0 +1,184 @@
+# 核心基础设施层 — `api/core/`
+
+## 层级定位
+
+| 属性 | 值 |
+|---|---|
+| **层级编号** | 第 7 层（最底层） |
+| **层级名称** | 核心基础设施层 |
+| **依赖方向** | 不依赖其他业务模块，仅依赖第三方库和 Python 标准库 |
+| **被依赖者** | server 启动脚本、main 入口、中间件层、路由层 |
+
+```
+⑥ 长期记忆层 + 会话管理层 (memory/ + session/)
+      ↑ 依赖
+⑦ 核心基础设施层 (core/)
+      ↑ 依赖
+   第三方库 / 标准库
+```
+
+## 模块文件清单
+
+| 文件 | 核心类型/函数 | 职责 |
+|---|---|---|
+| `auth.py` | `load_or_create_token()` / `rotate_token()` | Token 认证：从 YAML 加载或生成新 Token，支持安全轮换 |
+| `dependencies.py` | `get_system_prompt()` / `get_tools()` | 共享资源惰性单例：系统提示词 + 工具集的全局单例 |
+| `health.py` | `ComponentHealth` / `HealthResponse` / `get_health_report()` | 四部件健康自检：LLM / 记忆 / 原生工具 / MCP 工具 |
+
+### auth.py — Token 认证
+
+```python
+AUTH_TOKEN_PATH = Path(...) / "config" / "auth_token.yaml"
+
+
+def load_or_create_token() -> str:
+    """从 auth_token.yaml 加载 Token，不存在则生成并持久化。"""
+    ...
+
+
+def rotate_token() -> str:
+    """轮换 Token，覆盖写入文件并返回新值。"""
+    ...
+```
+
+### dependencies.py — 惰性单例
+
+```python
+_system_prompt: str | None = None
+_tools: list | None = None
+
+
+def get_system_prompt() -> str:
+    global _system_prompt
+    if _system_prompt is None:
+        _system_prompt = build_system_prompt()
+    return _system_prompt
+
+
+def get_tools() -> list:
+    global _tools
+    if _tools is None:
+        _tools = get_all_tools()
+    return _tools
+```
+
+### health.py — 健康自检
+
+```python
+class ComponentHealth(BaseModel):
+    status: Literal["ok", "error"]
+    latency_ms: float | None = None
+    detail: str | None = None
+
+
+class HealthResponse(BaseModel):
+    status: Literal["ok", "degraded"]
+    version: str
+    llm: ComponentHealth          # LLM 连通性
+    memory: ComponentHealth       # 记忆文件 + 后台消费者
+    native_tools: ComponentHealth # 内置工具集
+    mcp_tools: ComponentHealth    # MCP 工具集
+    anthropic_skills_count: int
+    providers: dict[str, ComponentHealth]
+    timestamp: float
+```
+
+四个健康检查函数各自独立，互不依赖：
+
+- **check_llm** — 遍历 ProviderManager 中所有 enabled provider，逐个调用 `provider.check_health()`，第一个成功的即返回 `ok`，全部失败则返回 `error`
+- **check_memory** — 检查记忆 YAML 文件是否存在，并验证后台消费者（ltm）是否在运行
+- **check_native_tools** — 从 `app.state.native_tools` 读取工具列表，验证其可访问性
+- **check_mcp_tools** — 从 `app.state.mcp_tools` 读取 MCP 工具列表，空列表视为 `ok`（未配置 MCP 服务器即正常状态）
+
+最终 `get_health_report()` 聚合四部件结果：
+
+```python
+async def get_health_report(app: FastAPI) -> HealthResponse:
+    llm = await check_llm(app)
+    memory = await check_memory(app)
+    native_tools = await check_native_tools(app)
+    mcp_tools = await check_mcp_tools(app)
+    providers = await check_health_providers(app)
+
+    all_checks = [llm, memory, native_tools, mcp_tools] + list(providers.values())
+    overall = "ok" if all(c.status == "ok" for c in all_checks) else "degraded"
+
+    return HealthResponse(status=overall, version=__version__, ...)
+```
+
+## Token 轮换逻辑（auth.py）
+
+```python
+def rotate_token() -> str:
+    """轮换 Token，覆盖写入文件并返回新值。"""
+    token = secrets.token_urlsafe(32)
+    AUTH_TOKEN_PATH.write_text(
+        yaml.dump({"token": token}, encoding="utf-8").decode("utf-8"),
+        encoding="utf-8",
+    )
+    return token
+```
+
+使用 `secrets.token_urlsafe(32)` 生成 256 位随机 Token，直接覆写 YAML 文件。无状态设计 —— 不保留内存副本，每次调用从文件读取或生成新的 Token。
+
+## 职责描述
+
+- **无状态基础设施**：所有函数均为纯函数或惰性初始化，不持有运行时可变状态
+- **跨模块共享**：系统提示词和工具集通过惰性单例在全局范围内共享，避免重复构建
+- **健康自检**：提供 LLM、记忆、工具四个维度的健康检查，供监控和路由层使用
+- **认证凭证管理**：Token 的生成、持久化、轮换，供中间件层认证使用
+
+## 被依赖关系
+
+| 上层模块 | 依赖内容 |
+|---|---|
+| `api/server.py`（应用启动） | `load_or_create_token`、`get_system_prompt`、`get_tools`、`get_health_report` |
+| `main.py`（CLI 入口） | `rotate_token` |
+| `api/middleware/`（中间件层） | 间接通过 `server.py` 注入 Token 验证逻辑 |
+| `api/routes/`（路由层） | 间接通过 `server.py` 注册健康检查端点（`/api/health`） |
+
+## 设计要点
+
+### 1. 单例模式（dependencies.py）
+
+```python
+_system_prompt: str | None = None
+_tools: list | None = None
+```
+
+通过模块级全局变量 + 双重惰性初始化实现单例。`get_system_prompt()` 和 `get_tools()` 仅在首次调用时构建一次，后续直接返回缓存结果。该模式：
+
+- 避免了 FastAPI 启动时的冷启动开销
+- 线程安全（CPython GIL 保护全局变量赋值）
+- 不支持动态重新加载（如需更新需重启服务）
+
+### 2. 无状态设计（auth.py / health.py）
+
+- `auth.py` 不保留 Token 内存副本，每次认证由中间件从文件加载
+- `health.py` 的每个检查函数都是独立的，不共享内部状态
+- `HealthResponse` 是值对象（Pydantic BaseModel），一次性构造后不可变
+
+### 3. 健康检查的策略
+
+每项检查独立 try/except，某项失败不影响其他项的结果收集。最终 status 只有当**全部**部件正常才为 `ok`，任一部件异常则整体为 `degraded`。
+
+## 设计约定评估
+
+### 发现：health.py 存在向上依赖违规
+
+`api/core/health.py` 中存在对上层模块的引用：
+
+```python
+from api.memory.manager import MemoryManager        # 依赖 memory/（第⑥层）
+from api.memory.narrative import MEMORY_PATH         # 依赖 memory/（第⑥层）
+```
+
+**问题**：第⑦层（core）不应依赖第⑥层（memory）。根据"下层不依赖上层"的约定，`health.py` 中对 `MemoryManager` 的调用构成了自底向上的反向依赖。
+
+**影响**：该依赖使 `core/` 无法在脱离 `memory/` 模块的环境下独立测试或复用。
+
+**改进建议**：
+
+1. **接口抽象**：在 `core/` 内定义健康检查接口（Protocol），将 `check_memory` 的具体实现注入（如通过 FastAPI `app.state` 传递），而不是直接 import memory 模块
+2. **挪动位置**：将 `check_memory` 函数移至 `memory/` 模块，由 health 端点通过依赖注入聚合结果
+3. **当前权宜方案**：若短期内不改，可通过 `app.state.memory_manager` 注入 MemoryManager 实例，避免硬导入

--- a/dev_docs/backend-architecture/data-layer.md
+++ b/dev_docs/backend-architecture/data-layer.md
@@ -1,0 +1,156 @@
+# 数据资源层 — `api/data/`
+
+## 层级定位
+
+**第⑦层（最底层）**，与 `core/`（核心基础设施层）同属架构最底层。
+
+数据资源层是 SonettoHere 后端分层架构中的**最底层**，不依赖任何其他模块，仅被上层模块读取或写入。
+
+```
+┌──────────────────────────────────────┐
+│          上层模块 (routes/            │
+│         providers/ session/)          │  ← 依赖 data/
+├──────────────────────────────────────┤
+│  ⑦ 数据资源层 (data/)                 │  纯静态资源、文件存储
+└──────────────────────────────────────┘
+```
+
+## 模块内容
+
+| 文件 / 目录 | 类型 | 用途 | 管理方式 |
+|---|---|---|---|
+| `news.yaml` | YAML 文件 | 系统更新动态数据 | 手动编辑（版本管理） |
+| `SonettoTest.png` | PNG 图片 | 视觉能力检测测试资源 | 静态文件（Git 管理） |
+| `const-sessions/` | 目录 | 固定会话持久化存储 | 运行时由 `const_store` 读写 |
+
+### 目录结构
+
+```
+api/data/
+├── news.yaml              # 系统更新动态
+├── SonettoTest.png        # 视觉检测测试图片
+└── const-sessions/        # 固定会话 YAML 持久化目录（运行时创建）
+```
+
+## 职责描述
+
+### 1. 静态数据提供
+
+`news.yaml` 存储系统更新动态，供 REST API `/api/news` 端点读取。数据格式为 YAML 列表，每条记录包含标题、描述、类型、日期、标签等信息。
+
+### 2. 测试资源
+
+`SonettoTest.png` 是一张包含文字 "Sonetto" 的测试图片，用于模型视觉能力检测。在保存 LLM 提供商配置时，系统向每个模型发送此图片并检测其是否能正确识别图片中的文字。
+
+### 3. 固定会话文件存储目录
+
+`const-sessions/` 目录为运行时目录，由 `api/session/const_store.py` 管理。当用户将会话标记为「固定会话」时，会话状态（元数据 + 对话消息）会序列化为 YAML 文件持久化到此目录中。应用启动时，系统会从该目录加载所有固定会话并重建到内存 SessionManager 中。
+
+## 设计要点
+
+| 要点 | 说明 |
+|---|---|
+| **纯静态资源** | 模块本身不含任何运行时 Python 逻辑，仅提供文件存储 |
+| **无运行时逻辑** | 所有读写操作由上层模块（routes、providers、session）完成 |
+| **无外部依赖** | 不导入任何项目内模块，也不依赖数据库等外部服务 |
+| **文件即接口** | 模块边界通过文件路径约定，而非函数调用 |
+
+## 被依赖关系
+
+| 上层模块 | 文件路径 | 用途 | 操作类型 |
+|---|---|---|---|
+| `api/routes/news.py` | `api/data/news.yaml` | 读取系统更新动态并返回 REST API 响应 | 只读 |
+| `api/providers/vision.py` | `api/data/SonettoTest.png` | 加载测试图片并发送给模型进行视觉能力检测 | 只读 |
+| `api/session/const_store.py` | `api/data/const-sessions/` | 固定会话的 YAML 持久化读写 | 读写 |
+| `api/server.py` | `api/data/const-sessions/` | 应用启动时加载所有固定会话到内存 | 只读 |
+
+## 关键代码片段
+
+### 读取 news.yaml（`api/routes/news.py`）
+
+```python
+from fastapi import APIRouter
+from pydantic import BaseModel
+from pathlib import Path
+import yaml
+
+router = APIRouter()
+
+NEWS_PATH = Path(__file__).resolve().parent.parent / "data" / "news.yaml"
+
+
+class NewsEntry(BaseModel):
+    id: str
+    en_title: str | None = None
+    title: str
+    description: str
+    type: str
+    date: str
+    tags: list[str] = []
+    version: str
+    pr_number: int | None = None
+
+
+class ListNewsResponse(BaseModel):
+    news: list[NewsEntry]
+
+
+def _load_news() -> list[NewsEntry]:
+    if not NEWS_PATH.exists():
+        return []
+    with open(NEWS_PATH, encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    entries = [NewsEntry(**item) for item in raw.get("news", [])]
+    # 按日期降序排列（最新的在前）
+    entries.sort(key=lambda e: e.date, reverse=True)
+    return entries
+
+
+@router.get("/news", response_model=ListNewsResponse)
+def list_news():
+    """返回所有更新动态，按日期降序排列。"""
+    return ListNewsResponse(news=_load_news())
+```
+
+### 引用 SonettoTest.png（`api/providers/vision.py`）
+
+```python
+IMAGE_PATH = Path(__file__).resolve().parent.parent / "data" / "SonettoTest.png"
+```
+
+### const-sessions 目录操作（`api/session/const_store.py`）
+
+```python
+_CONST_DIR = Path(__file__).resolve().parent.parent / "data" / "const-sessions"
+
+def _ensure_dir() -> Path:
+    _CONST_DIR.mkdir(parents=True, exist_ok=True)
+    return _CONST_DIR
+
+def load_all_const_sessions() -> list[dict]:
+    """扫描 const-sessions/ 目录，加载所有 YAML。"""
+    ensure_dir = _ensure_dir()
+    sessions = []
+    for fpath in sorted(ensure_dir.glob("*.yaml")):
+        data = load_const_session(fpath)
+        if data and data.get("session_id"):
+            sessions.append(data)
+    return sessions
+```
+
+## 演进建议
+
+### 数据量增长时的迁移考量
+
+当前 `data/` 模块采用纯文件存储方式，在小规模场景下简单可靠。若未来数据量增长，以下场景建议考虑迁移到数据库：
+
+| 场景 | 当前方式的问题 | 建议迁移方案 | 优先级 |
+|---|---|---|---|
+| 更新动态条目超过数百条 | YAML 文件过大，加载效率下降 | 迁移到 SQLite 或 PostgreSQL | 低 |
+| 固定会话数量激增 | YAML 文件散落目录，查询效率低 | 迁移到关系型数据库 + 索引 | 中 |
+| 需要按条件过滤或搜索 | 需全量加载后内存过滤 | 数据库查询（WHERE / LIKE 等） | 低 |
+| 多实例部署 | 文件存储无法共享 | 对象存储（S3/MinIO）或 PostgreSQL | 高 |
+
+### 保持现状的场景
+
+如果项目保持单实例部署且数据量可控，当前的文件存储方案完全足够，无需引入数据库带来的运维复杂度。

--- a/dev_docs/backend-architecture/memory-layer.md
+++ b/dev_docs/backend-architecture/memory-layer.md
@@ -1,0 +1,214 @@
+# 长期记忆层 (memory/)
+
+## 层级定位
+
+**第⑥层 — 长期记忆层**。与 `session/` 会话管理层并列，位于 Provider 抽象层（第⑤层）之下，核心基础设施层（第⑦层）之上。通过 `@tool` 暴露给 Agent 编排层（第③层）使用，同时提供 REST 接口复用。
+
+```
+③ Agent 编排层 ─── @tool ────────────► ⑥ memory/  (CRUD 操作)
+② 路由层 ───────── REST ─────────────► ⑥ memory/  (REST 复用)
+⑥ memory/ ─────── create_llm() ─────► ⑤ providers/ (后台叙事 LLM 调用)
+```
+
+## 模块文件清单
+
+| 文件 | 职责 |
+|------|------|
+| `manager.py` | MemoryManager + MemoryItem — YAML 持久化 CRUD，文件锁并发安全 |
+| `narrative.py` | LongTermMemoryInterface — 后台 LLM 增量总结管线 + 5 个模块级 `@tool` |
+| `callback.py` | MemoryToolCallback — CRUD 工具事件 → WebSocket 前端推送 |
+| `user_init.py` | 首次运行初始化：USER.md / SOUL.md / .env 文件复制 |
+
+## 职责描述
+
+### 1. 记忆的 CRUD 存储
+
+`MemoryManager` 封装了对 `memory.yaml` 的全部操作，提供增（add）、删（delete）、改（update）、查（show/show_description_history）、合并（merge）方法。
+
+### 2. LLM 驱动的记忆叙事与总结
+
+`LongTermMemoryInterface` 是异步管线：每轮对话消息 → `asyncio.Queue` → 后台 LLM CRUD Agent → `memory.yaml` 写入。实现了冷启动（首次无记忆）和增量更新（已有记忆）两种叙事策略。
+
+### 3. 首次运行环境初始化
+
+`user_init.py` 在应用启动时调用 `ensure_all()`，确保 USER.md、SOUL.md、.env 等必要文件存在，不存在时从 `.example` 模板复制。
+
+## 关键代码片段
+
+### MemoryManager 核心 CRUD + 文件锁
+
+```python
+# api/memory/manager.py
+
+class MemoryManager:
+    def __init__(self, yaml_file: str):
+        self._yaml_file = yaml_file
+        self._ensure_file_exists()
+
+    def add(self, description: str, theme: str) -> str:
+        """新增记忆条目。使用 portalocker 文件锁保证并发安全。"""
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            new_id = self._generate_id()
+            items[new_id] = MemoryItem(description, theme)
+            self._write_all(items)
+        return new_id
+
+    def delete(self, id: str) -> str:
+        """删除条目，返回删除的描述文本。"""
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            if id not in items:
+                raise ValueError(f"MemoryManager: Memory item with ID {id} not found")
+            removed = items.pop(id)
+            self._write_all(items)
+        return removed.description
+
+    def update(self, id: str, reason: str,
+               new_description: str | None = None,
+               new_theme: str | None = None):
+        """更新条目，记录变更原因和历史。"""
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            if id not in items:
+                raise ValueError(f"MemoryManager: Memory item with ID {id} not found")
+            items[id].update(reason, new_description, new_theme)
+            self._write_all(items)
+
+    def merge(self, id1: str, id2: str,
+              merged_description: str, merged_theme: str, reason: str):
+        """合并两条记忆，保留完整修改历史。"""
+        with portalocker.Lock(self._lock_path, timeout=5):
+            items = self._read_all()
+            if id1 not in items or id2 not in items:
+                raise ValueError(...)
+            items[id1].merge(items[id2], reason, merged_description, merged_theme)
+            items.pop(id2)
+            self._write_all(items)
+```
+
+文件锁机制：
+- 使用 `portalocker.Lock` 对 `.lock` 文件加互斥锁，超时时间 5 秒
+- 所有读写操作均在锁保护范围内执行
+- 支持多进程/多线程并发安全
+
+### 模块级 @tool 定义
+
+```python
+# api/memory/narrative.py
+
+@tool
+def create_memory(content: str, section: str) -> str:
+    """添加一条新的记忆条目到指定分区。"""
+    content = _sanitize(content)
+    if len(content) > MAX_DESC_LENGTH:
+        return f"驳回：记忆内容超过 {MAX_DESC_LENGTH} 字限制..."
+    if _current_mm is None:
+        return "错误：记忆管理器未初始化。"
+    new_id = _current_mm.add(description=content, theme=section)
+    return f"已创建 [{new_id}] ({section}): {content}"
+
+@tool
+def read_memories() -> str:
+    """查看当前所有记忆条目及其 ID 和分区。"""
+    if _current_mm is None:
+        return "（暂无记忆条目）"
+    return _format_entries_for_tool(_current_mm.show())
+
+@tool
+def update_memory(id: str, content: str, reason: str) -> str:
+    """根据 ID 更新一条已有记忆。"""
+    ...
+
+@tool
+def delete_memory(id: str, reason: str) -> str:
+    """根据 ID 删除一条记忆。"""
+    ...
+
+@tool
+def merge_memories(id1: str, id2: str, content: str, section: str, reason: str) -> str:
+    """将两条相似记忆合并为一条。"""
+    ...
+```
+
+这些 `@tool` 函数通过模块级全局变量 `_current_mm` 委托给 `MemoryManager` 实例，由 `LongTermMemoryInterface._consumer()` 在启动时设置。
+
+## 设计要点
+
+### 文件锁保证并发安全
+
+所有 `MemoryManager` 的写操作（add / delete / update / merge）都通过 `portalocker.Lock` 保护，读操作（show / show_description_history）同样加锁。锁文件 (`.lock`) 与数据文件 (.yaml) 同路径，超时 5 秒。
+
+```python
+@property
+def _lock_path(self) -> str:
+    return self._yaml_file + ".lock"
+```
+
+### YAML 持久化
+
+- 数据以 `dict[id → MemoryItem.__dict__]` 的格式写入 YAML
+- `_read_all` / `_write_all` 是对 YAML 文件的唯二读写入口
+- ID 生成：`secrets.token_hex(4)` → 8 字符十六进制（旧版 UUID 格式在读取时自动迁移）
+- `MemoryItem` 提供 `to_dict()` 语义（直接使用 `__dict__`）和 `show_description_history()` 历史追溯
+
+### 后台总结不阻塞聊天
+
+`LongTermMemoryInterface` 采用**生产者-消费者**异步管线：
+
+```
+send_history(user_msg)           — 生产者，非阻塞放入队列
+    │
+    ▼
+Queue[ (session_id, turn_id, messages), ... ]
+    │
+    ▼
+_consumer()                      — 后台协程，逐条消费
+    │
+    ├── _set_current_mm(mm)     — 注入 MemoryManager
+    ├── create_agent(llm, tools) — 创建 CRUD Agent
+    ├── agent.ainvoke(...)       — LLM 调用
+    ├── callback.py              — 推送 tool 事件到前端
+    └── memory.yaml              — 持久化写入
+```
+
+- 聊天响应直接返回用户，不等待记忆总结完成
+- 后台消费者的 LLM 调用复用同一个 Provider 提供的 `BaseChatModel`
+- 支持 `stop_listening()` 安全关闭（`None` 哨兵）
+
+## 分层边界
+
+### 对外暴露方式
+
+| 使用方 | 接口方式 | 具体入口 |
+|--------|----------|----------|
+| Agent 编排层 | `@tool` 函数 | `create_memory` / `read_memories` / `update_memory` / `delete_memory` / `merge_memories` |
+| REST 路由层 | 直接调用 `MemoryManager` | 通过 `LongTermMemoryInterface` 间接调用 |
+| Vignette 前端 | REST API | `/api/memories` 端点返回分组记忆（`get_memories_grouped`） |
+| Agent 工具层 | `get_narrative()` | 读取完整记忆叙事文本，作为系统提示前缀 |
+| 查询相关 | `get_related_memory_from()` | 基于 LLM 的语义检索 |
+
+### 依赖关系
+
+| 依赖方向 | 目标模块 | 说明 |
+|----------|----------|------|
+| `narrative.py →` | `manager.py` | MemoryManager + MemoryItem |
+| `narrative.py →` | `callback.py` | MemoryToolCallback |
+| `narrative.py →` | `api.session.manager` | SessionState（用于提取 checkpointer 消息） |
+| `narrative.py →` | `api.session.ws_registry` | WebSocketRegistry（用于事件推送） |
+| `callback.py →` | `api.session.ws_registry` | WebSocketRegistry（用于工具事件推送） |
+| `narrative.py →` | `api.providers` | 通过 `create_agent` 间接调用（LLM 由外部注入） |
+
+### 设计约定评估
+
+**发现的分层违规**：
+
+1. **模块级全局变量**：`narrative.py` 中的 `_current_mm` 是模块级可变全局状态，通过 `_set_current_mm()` 注入。这种设计在单消费者场景下工作正常，但若并发存在多个 `LongTermMemoryInterface` 实例（如多租户），全局状态会互相覆盖。建议改为实例级别的依赖注入，使 `@tool` 函数与具体的 `MemoryManager` 实例绑定。
+
+2. **Session 依赖方向**：`narrative.py` 和 `callback.py` 都依赖 `api.session.ws_registry`。这属于同一层级（第⑥层）内的模块间依赖，不违反分层规则。但应注意：`session/` 与 `memory/` 同层，彼此引入时需要避免循环依赖。
+
+3. **模块级 @tool 的测试性**：`@tool` 函数是模块级函数而非类方法，无法在单元测试中轻松替换 `_current_mm`。当前通过 `lru_cache` 的 `get_narrative()` 也存在静态文件路径的硬编码（`MEMORY_PATH` 在第 29 行硬编码为 `config/personas/memory.yaml`）。
+
+**改进建议**：
+- 将 `@tool` 函数改为类方法或工厂函数，通过闭包绑定 `MemoryManager` 实例，消除全局可变状态。
+- 或者使用 `contextvars` 为每个异步任务独立管理 `_current_mm`，支持多实例并发。

--- a/dev_docs/backend-architecture/middleware-layer.md
+++ b/dev_docs/backend-architecture/middleware-layer.md
@@ -1,0 +1,249 @@
+# 中间件层 (middleware/) — 第①层
+
+## 层级定位
+
+中间件层是后端分层架构中的 **第①层（最外层）**，是客户端请求进入后端系统的 **第一道关卡**。它作为 ASGI 中间件，在 FastAPI 路由分发之前拦截所有 HTTP 和 WebSocket 请求，执行横切关注点（Cross-cutting Concerns）的处理。
+
+```
+HTTP / WebSocket 客户端
+       │
+       ▼
+┌──────────────────────┐
+│ ① 中间件层 (middleware) │  ← 当前模块：认证鉴权、请求预处理
+├──────────────────────┤
+│ ② 路由层 (routes)     │  ← 请求分发
+├──────────────────────┤
+│ ③ Agent 编排层        │  ← 业务逻辑
+└──────────────────────┘
+```
+
+## 模块文件清单
+
+`api/middleware/` 目录下包含 **1 个中间件模块**（不含 `__init__.py`）：
+
+| 文件 | 类/组件 | 类型 | 职责 |
+|------|---------|------|------|
+| `auth.py` | `AuthMiddleware` | ASGI 中间件 | 统一拦截 HTTP API 和 WebSocket 请求进行 Token 鉴权 |
+
+### 模块架构
+
+```
+api/middleware/
+├── __init__.py     # （空）
+└── auth.py         # AuthMiddleware — ASGI 认证中间件
+```
+
+## 职责描述
+
+中间件层的核心职责包括：
+
+### 1. 认证鉴权
+
+- 对所有 `/api/*` 和 `/ws/*` 路径的请求执行 Token 校验
+- 鉴权失败的 HTTP 请求返回 `401 JSONResponse`
+- 鉴权失败的 WebSocket 连接返回 `4001` 关闭码
+- 白名单路径（如 `/api/health`）免鉴权
+
+### 2. 请求预处理
+
+- 从多种来源提取认证 Token（请求头、WebSocket sub-protocol）
+- WebSocket 鉴权通过后，自动注入 `subprotocol` 到 `websocket.accept` 消息
+- 非 API/WebSocket 路径直接放行
+
+### 3. 不处理业务逻辑
+
+中间件严格限定在认证鉴权范畴，不涉及任何业务逻辑处理、数据转换或服务调用。
+
+## 实现细节
+
+### ASGI 中间件架构
+
+`AuthMiddleware` 实现为标准 ASGI 中间件，遵循 ASGI 规范：
+
+```python
+class AuthMiddleware:
+    """ASGI 中间件 — 在请求到达路由前完成鉴权，HTTP 和 WebSocket 统一处理。"""
+
+    def __init__(self, app):
+        self.app = app  # 下一层 ASGI 应用（FastAPI 路由）
+
+    async def __call__(self, scope, receive, send):
+        # 鉴权逻辑...
+        # 通过后继续传递请求到下一层
+        return await self.app(scope, receive, send)
+```
+
+### 请求处理流程
+
+```
+客户端请求
+    │
+    ▼
+AuthMiddleware.__call__(scope, receive, send)
+    │
+    ├── 1. 检查路径 scope["path"]
+    │      ├── 非 /api/* 且非 /ws/* → 直接放行
+    │      ├── /api/health → 直接放行（白名单）
+    │      └── 需要鉴权
+    │
+    ├── 2. 提取 Token (_extract_token)
+    │      ├── 通用路径: X-Sonetto-Token 请求头
+    │      └── WebSocket 专用: scope.subprotocols
+    │
+    ├── 3. 校验 Token
+    │      ├── 缺失或不匹配 → _reject()
+    │      │      ├── HTTP → 401 JSONResponse
+    │      │      └── WebSocket → 4001 websocket.close
+    │      └── 通过
+    │
+    ├── 4. WebSocket subprotocol 注入
+    │      ├── 拦截 websocket.accept 消息
+    │      └── 自动注入 subprotocol（前端传入的 Token）
+    │
+    └── 5. 放行到下一层
+           return await self.app(scope, receive, send)
+```
+
+### Token 校验机制
+
+Token 的来源有两个路径：
+
+| 来源 | 适用场景 | 提取方式 |
+|------|---------|----------|
+| `X-Sonetto-Token` 请求头 | HTTP API + WebSocket | `scope["headers"]` 中解析 `b"x-sonetto-token"` |
+| `Sec-WebSocket-Protocol` (subprotocols) | WebSocket 浏览器 | `scope["subprotocols"][0]`（ASGI server 自动解析） |
+
+Token 优先级：`X-Sonetto-Token` 请求头优先，WebSocket subprotocols 作为备选。校验方式为 **精确字符串匹配**，与 `app.state.auth_token` 对比。
+
+### 白名单机制
+
+当前白名单仅包含健康检查路径 `/api/health`，用于 Kubernetes 或 Docker 的健康探针免鉴权访问。
+
+## 设计要点
+
+### 无状态
+
+`AuthMiddleware` 是无状态的 —— 它不维护任何会话状态、缓存或连接池。每次请求独立鉴权，不存在会话污染风险。
+
+### 可组合
+
+ASGI 中间件遵循 `(scope, receive, send) → coroutine` 的通用接口，可以与其他 ASGI 中间件（如 CORS、GZip、TrustedHost）自由组合，唯一的依赖是下一层 `self.app`。
+
+### 不处理业务逻辑
+
+中间件的职责严格限定在认证鉴权范围：
+
+- 不做请求/响应体解析
+- 不调用下层服务（session manager、provider manager 等）
+- 不修改业务数据
+- 不记录审计日志（日志应在 application 层面处理）
+
+### 安全性考虑
+
+- 未经鉴权的 WebSocket 连接在握手阶段即被关闭（4001），不占用后续资源
+- Token 比较使用 `!=` 而非 `==` 以避免类型相关的意外行为（两者在 Python 中行为一致，但使用 `!=` 更明确地表达了预期结果）
+- `subprotocols` 注入避免前端重复协商协议，但对 `scope` 的修改仅限于 `send` 回调，不修改原始 `scope`
+
+## 关键代码片段
+
+### AuthMiddleware.__call__ 核心逻辑 (`auth.py`)
+
+```python
+class AuthMiddleware:
+    """ASGI 中间件 — 在请求到达路由前完成鉴权，HTTP 和 WebSocket 统一处理。"""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        path = scope.get("path", "")
+
+        # 仅保护 API 和 WebSocket 路径
+        if not path.startswith("/api/") and not path.startswith("/ws/"):
+            return await self.app(scope, receive, send)
+
+        # 白名单：健康检查
+        if path == "/api/health":
+            return await self.app(scope, receive, send)
+
+        # 提取并校验 Token
+        token = self._extract_token(scope)
+        app = scope.get("app")
+        expected = app.state.auth_token if app is not None else None
+
+        if not expected or token != expected:
+            return await self._reject(scope, receive, send)
+
+        # WebSocket 鉴权通过后：拦截 handler 的 websocket.accept 消息，
+        # 自动注入 subprotocol（前端通过 new WebSocket(url, [token]) 请求的协议），
+        # 业务 handler 无需感知 sub-protocol 协商细节。
+        if scope["type"] == "websocket":
+            protocols = scope.get("subprotocols", [])
+            if protocols:
+                original_send = send
+
+                async def _accept_with_subprotocol(message):
+                    if message.get("type") == "websocket.accept" and not message.get("subprotocol"):
+                        message = {**message, "subprotocol": protocols[0]}
+                    await original_send(message)
+
+                return await self.app(scope, receive, _accept_with_subprotocol)
+
+        return await self.app(scope, receive, send)
+```
+
+### Token 提取逻辑
+
+```python
+def _extract_token(self, scope) -> str:
+    """从请求头提取 Token。
+
+    HTTP / WebSocket 通用路径: X-Sonetto-Token 自定义头
+    WebSocket 专用路径: scope.subprotocols（由 ASGI server/uvicorn 从
+    Sec-WebSocket-Protocol 握手头部解析，前端通过 new WebSocket(url, [token])
+    传入）。优先使用 subprotocols 字段，比手动解析 raw header 更可靠。
+    """
+    headers = dict(scope.get("headers", []))
+
+    # 通用：X-Sonetto-Token 自定义头
+    token_bytes = headers.get(b"x-sonetto-token", b"")
+    if token_bytes:
+        return token_bytes.decode()
+
+    # WebSocket 专用：从 ASGI scope 的 subprotocols 字段提取
+    # ASGI server 在握手时自动解析 Sec-WebSocket-Protocol 头部，
+    # 存入 scope["subprotocols"] = [token]
+    if scope["type"] == "websocket":
+        protocols = scope.get("subprotocols", [])
+        if protocols:
+            return protocols[0]
+
+    return ""
+```
+
+### 拒绝响应逻辑
+
+```python
+async def _reject(self, scope, receive, send):
+    """根据 scope 类型返回 HTTP 401 或 WebSocket 4001 关闭。"""
+    if scope["type"] == "websocket":
+        await send({"type": "websocket.close", "code": 4001})
+    else:
+        response = JSONResponse(
+            {"detail": "Unauthorized — X-Sonetto-Token 缺失或不匹配"},
+            status_code=401,
+        )
+        await response(scope, receive, send)
+```
+
+## 设计约定评估
+
+| 原则 | 遵守情况 | 说明 |
+|------|---------|------|
+| 无状态 | 通过 | 中间件不维护任何状态，每次请求独立鉴权 |
+| 可组合 | 通过 | 标准 ASGI 中间件接口，可与其他中间件链式组合 |
+| 不处理业务逻辑 | 通过 | 仅做 Token 比对和路径放行 |
+| 从 app.state 读取配置 | 通过 | Token 通过 `app.state.auth_token` 获取，由启动时注入 |
+| 统一处理 HTTP 和 WebSocket | 通过 | 单一中间件覆盖两种协议，4001 和 401 分别对应 |
+
+暂无发现分层违规。中间件层严格遵循了关注点分离的原则，职责清晰，边界明确。

--- a/dev_docs/backend-architecture/providers-layer.md
+++ b/dev_docs/backend-architecture/providers-layer.md
@@ -1,0 +1,191 @@
+# 提供商抽象层 (providers/)
+
+## 层级定位
+
+**第⑤层 — LLM 提供商抽象层**。位于 Agent 编排层（第③层）之下，会话管理层与记忆层（第⑥层）之上。为上层 Agent 和 REST 接口提供统一的 LLM 提供商接入能力，屏蔽不同 API 厂商的差异。
+
+```
+③ Agent 编排层 ─────────────────────► ⑤ providers/  (create_llm / check_health)
+⑥ session/ + memory/ ───────────────► ⑤ providers/  (获取默认 LLM)
+```
+
+## 模块文件清单
+
+| 文件 | 职责 |
+|------|------|
+| `__init__.py` | Provider 抽象基类、ProviderConfig 与 HealthStatus 数据类定义 |
+| `manager.py` | ProviderManager — 按 id 索引，管理所有已注册 Provider 实例 |
+| `store.py` | ProviderConfigStore — `providers.yaml` 文件存储的 CRUD |
+| `openai_provider.py` | OpenAIProvider — OpenAI 兼容 API 的通用实现 |
+| `enrich.py` | 模型元数据并发检测入口 + `register()` 注册机制 |
+| `vision.py` | 模型视觉能力检测：`test_model_vision` / `detect_vision_if_available` |
+| `model_context_windows.py` | 从 OpenRouter API 拉取模型上下文窗口数据 |
+| `capabilities/` | 预留子包，待扩展 |
+
+## 职责描述
+
+### 1. LLM 提供商统一抽象
+
+通过 `Provider` 抽象基类定义所有提供商必须实现的接口，上层代码面向抽象编程，不依赖具体实现。
+
+```python
+# api/providers/__init__.py
+
+class Provider(ABC):
+    """所有 LLM 提供商必须实现的接口。"""
+
+    def __init__(self, config: ProviderConfig):
+        self.config = config
+
+    @property
+    def provider_name(self) -> str:
+        return self.config.id
+
+    @property
+    def default_model(self) -> str:
+        if self.config.default_model and self.config.default_model in self.config.models:
+            return self.config.default_model
+        return self.config.models[0] if self.config.models else ""
+
+    @property
+    def available_models(self) -> list[str]:
+        return self.config.models
+
+    @abstractmethod
+    def create_llm(self, model: str, **kwargs) -> BaseChatModel:
+        """根据指定模型名创建 LangChain ChatModel 实例。"""
+        ...
+
+    @abstractmethod
+    async def check_health(self) -> HealthStatus:
+        """验证提供商 API 连接是否正常。"""
+        ...
+```
+
+### 2. 多模型支持与动态发现
+
+`ProviderConfig` 的数据模型设计支持一个 Provider 下挂多个模型，`ProviderManager` 负责按 id 索引并提供查询接口。
+
+### 3. 连接测试与健康检测
+
+每轮健康检测通过 `AsyncOpenAI.client.models.list()` 执行真实 API 调用，返回状态（ok/error）和延迟（ms）。
+
+```python
+# api/providers/openai_provider.py
+
+class OpenAIProvider(Provider):
+    def create_llm(self, model: str, **kwargs) -> BaseChatModel:
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(
+            model=model,
+            api_key=self.config.api_key,
+            base_url=self.config.base_url,
+            **kwargs,
+        )
+
+    async def check_health(self) -> HealthStatus:
+        import time
+        from openai import AsyncOpenAI
+        start = time.monotonic()
+        try:
+            client = AsyncOpenAI(
+                api_key=self.config.api_key,
+                base_url=self.config.base_url,
+            )
+            await client.models.list()
+            elapsed = (time.monotonic() - start) * 1000
+            return HealthStatus(status="ok", latency_ms=round(elapsed, 1))
+        except Exception as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            return HealthStatus(status="error", latency_ms=round(elapsed, 1), detail=str(exc))
+```
+
+### 4. 模型能力检测
+
+视觉能力和上下文窗口的检测以 **enrichment 注册机制** 实现：
+
+```python
+# api/providers/enrich.py
+
+_registry: list[Callable[[ProviderConfig], object]] = []
+
+def register(func: Callable[[ProviderConfig], object]) -> None:
+    """注册一个 enrichment 函数，入参为 ProviderConfig，原地修改。"""
+    _registry.append(func)
+
+# 注册内置 enrichment
+register(detect_vision_if_available)
+register(fill_missing_context_windows)
+
+async def enrich_provider_config(config: ProviderConfig) -> None:
+    """并发执行所有已注册的 enrichment 函数。"""
+    await asyncio.gather(*(f(config) for f in _registry))
+```
+
+视觉检测逻辑：向模型发送一张含 "Sonetto" 文字的测试图片，要求模型读出文字，若响应包含 "Sonetto" 则判定为有视觉能力。
+
+上下文窗口检测逻辑：从 OpenRouter /api/v1/models 拉取全量数据，按精确匹配 → 后缀匹配 → 子串匹配的优先级补充缺失值。OpenRouter 是唯一数据源，无硬编码兜底。
+
+## 设计要点
+
+### 策略模式
+
+`Provider` 抽象基类定义了策略接口，`OpenAIProvider` 是策略的具体实现。`ProviderManager._build_provider` 充当策略工厂，根据 `config.provider_type` 实例化对应的策略。
+
+```python
+@staticmethod
+def _build_provider(config: ProviderConfig) -> Provider:
+    if config.provider_type == "openai":
+        from api.providers.openai_provider import OpenAIProvider
+        return OpenAIProvider(config)
+    msg = f"Unknown provider type: {config.provider_type}"
+    raise ValueError(msg)
+```
+
+### 开放封闭原则
+
+- **扩展（开放）**：新增提供商只需实现 `Provider` 抽象类，并在 `_build_provider` 工厂中添加一条分支。
+- **封闭（封闭）**：上层代码（Agent 编排、REST 路由）通过 `ProviderManager.create_llm()` 或 `ProviderManager.get_default_llm()` 获取 LLM，无需感知具体 Provider 类型。
+- **enrichment 机制**：新增元数据检测能力只需 `@register` 装饰一个 `(ProviderConfig) -> object` 函数，核心代码无需修改。
+
+### 动态检测
+
+每次保存/更新提供商配置时，`enrich_provider_config` 自动并发执行：
+- 视觉能力检测（每个模型独立测试）
+- 上下文窗口补全（从 OpenRouter 拉取）
+
+所有检测结果原地填充到 `ProviderConfig` 的 `model_vision` 和 `model_context_windows` 字段。
+
+## 扩展性评估
+
+### 添加一个新的 Provider 类型
+
+**修改文件数：2~3 个**
+
+| 步骤 | 文件 | 操作 |
+|------|------|------|
+| 1 | `api/providers/my_provider.py` | **新增**，实现 `class MyProvider(Provider)`，实现 `create_llm` 和 `check_health` |
+| 2 | `api/providers/manager.py` | **修改** `_build_provider` 工厂，添加 `elif config.provider_type == "my_type":` 分支 |
+| 3 | （可选）`api/providers/enrich.py` | 若需自定义 enrichment，注册新函数 |
+
+**完整流程**：
+1. 创建新文件实现 `Provider` 接口
+2. 在 `_build_provider` 工厂注册映射
+3. 配置 `providers.yaml` 中设置 `provider_type: "my_type"`
+4. 重启或调用 reload 即可生效
+
+### 添加一个新的 enrichment 能力
+
+**修改文件数：1 个**（仅需在任意文件中定义并用 `register()` 装饰，无需修改核心代码）
+
+### 设计约定评估
+
+**发现的分层违规**：
+
+1. **工厂硬编码**：`ProviderManager._build_provider` 中的 provider_type → 实现类的映射是硬编码的。理想情况下应通过注册表机制（如 `register_provider_type("openai", OpenAIProvider)`）实现，使新增提供商时无需修改 `manager.py`。当前设计违背了开放封闭原则的"封闭"要求。
+
+2. **Vision 检测直接实例化**：`vision.py` 中的 `detect_vision_capabilities` 硬编码 `OpenAIProvider(config)`，绕过工厂方法。若新增非 OpenAI 的 Provider 类型，视觉检测逻辑需要更新来适配。
+
+**改进建议**：
+- 在 `Provider` 基类中添加类方法或注册机制，使 `_build_provider` 变为动态查找。
+- `vision.py` 应从 `ProviderManager` 获取 Provider 实例，而非直接 `import OpenAIProvider`。

--- a/dev_docs/backend-architecture/routes-layer.md
+++ b/dev_docs/backend-architecture/routes-layer.md
@@ -1,0 +1,403 @@
+# 路由层 (routes/) — 第②层
+
+## 层级定位
+
+路由层是后端分层架构中的 **第②层**，位于中间件层之下、Agent 编排层之上。它负责 **HTTP 请求分发与 WebSocket 事件派发**，本身不包含业务逻辑，仅作为将客户端请求路由到下层服务的薄胶合层。
+
+```
+HTTP / WebSocket 客户端
+       │
+       ▼
+┌──────────────────────┐
+│ ① 中间件层 (middleware) │  ← 认证鉴权
+├──────────────────────┤
+│ ② 路由层 (routes)     │  ← 请求分发（当前模块）
+├──────────────────────┤
+│ ③ Agent 编排层        │  ← 业务逻辑
+└──────────────────────┘
+```
+
+## 模块文件清单
+
+`api/routes/` 目录下共 **15 个路由模块**（不含 `__init__.py`），按功能分类如下：
+
+| 文件 | 职责 | 端点类型 |
+|------|------|----------|
+| `chat.py` | WebSocket 主端点：连接管理、事件派发（ping, chat, user_response, cancel, update_auto_approve） | WebSocket |
+| `sessions.py` | 会话 CRUD、Const 固定会话、撤回 (undo)、上下文用量查询、标题生成 | REST |
+| `providers.py` | LLM 提供商 CRUD、连接测试、模型发现 | REST |
+| `memory.py` | 长期记忆叙事获取、记忆分组列表、随机 moment | REST |
+| `persona.py` | 人设文件 (SOUL.md / USER.md) 读写 | REST |
+| `env_vars.py` | 工具环境变量管理 (.env 文件读写) | REST |
+| `files.py` | 本地文件选择对话框 (tkinter) | REST |
+| `images.py` | 本地图片文件提供（含安全策略校验） | REST |
+| `mcp.py` | MCP 服务器配置查看与热加载 | REST |
+| `news.py` | 系统更新动态列表 | REST |
+| `balance.py` | DeepSeek 余额查询 | REST |
+| `path_whitelist.py` | 路径白名单 CRUD 与路径安全检查 | REST |
+| `restart.py` | 后端进程重启 | REST |
+| `skills.py` | Anthropic Skills / Macros / 内置工具列表 | REST |
+| `sonetto_blocker.py` | 拒止锚 (SonettoBlocker) 管理（创建/删除标记文件） | REST |
+
+### 各文件详细说明
+
+#### `chat.py` — WebSocket 聊天端点
+
+WebSocket 连接的生命周期管理核心文件。定义了 `websocket_chat` 端点 (`/ws/chat/{session_id}`)，职责包括：
+
+1. **连接初始化**：接受 WebSocket、获取/创建会话、注册 WebSocket 到注册表
+2. **推送初始上下文用量**：估算当前会话的 token 占用并推送给前端
+3. **断线重连恢复**：若会话有未完成的 sub-agent 任务则自动恢复执行
+4. **消息主循环**：通过字典派发 (`_HANDLERS`) 将消息分发给对应的事件处理器
+
+支持的事件类型：
+
+| 事件 | 处理器 | 功能 |
+|------|--------|------|
+| `ping` | `_handle_ping` | 心跳保活，回复 `pong` |
+| `chat` | `_handle_chat` | 创建 Agent 轮次，启动 `run_agent_turn` 异步任务 |
+| `user_response` | `_handle_user_response` | 处理用户对 Agent 交互请求的响应 |
+| `cancel` | `_handle_cancel` | 取消正在运行的 Agent 任务 |
+| `update_auto_approve` | `_handle_update_auto_approve` | 更新自动批准设置 |
+
+#### `sessions.py` — 会话管理
+
+提供完整的会话 CRUD 操作及高级功能：
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/sessions` | POST | 创建新会话 |
+| `/sessions` | GET | 列出所有会话 |
+| `/sessions/{session_id}` | GET | 获取单个会话详情 |
+| `/sessions/{session_id}/messages` | GET | 获取会话消息历史 |
+| `/sessions/{session_id}` | DELETE | 删除会话（const 会话同时清理磁盘） |
+| `/sessions/{session_id}/undo` | POST | 撤回最近 N 轮对话 |
+| `/sessions/{session_id}/context-usage` | GET | 查询上下文用量 |
+| `/sessions/{session_id}/const` | POST | 将会话固定为 const 持久化 |
+| `/sessions/{session_id}/const` | DELETE | 取消固定，删除 const 磁盘文件 |
+| `/sessions/{session_id}/generate-title` | POST | 使用 LLM 生成会话标题 |
+
+#### `providers.py` — LLM 提供商管理
+
+完整的提供商配置生命周期管理：
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/providers` | GET | 列出所有提供商 |
+| `/providers/{provider_id}` | GET | 获取单个提供商配置 |
+| `/providers` | POST | 新增提供商（含模型元数据自动填充） |
+| `/providers/{provider_id}` | PUT | 更新提供商配置 |
+| `/providers/{provider_id}` | DELETE | 删除提供商 |
+| `/providers/test` | POST | 测试任意凭据的连接 |
+| `/providers/{provider_id}/test` | POST | 测试已保存提供商的连接 |
+| `/providers/discover-models` | POST | 根据凭据拉取模型列表 |
+| `/providers/{provider_id}/discover-models` | POST | 拉取并更新已保存提供商的模型列表 |
+
+新增/更新提供商后会调用 `_refresh_app_llm` 刷新应用全局 LLM 实例，并同步长期记忆 (LTM) 消费者的启停。
+
+#### `memory.py` — 长期记忆
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/narrative` | GET | 获取当前叙事文本 |
+| `/memories` | GET | 获取按主题分组的记忆列表 |
+| `/moment` | GET | 随机获取一条记忆 moment（含描述历史） |
+
+#### `persona.py` — 人设文件
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/persona` | GET | 读取 SOUL.md 或 USER.md 内容 |
+| `/persona` | PUT | 写入 SOUL.md 或 USER.md 内容 |
+
+#### `env_vars.py` — 环境变量管理
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/env-vars` | GET | 列出所有已知环境变量（值脱敏显示） |
+| `/env-vars` | PUT | 更新单个环境变量并持久化到 .env |
+| `/env-vars/batch` | PUT | 批量更新多个环境变量 |
+
+更新后通过 `importlib.reload` 刷新运行时配置。
+
+#### `files.py` — 文件选择对话框
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/select-file` | GET | 打开系统原生文件选择对话框（tkinter），返回所选路径 |
+
+仅在本地开发环境可用。
+
+#### `images.py` — 图片文件服务
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/images/serve` | GET | 根据绝对路径返回图片文件（含安全策略校验） |
+
+安全策略包括：限制常见图片扩展名、SonettoBlocker 拒止锚检查、路径白名单检查。
+
+#### `mcp.py` — MCP 服务器管理
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/mcp/servers` | GET | 返回所有已配置的 MCP 服务器信息 |
+| `/mcp/reload` | POST | 热加载 MCP 配置：重新解析 YAML、重建连接、替换工具列表 |
+
+热加载失败时保留旧工具列表不变。
+
+#### `news.py` — 系统更新动态
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/news` | GET | 返回所有更新动态（按日期降序排列） |
+
+#### `balance.py` — 余额查询
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/deepseek-balance` | GET | 查询 DeepSeek 账户余额 |
+
+通过扫描已配置的提供商列表，自动查找 base_url 包含 `deepseek.com` 的提供商并使用其 API Key。
+
+#### `path_whitelist.py` — 路径白名单
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/path-whitelist` | GET | 列出所有白名单条目 |
+| `/path-whitelist` | POST | 添加白名单条目 |
+| `/path-whitelist/{index}` | PUT | 更新指定索引的白名单条目 |
+| `/path-whitelist/{index}` | DELETE | 删除指定索引的白名单条目 |
+| `/check-path-blocked` | GET | 检查路径是否被拒止锚或白名单阻挡 |
+
+#### `restart.py` — 后端重启
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/restart` | POST | 启动新后端进程后优雅退出当前进程 |
+
+通过 `subprocess.Popen` 启动新进程，然后 `sys.exit(0)` 触发 FastAPI lifespan shutdown。
+
+#### `skills.py` — 技能与工具列表
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/skills` | GET | 扫描 `anthropic_skills/` 目录，返回所有 SKILL.md 的结构化列表 |
+| `/macros` | GET | 扫描 `macros/` 目录，返回所有 MACRO.md 的结构化列表 |
+| `/tools` | GET | 返回所有已加载的内置工具（native_tools + mcp_tools） |
+
+#### `sonetto_blocker.py` — 拒止锚管理
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/sonetto-blocker` | GET | 列出所有拒止锚条目 |
+| `/sonetto-blocker` | POST | 添加拒止锚（在目标目录创建标记文件） |
+| `/sonetto-blocker/{index}` | DELETE | 删除拒止锚（移除标记文件和持久化记录） |
+
+## 职责描述
+
+路由层的核心职责限定为以下三点：
+
+### 1. 解析 HTTP/WebSocket 请求参数
+
+- 从 FastAPI 的路径参数、Query 参数、Request body 中提取客户端传入的数据
+- 使用 Pydantic 模型 (`BaseModel` 子类) 进行请求体验证与类型转换
+- WebSocket 消息通过 `json.loads` 解析为字典后按 `type` 字段派发
+
+### 2. 调用下层服务
+
+- 通过 `request.app.state` 获取全局单例（session manager、provider manager、LTM 等）
+- 调用下层服务的公开方法执行业务逻辑
+- 路由函数本身不包含业务逻辑实现，仅作为编排入口
+
+### 3. 序列化响应并返回
+
+- 将下层服务的返回值转换为 Pydantic response 模型或字典
+- 处理异常情况（如资源不存在返回 404、冲突返回 409、服务不可用返回 503）
+- WebSocket 消息通过 `ws.send_json()` 推送 JSON 格式响应
+
+## 数据流
+
+### REST 请求流程
+
+```
+客户端 HTTP 请求
+       │
+       ▼
+AuthMiddleware (①) ─── Token 校验 ─── 失败 → 401 JSONResponse
+       │ 通过
+       ▼
+FastAPI Router ─── 路径匹配 → 路由处理函数
+       │
+       ▼
+路由函数:
+  1. 通过 request.app.state 获取下层服务
+  2. 调用下层服务方法
+  3. 返回 Pydantic 模型 / 字典
+       │
+       ▼
+FastAPI 自动序列化为 JSON 响应 → 客户端
+```
+
+### WebSocket 消息流程
+
+```
+客户端 WebSocket 连接 → /ws/chat/{session_id}
+       │
+       ▼
+AuthMiddleware ─── Token 校验 ─── 失败 → 4001 close
+       │ 通过
+       ▼
+chat.py: websocket_chat()
+  1. ws.accept() — 接受连接
+  2. 获取/创建 SessionState
+  3. 注册 ws_registry
+  4. 推送初始 context_usage
+  5. 断线重连时恢复 sub-agent
+       │
+       ▼
+消息主循环 (while True):
+  ws.receive_text() → json.loads(msg)
+       │
+       ├── type="ping"    → _handle_ping    → 回复 pong
+       ├── type="chat"    → _handle_chat    → 创建 asyncio.Task → run_agent_turn
+       ├── type="user_response" → _handle_user_response → interaction.resolve()
+       ├── type="cancel"  → _handle_cancel  → agent_task.cancel()
+       └── type="update_auto_approve" → _handle_update_auto_approve → 更新设置
+       │
+       ▼ (chat 事件)
+Agent 编排层 — run_agent_turn()
+       │
+       ├── Provider (LLM 调用)
+       ├── Callbacks (WebSocket 事件推送)
+       └── Session (消息持久化)
+```
+
+## 设计约定
+
+### 分层边界原则
+
+| 原则 | 说明 | 遵守情况 |
+|------|------|----------|
+| 路由不包含业务逻辑 | 路由函数应仅为薄胶合层，业务逻辑委托给下层服务 | 基本遵守 |
+| 路由不直接操作 LLM | LLM 调用应通过 agent 层或 provider 层进行 | 基本遵守（`generate-title` 通过 `ProviderManager` 获取 LLM） |
+| 路由不直接操作文件系统 | 文件读写应封装在专门的 service/store 层 | **部分违反**（见下文） |
+| 路由不直接操作数据库 | 数据库操作应通过 session/memory 层 | 无不涉及数据库 |
+
+### 已识别的分层违规
+
+在审阅代码时发现以下 **分层违规** 情况，路由层直接操作了文件系统或系统调用：
+
+#### 违规 1: 路由直接读写文件
+
+以下路由模块直接使用 `Path.read_text()` / `Path.write_text()` 或 YAML 文件 API 操作持久化存储：
+
+- `persona.py` — 直接读写 `config/personas/SOUL.md` 和 `USER.md`
+- `env_vars.py` — 直接通过 `dotenv.set_key()` 写入 `.env` 文件
+- `path_whitelist.py` — 直接读写 `config/path_whitelist.yaml`
+- `sonetto_blocker.py` — 直接读写 `config/sonetto_blocker.yaml` 并创建/删除文件系统标记文件
+- `news.py` — 直接读取 `api/data/news.yaml`
+
+**改进建议**：将这些文件操作抽取为独立的 service 模块（如 `services/persona_service.py`、`services/env_service.py`），路由层仅调用 service 接口。
+
+#### 违规 2: 路由直接启动子进程
+
+- `restart.py` — 直接在路由函数中调用 `subprocess.Popen` 和 `sys.exit(0)`
+- `files.py` — 直接在路由函数中调用 `tkinter.filedialog`（该操作本质上是 GUI 系统调用）
+
+**改进建议**：将进程管理逻辑封装在 `core/` 层的服务中，路由层仅暴露端点。
+
+#### 违规 3: 路由直接使用第三方 HTTP 客户端
+
+- `balance.py` — 直接在路由函数中使用 `httpx.AsyncClient` 调用 DeepSeek API
+
+**改进建议**：将 HTTP 请求封装到服务层（如 `services/balance_service.py`），路由层调用服务接口。
+
+#### 违规 4: 路由处理复杂业务逻辑
+
+- `sessions.py` — `generate_title` 函数中包含大量 prompt 拼接逻辑、LLM 调用异常处理、响应解析逻辑
+
+**改进建议**：将标题生成逻辑抽取为独立的 service 函数，路由层仅调用 `generate_session_title(session)`。
+
+## 关键代码片段
+
+### WebSocket 事件派发核心逻辑 (`chat.py`)
+
+以下是 WebSocket 消息主循环和基于字典的事件派发机制：
+
+```python
+# 事件处理器注册表
+_HANDLERS: dict[str, Handler] = {}
+
+def ws_event_handler(event_type: str):
+    """装饰器：将 handler 函数注册到 _HANDLERS 字典。"""
+    def decorator(func):
+        _HANDLERS[event_type] = func
+        return func
+    return decorator
+
+# ── 消息主循环（字典派发） ─────────────────────────────
+# （位于 websocket_chat 函数内）
+try:
+    while True:
+        raw = await ws.receive_text()
+        msg = json.loads(raw)
+
+        handler = _HANDLERS.get(msg.get("type", ""))
+        if handler is not None:
+            agent_task = await handler(
+                ws, session_id, session, agent_task, msg, app_state
+            )
+
+except WebSocketDisconnect:
+    pass  # 客户端断开是正常行为
+finally:
+    app_state.ws_registry.unregister(session_id)
+    if agent_task is not None and not agent_task.done():
+        agent_task.cancel()
+    session.clear_active_task()
+    interaction.clear_session_settings(session_id)
+```
+
+关键设计特点：
+
+- **装饰器注册模式**：通过 `@ws_event_handler("type")` 将处理函数注册到 `_HANDLERS` 字典，新增事件类型只需添加新的 handler 函数
+- **统一签名**：所有 handler 接收相同参数签名 `(ws, session_id, session, agent_task, msg, app_state)`，返回更新后的 `agent_task`
+- **Agent 任务单例**：对话轮次通过 `asyncio.create_task` 启动，由 `session.set_active_task()` 跟踪，保证同时只有一个 Agent 任务在运行
+
+### 典型 REST 处理函数 (`sessions.py`)
+
+以创建会话端点为例，展示 REST 路由的标准模式：
+
+```python
+@router.post("/sessions")
+async def create_session(request: Request):
+    sm = request.app.state.session_manager
+    session = sm.create()
+    return {"session_id": session.session_id, "created_at": session.created_at}
+```
+
+以获取会话端点为例，展示含错误处理的模式：
+
+```python
+@router.get("/sessions/{session_id}")
+async def get_session(session_id: str, request: Request):
+    sm = request.app.state.session_manager
+    session = sm.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return {
+        "session_id": session.session_id,
+        "message_count": session.message_count,
+        "created_at": session.created_at,
+        "has_active_agent": session.has_active_task(),
+        "is_const": session.is_const,
+        "const_name": session.const_name,
+    }
+```
+
+模式总结：
+
+1. 通过 `request.app.state` 获取全局服务实例
+2. 调用服务方法（`sm.get()`, `sm.create()` 等）
+3. 对 None 结果返回 404 HTTPException
+4. 返回字典或 Pydantic 模型作为响应

--- a/dev_docs/backend-architecture/session-layer.md
+++ b/dev_docs/backend-architecture/session-layer.md
@@ -1,0 +1,243 @@
+# 会话管理层 — `api/session/`
+
+## 层级定位
+
+| 属性 | 值 |
+|---|---|
+| **层级编号** | 第 6 层 |
+| **层级名称** | 会话管理层 |
+| **依赖方向** | 不依赖上层业务模块（agent / routes / providers），仅依赖第三方库和 Python 标准库 |
+| **被依赖者** | agent 编排层、routes 路由层、memory 回调层、server 启动脚本 |
+
+```
+⑤ 提供商抽象层 (providers/)
+      ↑ 依赖
+⑥ 会话管理层 (session/)  +  长期记忆层 (memory/)
+      ↑ 依赖
+⑦ 核心基础设施层 (core/)  +  数据资源层 (data/)
+```
+
+## 模块文件清单
+
+| 文件 | 核心类型/函数 | 职责 |
+|---|---|---|
+| `manager.py` | `SessionState` / `SessionManager` | 会话状态管理：多会话隔离 + TTL 过期清理 |
+| `const_store.py` | `save_const_session` / `delete_const_session` / `serialize_messages` | Const 固定会话 YAML 持久化 |
+| `ws_registry.py` | `WebSocketRegistry` | WebSocket 连接注册表 |
+
+## 职责描述
+
+- **会话生命周期管理**：创建、获取、删除运行时会话，维护 `SessionState` 中的 Agent 编译图、检查点、消息计数等运行时状态
+- **TTL 过期清理**：定期扫描并清理超过 TTL 阈值（默认 1800 秒）未活跃的会话
+- **WebSocket 连接跟踪**：维护 session_id 到 WebSocket 连接的映射，供回调层向指定会话推送事件
+- **固定会话持久化**：将会话元数据和对话消息序列化为 YAML 文件，支持保存、加载、删除
+
+## 关键代码片段
+
+### SessionManager 核心方法（manager.py）
+
+```python
+class SessionManager:
+    def __init__(self, ttl_seconds: int = 1800):
+        self._sessions: dict[str, SessionState] = {}
+        self._ttl = ttl_seconds
+
+    def create(self) -> SessionState:
+        """创建新会话并注册。"""
+        session_id = uuid.uuid4().hex
+        session = SessionState(session_id=session_id)
+        self._sessions[session_id] = session
+        return session
+
+    def get(self, session_id: str) -> SessionState | None:
+        """获取会话，同时更新 last_active 时间戳。"""
+        session = self._sessions.get(session_id)
+        if session is not None:
+            session.last_active = time.time()
+        return session
+
+    def get_or_create(self, session_id: str) -> SessionState:
+        """获取或创建（幂等）。"""
+        session = self.get(session_id)
+        if session is None:
+            session = SessionState(session_id=session_id)
+            self._sessions[session_id] = session
+        return session
+
+    def delete(self, session_id: str) -> bool:
+        """删除指定会话。"""
+        if session_id in self._sessions:
+            del self._sessions[session_id]
+            return True
+        return False
+
+    def cleanup_expired(self) -> int:
+        """清理所有过期会话，返回清理数量。"""
+        now = time.time()
+        expired = [
+            sid for sid, s in self._sessions.items()
+            if now - s.last_active > self._ttl
+        ]
+        for sid in expired:
+            del self._sessions[sid]
+        return len(expired)
+```
+
+#### SessionState 数据结构
+
+```python
+@dataclass
+class SessionState:
+    session_id: str
+    created_at: float
+    last_active: float
+    message_count: int
+    _active_task: asyncio.Task | None         # 当前正在运行的 Agent 任务
+    checkpointer: MemorySaver                  # LangGraph 检查点（支持 undo/重放）
+    _graph: CompiledStateGraph | None          # 缓存的 Agent 编译图
+    auto_approve: bool
+
+    # Sub-agent 字段
+    is_subagent: bool
+    parent_session_id: str | None
+    _sub_agent_task: str | None
+    _pending_result: asyncio.Future | None
+
+    # Const 固定会话字段
+    is_const: bool
+    const_name: str
+```
+
+### WebSocketRegistry 注册表（ws_registry.py）
+
+```python
+class WebSocketRegistry:
+    """协程安全的 WebSocket 注册表。
+
+    在 websocket_chat() accept 后 register，断开时 unregister。
+    所有操作在单线程事件循环中执行，无需加锁。
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, WebSocket] = {}
+
+    def register(self, session_id: str, ws: WebSocket) -> None:
+        """注册 session_id → WebSocket 映射。"""
+        self._sessions[session_id] = ws
+
+    def unregister(self, session_id: str) -> None:
+        """移除 session_id 的映射。"""
+        self._sessions.pop(session_id, None)
+
+    def get(self, session_id: str) -> WebSocket | None:
+        """获取指定 session_id 的 WebSocket，不存在时返回 None。"""
+        return self._sessions.get(session_id)
+```
+
+## 被依赖关系
+
+| 上层模块 | 依赖内容 | 用途 |
+|---|---|---|
+| `api/server.py` | `SessionManager`、`WebSocketRegistry`、`const_store` 函数 | 应用启动时初始化会话管理器、注册表 |
+| `api/routes/chat.py` | `SessionState` | WebSocket 聊天端点获取/创建会话 |
+| `api/routes/sessions.py` | `const_store`（`flatten_content`、`save_const_session`、`delete_const_session`） | REST API：固定会话 CRUD |
+| `api/agent/turn.py` | `SessionState`、`const_store`（`save_const_session`、`serialize_messages`） | Agent 轮次结束时持久化固定会话 |
+| `api/agent/context_usage.py` | `SessionState` | Agent 上下文用量追踪 |
+| `api/memory/callback.py` | `WebSocketRegistry` | LangChain 回调中通过注册表推送事件到前端 |
+| `api/memory/narrative.py` | `SessionState`、`WebSocketRegistry` | 叙事生成时广播事件 |
+
+## 设计要点
+
+### 1. 线程安全
+
+- `SessionManager` 和 `WebSocketRegistry` 均在单线程 asyncio 事件循环中运行，`dict` 操作天然协程安全，无需显式加锁
+- `SessionState` 使用 `dataclass` 不可变默认值，可变字段（`_active_task`、`_pending_result`等）通过封装方法访问，避免外部直接修改内部状态
+
+### 2. TTL 过期策略
+
+```python
+def cleanup_expired(self) -> int:
+    now = time.time()
+    expired = [
+        sid for sid, s in self._sessions.items()
+        if now - s.last_active > self._ttl
+    ]
+    for sid in expired:
+        del self._sessions[sid]
+    return len(expired)
+```
+
+- 默认 TTL：1800 秒（30 分钟），在 `SessionManager.__init__` 中配置
+- 过期判定：`last_active > ttl`，每次 `get()` 调用会自动刷新 `last_active`
+- 惰性清理策略：`cleanup_expired()` 不由定时器触发，而是在请求路径中按需调用（如 `list_sessions` 时附带清理）
+
+### 3. 惰性清理
+
+清理并非主动后台任务，而是由上层调用方在适当的时机触发：
+
+- 会话列表查询时附带一次过期清理
+- 创建新会话时检查整体会话数量上限（若需）
+- 避免引入额外的后台调度复杂性
+
+### 4. 固定会话持久化（const_store.py）
+
+```python
+def serialize_messages(raw_messages: list) -> list[dict]:
+    """将 LangChain BaseMessage 对象转为可序列化的纯 dict 列表。"""
+    ...
+
+def save_const_session(session_id, const_name, metadata, messages) -> str:
+    """将会话持久化为 YAML 文件。"""
+    ...
+
+def delete_const_session(session_id: str) -> bool:
+    """删除 const 会话文件。"""
+    ...
+```
+
+- 序列化路径：`LangChain BaseMessage` → `serialize_messages()` → `dict` → `yaml.dump()` → YAML 文件
+- 存储位置：`api/data/const-sessions/{session_id}.yaml`
+- 路径安全性：通过 `_validate_session_id()` 阻止路径遍历攻击
+
+### 5. Sub-agent 机制
+
+`SessionState` 内建对子 Agent 的支持：
+
+- `is_subagent` / `parent_session_id`：标识子会话及其父会话
+- `_pending_result`：`asyncio.Future`，用于父会话等待子会话的异步结果
+- `_sub_agent_task`：存储子 Agent 任务描述，供消费
+
+## 设计约定评估
+
+### 违规 1：ws_registry.py 反向耦合 HTTP 传输对象
+
+```python
+from fastapi import WebSocket  # ws_registry.py 第 3 行
+
+
+class WebSocketRegistry:
+    def __init__(self) -> None:
+        self._sessions: dict[str, WebSocket] = {}  # 存储 FastAPI WebSocket 对象
+```
+
+**问题**：会话管理层（第⑥层）内部直接存储了 `fastapi.WebSocket` 对象。`WebSocket` 是 HTTP/WebSocket 传输层（框架级）的具体类型，将传输对象存储在状态管理层中，造成了以下后果：
+
+- 会话管理层与 FastAPI 框架耦合，难以替换或升级 Web 框架
+- 单元测试时需要 mock FastAPI WebSocket 对象
+- 该注册表的本质是"会话 ID → 推送通道"的抽象映射，不应暴露传输层细节
+
+**改进建议**：
+
+1. **接口抽象**：在 `session/` 中定义抽象的 `EventPublisher` 协议（Protocol），只暴露 `send_json()` / `send_text()` 方法，在路由层实现 FastAPI `WebSocket` 适配器
+2. **泛型设计**：将 `WebSocketRegistry` 改造为泛型注册表 `Registry[SessionId, Connection]`，不关心具体连接类型
+3. **最小化方案**：在 `ws_registry.py` 中对 `WebSocket` 的使用限定为只调用 `send_json()` 等方法，避免直接操作底层 ASGI 接口
+
+### 检查通过项
+
+| 检查项 | 结果 |
+|---|---|
+| `manager.py` 是否导入上层业务模块（routes / agent / providers）？ | 通过 — 仅依赖 `langgraph`、`asyncio`、标准库 |
+| `const_store.py` 是否导入上层业务模块？ | 通过 — 仅依赖 `yaml`、`pathlib`、标准库 |
+| `ws_registry.py` 是否导入 `api.routes` 或 `api.agent`？ | 通过 — 仅导入 `fastapi.WebSocket`（属框架级别，非业务模块） |
+| 会话层是否包含 HTTP 请求处理逻辑？ | 通过 — 无 `Request` / `Response` 处理逻辑 |
+| 会话层的 TTL 清理是否依赖定时器框架？ | 通过 — 纯惰性清理，无后台调度 |


### PR DESCRIPTION
为后端所有 9 个模块创建架构层级文档, 按 7 层架构组织: middleware → routes → agent → callbacks → providers → memory/session → core/data

每份文档包含层级定位、文件清单、关键代码、数据流和设计约定评估。