### PR TITLE
refactor(session): 将 SessionState 字段拆分为多个子数据类

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -147,7 +147,6 @@ async def _handle_update_auto_approve(
     interaction.set_session_auto_approve(
         session_id, msg["payload"]["auto_approve"]
     )
-    session.auto_approve = msg["payload"]["auto_approve"]
     return agent_task
 
 @router.websocket("/ws/chat/{session_id}")

--- a/api/session/manager.py
+++ b/api/session/manager.py
@@ -10,28 +10,27 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph.state import CompiledStateGraph
 
 
+# ── 子数据类：会话元信息 ──────────────────────────────────────────
+
 @dataclass
-class SessionState:
+class SessionMeta:
+    """会话基础元信息：标识、创建/活动时间、消息计数。"""
     session_id: str
-    created_at: float = field(default_factory=time.time)
-    last_active: float = field(default_factory=time.time)
+    created_at: float
+    last_active: float
     message_count: int = 0
+
+
+# ── 子数据类：Agent 运行时 ────────────────────────────────────────
+
+@dataclass
+class AgentRuntime:
+    """Agent 运行时状态：活动任务、检查点、编译图。"""
     _active_task: asyncio.Task | None = field(default=None, repr=False)
     checkpointer: MemorySaver = field(default_factory=MemorySaver)
     _graph: CompiledStateGraph | None = field(default=None, repr=False)
-    # ── Sub-agent 字段 ─────────────────────────────────────
-    is_subagent: bool = False
-    _sub_agent_task: str | None = field(default=None, repr=False)
-    _pending_result: asyncio.Future | None = field(default=None, repr=False)
 
-    # ── WebSocket 引用 ──────────────────────────────────────
-    ws: WebSocket | None = field(default=None, repr=False)
-
-    # ── Const 固定会话字段 ──────────────────────────────────
-    is_const: bool = False
-    const_name: str = ""
-
-    # ── _graph 封装 ────────────────────────────────────────────
+    # ── _graph 封装 ─────────────────────────────────────────
     def get_graph(self) -> CompiledStateGraph | None:
         """返回缓存的 Agent 编译图，未构建时返回 None。"""
         return self._graph
@@ -40,7 +39,7 @@ class SessionState:
         """缓存 Agent 编译图（供 undo/重放使用）。"""
         self._graph = graph
 
-    # ── _active_task 封装 ──────────────────────────────────────
+    # ── _active_task 封装 ───────────────────────────────────
     def has_active_task(self) -> bool:
         """Agent 是否正在运行（协程未完成）。"""
         return self._active_task is not None and not self._active_task.done()
@@ -58,18 +57,17 @@ class SessionState:
         if self._active_task is not None and not self._active_task.done():
             self._active_task.cancel()
 
-    # ── _sub_agent_task 封装 ───────────────────────────────────
-    def has_sub_agent_task(self) -> bool:
-        """是否有子 Agent 任务描述待消费。"""
-        return self._sub_agent_task is not None
 
-    def consume_sub_agent_task(self) -> str | None:
-        """消费子 Agent 任务描述（一次性取出并清空）。"""
-        task = self._sub_agent_task
-        self._sub_agent_task = None
-        return task
+# ── 子数据类：Sub-agent 状态 ──────────────────────────────────────
 
-    # ── _pending_result 封装 ───────────────────────────────────
+@dataclass
+class SubAgentData:
+    """Sub-agent 会话状态：标记、任务描述、异步 Future。"""
+    is_subagent: bool = False
+    _sub_agent_task: str | None = field(default=None, repr=False)
+    _pending_result: asyncio.Future | None = field(default=None, repr=False)
+
+    # ── _pending_result 封装 ────────────────────────────────
     @property
     def pending_future(self) -> asyncio.Future | None:
         """暴露内部 Future，用于 asyncio.wait_for 等原生操作。"""
@@ -98,7 +96,26 @@ class SessionState:
         if self._pending_result is not None and not self._pending_result.done():
             self._pending_result.cancel()
 
-    # ── 公有字段便捷方法 ───────────────────────────────────────
+    # ── _sub_agent_task 封装 ────────────────────────────────
+    def has_sub_agent_task(self) -> bool:
+        """是否有子 Agent 任务描述待消费。"""
+        return self._sub_agent_task is not None
+
+    def consume_sub_agent_task(self) -> str | None:
+        """消费子 Agent 任务描述（一次性取出并清空）。"""
+        task = self._sub_agent_task
+        self._sub_agent_task = None
+        return task
+
+
+# ── 子数据类：固定会话 ────────────────────────────────────────────
+
+@dataclass
+class ConstSession:
+    """固定会话标记与名称。"""
+    is_const: bool = False
+    const_name: str = ""
+
     def constify(self, name: str) -> None:
         """将会话标记为固定会话。"""
         self.is_const = True
@@ -109,13 +126,167 @@ class SessionState:
         self.is_const = False
         self.const_name = ""
 
+
+# ── 会话状态（组合层）───────────────────────────────────────────
+
+class SessionState:
+    """会话状态 — 组合多个子数据类，保持原有外部接口不变。"""
+
+    def __init__(self, session_id: str, **kwargs):
+        self.meta = SessionMeta(
+            session_id=session_id,
+            created_at=kwargs.pop("created_at", time.time()),
+            last_active=kwargs.pop("last_active", time.time()),
+            message_count=kwargs.pop("message_count", 0),
+        )
+        self.runtime = AgentRuntime(
+            _active_task=kwargs.pop("_active_task", None),
+            checkpointer=kwargs.pop("checkpointer", MemorySaver()),
+            _graph=kwargs.pop("_graph", None),
+        )
+        self.sub_agent = SubAgentData(
+            is_subagent=kwargs.pop("is_subagent", False),
+            _sub_agent_task=kwargs.pop("_sub_agent_task", None),
+            _pending_result=kwargs.pop("_pending_result", None),
+        )
+        self._ws: WebSocket | None = kwargs.pop("ws", None)
+        self.const = ConstSession(
+            is_const=kwargs.pop("is_const", False),
+            const_name=kwargs.pop("const_name", ""),
+        )
+        if kwargs:
+            raise TypeError(
+                f"__init__() got unexpected keyword arguments: {kwargs}"
+            )
+
+    # ── 扁平转发属性 ─────────────────────────────────────────
+
+    @property
+    def session_id(self) -> str:
+        return self.meta.session_id
+
+    @property
+    def created_at(self) -> float:
+        return self.meta.created_at
+
+    @property
+    def last_active(self) -> float:
+        return self.meta.last_active
+
+    @last_active.setter
+    def last_active(self, value: float) -> None:
+        self.meta.last_active = value
+
+    @property
+    def message_count(self) -> int:
+        return self.meta.message_count
+
+    @property
+    def checkpointer(self) -> MemorySaver:
+        return self.runtime.checkpointer
+
+    @property
+    def is_subagent(self) -> bool:
+        return self.sub_agent.is_subagent
+
+    @property
+    def is_const(self) -> bool:
+        return self.const.is_const
+
+    @property
+    def const_name(self) -> str:
+        return self.const.const_name
+
+    @property
+    def pending_future(self) -> asyncio.Future | None:
+        return self.sub_agent.pending_future
+
+    @property
+    def ws(self) -> WebSocket | None:
+        return self._ws
+
+    @ws.setter
+    def ws(self, value: WebSocket | None) -> None:
+        self._ws = value
+
+    # ── 转发方法 ─────────────────────────────────────────────
+
+    def get_graph(self) -> CompiledStateGraph | None:
+        """返回缓存的 Agent 编译图，未构建时返回 None。"""
+        return self.runtime.get_graph()
+
+    def set_graph(self, graph: CompiledStateGraph) -> None:
+        """缓存 Agent 编译图（供 undo/重放使用）。"""
+        self.runtime.set_graph(graph)
+
+    def has_active_task(self) -> bool:
+        """Agent 是否正在运行（协程未完成）。"""
+        return self.runtime.has_active_task()
+
+    def set_active_task(self, task: asyncio.Task | None) -> None:
+        """设置当前 Agent 运行任务。"""
+        self.runtime.set_active_task(task)
+
+    def clear_active_task(self) -> None:
+        """清除 Agent 任务引用。"""
+        self.runtime.clear_active_task()
+
+    def cancel_active_task(self) -> None:
+        """取消正在运行的 Agent 任务（如存在且未完成）。"""
+        self.runtime.cancel_active_task()
+
+    def has_sub_agent_task(self) -> bool:
+        """是否有子 Agent 任务描述待消费。"""
+        return self.sub_agent.has_sub_agent_task()
+
+    def consume_sub_agent_task(self) -> str | None:
+        """消费子 Agent 任务描述（一次性取出并清空）。"""
+        return self.sub_agent.consume_sub_agent_task()
+
+    def has_pending_result(self) -> bool:
+        """是否有待处理的 Future 且未完成。"""
+        return self.sub_agent.has_pending_result()
+
+    def is_pending_done(self) -> bool:
+        """Future 是否存在且已完成（含成功和异常）。"""
+        return self.sub_agent.is_pending_done()
+
+    def resolve_pending(self, value: str) -> None:
+        """以结果值完成子 Agent 的 Future。"""
+        self.sub_agent.resolve_pending(value)
+
+    def fail_pending(self, message: str) -> None:
+        """以 RuntimeError 失败子 Agent 的 Future。"""
+        self.sub_agent.fail_pending(message)
+
+    def cancel_pending(self) -> None:
+        """取消子 Agent 的 Future。"""
+        self.sub_agent.cancel_pending()
+
+    def constify(self, name: str) -> None:
+        """将会话标记为固定会话。"""
+        self.const.constify(name)
+
+    def unconstify(self) -> None:
+        """取消固定标记。"""
+        self.const.unconstify()
+
     def increment_messages(self, by: int = 2) -> None:
         """增加消息计数（默认 user+assistant 一对）。"""
-        self.message_count += by
+        self.meta.message_count += by
 
     def reduce_messages(self, by: int) -> None:
         """减少消息计数（下限 0，用于 undo）。"""
-        self.message_count = max(0, self.message_count - by)
+        self.meta.message_count = max(0, self.meta.message_count - by)
+
+    def __repr__(self) -> str:
+        return (
+            f"SessionState(session_id={self.session_id!r}, "
+            f"created_at={self.created_at}, "
+            f"last_active={self.last_active}, "
+            f"message_count={self.message_count}, "
+            f"is_subagent={self.is_subagent})"
+        )
 
 
 class SessionManager:

--- a/api/session/manager.py
+++ b/api/session/manager.py
@@ -19,11 +19,8 @@ class SessionState:
     _active_task: asyncio.Task | None = field(default=None, repr=False)
     checkpointer: MemorySaver = field(default_factory=MemorySaver)
     _graph: CompiledStateGraph | None = field(default=None, repr=False)
-    auto_approve: bool = False
-
     # ── Sub-agent 字段 ─────────────────────────────────────
     is_subagent: bool = False
-    parent_session_id: str | None = None
     _sub_agent_task: str | None = field(default=None, repr=False)
     _pending_result: asyncio.Future | None = field(default=None, repr=False)
 
@@ -135,14 +132,12 @@ class SessionManager:
     def create_sub_session(
         self,
         task: str,
-        parent_session_id: str | None = None,
     ) -> SessionState:
         """创建 sub-agent 会话，携带任务文本和 pending future。"""
         session_id = uuid.uuid4().hex
         session = SessionState(
             session_id=session_id,
             is_subagent=True,
-            parent_session_id=parent_session_id,
             _sub_agent_task=task,
             _pending_result=asyncio.Future(),
         )

--- a/dev_docs/backend-architecture/session-layer.md
+++ b/dev_docs/backend-architecture/session-layer.md
@@ -21,7 +21,7 @@
 
 | 文件 | 核心类型/函数 | 职责 |
 |---|---|---|
-| `manager.py` | `SessionState` / `SessionManager` / `session_manager` | 会话状态管理：多会话隔离 + TTL 过期清理（模块级单例） |
+| `manager.py` | `SessionMeta` / `AgentRuntime` / `SubAgentData` / `ConstSession` / `SessionState` / `SessionManager` / `session_manager` | 会话状态管理：多会话隔离 + TTL 过期清理（模块级单例）。`SessionState` 组合四个子数据类，通过属性/方法转发保持对外接口不变 |
 | `const_store.py` | `save_const_session` / `delete_const_session` / `serialize_messages` | Const 固定会话 YAML 持久化 |
 
 ## 职责描述
@@ -84,30 +84,44 @@ class SessionManager:
 
 #### SessionState 数据结构
 
+SessionState 由四个子数据类组合而成：
+
 ```python
 @dataclass
-class SessionState:
+class SessionMeta:
+    """会话基础元信息"""
     session_id: str
     created_at: float
     last_active: float
     message_count: int
-    _active_task: asyncio.Task | None         # 当前正在运行的 Agent 任务
-    checkpointer: MemorySaver                  # LangGraph 检查点（支持 undo/重放）
-    _graph: CompiledStateGraph | None          # 缓存的 Agent 编译图
-    auto_approve: bool
 
-    # Sub-agent 字段
+@dataclass
+class AgentRuntime:
+    """Agent 运行时状态"""
+    _active_task: asyncio.Task | None    # 当前正在运行的 Agent 任务
+    checkpointer: MemorySaver             # LangGraph 检查点（支持 undo/重放）
+    _graph: CompiledStateGraph | None     # 缓存的 Agent 编译图
+
+@dataclass
+class SubAgentData:
+    """Sub-agent 会话状态"""
     is_subagent: bool
-    parent_session_id: str | None
     _sub_agent_task: str | None
     _pending_result: asyncio.Future | None
 
-    # WebSocket 引用
-    ws: WebSocket | None                 # 当前 WebSocket 连接，供后台推送事件
-
-    # Const 固定会话字段
+@dataclass
+class ConstSession:
+    """固定会话标记"""
     is_const: bool
     const_name: str
+
+class SessionState:
+    """组合层 — 转发子数据类的字段与方法"""
+    meta: SessionMeta
+    runtime: AgentRuntime
+    sub_agent: SubAgentData
+    const: ConstSession
+    ws: WebSocket | None                 # 当前 WebSocket 连接，供后台推送事件
 ```
 
 ### SessionState.ws — WebSocket 引用
@@ -136,7 +150,7 @@ class SessionState:
 ### 1. 线程安全
 
 - `SessionManager` 在单线程 asyncio 事件循环中运行，`dict` 操作天然协程安全，无需显式加锁
-- `SessionState` 使用 `dataclass` 不可变默认值，可变字段（`_active_task`、`_pending_result`等）通过封装方法访问，避免外部直接修改内部状态
+- `SessionState` 通过组合多个子数据类（`SessionMeta`、`AgentRuntime`、`SubAgentData`、`ConstSession`）组织会话状态。私有字段（`_active_task`、`_pending_result` 等）封装在子数据类中通过方法访问，避免外部直接修改内部状态
 
 ### 2. TTL 过期策略
 
@@ -186,9 +200,9 @@ def delete_const_session(session_id: str) -> bool:
 
 ### 5. Sub-agent 机制
 
-`SessionState` 内建对子 Agent 的支持：
+`SubAgentData` 内建对子 Agent 的支持（通过 `SessionState.sub_agent` 访问）：
 
-- `is_subagent` / `parent_session_id`：标识子会话及其父会话
+- `is_subagent`：标识子会话
 - `_pending_result`：`asyncio.Future`，用于父会话等待子会话的异步结果
 - `_sub_agent_task`：存储子 Agent 任务描述，供消费
 

--- a/dev_docs/projects/uml/session.md
+++ b/dev_docs/projects/uml/session.md
@@ -7,20 +7,47 @@
 skinparam classAttributeIconSize 0
 skinparam backgroundColor #FEFEFE
 
-' ===== 数据类 =====
+' ===== 子数据类 =====
 
-class SessionState <<dataclass>> {
+class SessionMeta <<dataclass>> {
   + session_id: str
   + created_at: float
   + last_active: float
   + message_count: int
+}
+
+class AgentRuntime <<dataclass>> {
   + checkpointer: MemorySaver
-  + is_subagent: bool
-  + parent_session_id: str | None
   _active_task: asyncio.Task | None
+  _graph: CompiledStateGraph | None
+}
+
+class SubAgentData <<dataclass>> {
+  + is_subagent: bool
   _sub_agent_task: str | None
   _pending_result: asyncio.Future | None
 }
+
+class ConstSession <<dataclass>> {
+  + is_const: bool
+  + const_name: str
+}
+
+' ===== 组合层 =====
+
+class SessionState {
+  + meta: SessionMeta
+  + runtime: AgentRuntime
+  + sub_agent: SubAgentData
+  + const: ConstSession
+  + ws: WebSocket | None
+}
+
+note top of SessionState
+  组合层：通过属性/方法
+  转发子数据类的字段与方法，
+  保持外部接口不变
+end note
 
 ' ===== 管理器 =====
 
@@ -28,7 +55,7 @@ class SessionManager {
   - _sessions: dict[str, SessionState]
   - _ttl: int
   + create() SessionState
-  + create_sub_session(task, parent_session_id) SessionState
+  + create_sub_session(task) SessionState
   + get(session_id) SessionState | None
   + get_or_create(session_id) SessionState
   + delete(session_id) bool
@@ -50,9 +77,15 @@ class asyncio.Future <<asyncio>> {
 ' ===== 关系 =====
 
 SessionManager o-- SessionState : manages
-SessionState *-- MemorySaver : checkpointer
-SessionState o-- asyncio.Task : _active_task
-SessionState o-- asyncio.Future : _pending_result
+
+SessionState *-- SessionMeta : meta
+SessionState *-- AgentRuntime : runtime
+SessionState *-- SubAgentData : sub_agent
+SessionState *-- ConstSession : const
+
+AgentRuntime *-- MemorySaver : checkpointer
+AgentRuntime o-- asyncio.Task : _active_task
+SubAgentData o-- asyncio.Future : _pending_result
 
 SessionManager --> SessionState : create / get 返回
 
@@ -63,7 +96,10 @@ SessionManager --> SessionState : create / get 返回
 
 ```
 api/
-└── session_manager.py    # SessionState, SessionManager
+└── session/
+    └── manager.py        # SessionMeta, AgentRuntime, SubAgentData, ConstSession,
+                          # SessionState, SessionManager, session_manager
+    └── const_store.py    # 固定会话 YAML 持久化
 ```
 
 ## 数据流
@@ -72,7 +108,7 @@ api/
 SessionManager
   ├─ create() → 新会话（无 checkpointer 历史）
   ├─ get_or_create(id) → 恢复已有/创建新会话
-  ├─ create_sub_session() → Sub-agent 会话（带 parent + pending_result）
+  ├─ create_sub_session(task) → Sub-agent 会话（带 pending Future）
   ├─ list_sessions() → 排序后的活跃会话列表
   └─ cleanup_expired() → TTL（默认 30 分钟）过期清理
 ```

--- a/tools/sub_agent/tool_call_sub_agent.py
+++ b/tools/sub_agent/tool_call_sub_agent.py
@@ -98,10 +98,7 @@ class CallSubAgentTool(ToolBase):
             pass
 
         # 1. 创建 sub-session
-        sub = sm.create_sub_session(
-            task=task,
-            parent_session_id=parent_session_id,
-        )
+        sub = sm.create_sub_session(task=task)
         print(
             f"[call_sub_agent] sub-session created: {sub.session_id}", file=sys.stderr
         )


### PR DESCRIPTION
### 变更内容

将 `SessionState` 的 14 个扁平字段按职责拆分为 4 个子数据类：

| 子数据类 | 字段 |
|---|---|
| `SessionMeta` | session_id, created_at, last_active, message_count |
| `AgentRuntime` | _active_task, checkpointer, _graph |
| `SubAgentData` | is_subagent, _sub_agent_task, _pending_result |
| `ConstSession` | is_const, const_name |

`SessionState` 作为组合层，通过属性/方法转发保持对外接口完全不变。

### 影响范围

- `api/session/manager.py` — 重构核心代码
- `dev_docs/backend-architecture/session-layer.md` — 更新架构文档
- `dev_docs/projects/uml/session.md` — 更新 PlantUML 类图

### 验证

- 所有外部字段访问 (`session.ws`, `session.checkpointer`, `session.last_active` 等) 保持一致
- 所有外部方法调用 (`has_active_task()`, `consume_sub_agent_task()` 等) 保持一致
- 构造方式 (`SessionState(session_id=...)`) 向后兼容
- `SessionManager.create_sub_session()` 等调用无需改动