### PR TITLE
refactor(memory): MemorySaver 全局单例化，短期记忆管理抽离为独立模块

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -4,6 +4,7 @@ from langchain.agents import create_agent
 from langchain_core.language_models import BaseChatModel
 from langchain_core.tools import BaseTool
 from langgraph.graph.state import CompiledStateGraph
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.checkpoint.memory import MemorySaver
 
 # 彩蛋：Sonetto 就是这个 CompiledStateGraph ✨
@@ -14,12 +15,12 @@ def build_agent(
     model: BaseChatModel,
     tools: list[BaseTool],
     system_prompt: str,
-    checkpointer: MemorySaver | None = None,
+    checkpointer: BaseCheckpointSaver | None = None,
 ) -> Sonetto:
     """构建 ReAct Agent 图。
 
     若提供 checkpointer 则复用（跨轮次持久化状态），
-    否则每次新建 MemorySaver（原有行为）。
+    否则新建 MemorySaver（回退行为）。
     """
     if checkpointer is None:
         checkpointer = MemorySaver()

--- a/api/agent/context_usage.py
+++ b/api/agent/context_usage.py
@@ -167,19 +167,12 @@ async def estimate_context_usage_from_session(
     max_tokens: int,
     model_name: str = "",
 ) -> dict:
-    """从 session checkpointer 拉取消息列表，估算上下文用量。
+    """从会话短期记忆拉取消息列表，估算上下文用量。
 
     返回字典，包括现用量、最大用量、占比、模型名称。
     """
     try:
-        cpt = await session.checkpointer.aget_tuple(
-            {"configurable": {"thread_id": session.session_id}}
-        )
-        if cpt is not None:
-            channel_values = cpt.checkpoint.get("channel_values", {})
-            counting_messages = channel_values.get("messages", [])
-        else:
-            counting_messages = []
+        counting_messages = await session.get_messages()
     except Exception:
         counting_messages = []
 

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -22,6 +22,7 @@ from api.providers.default_llm import get_default_llm
 from api.providers.manager import ProviderManager
 from api.session.const_store import save_const_session, serialize_messages
 from api.session.manager import SessionState
+from api.memory.short_term import get_checkpointer
 from langchain_core.language_models.chat_models import BaseChatModel
 from tools.base import format_error
 from tools.network.tool_image_understand import load_image_bytes, get_mime_type
@@ -209,14 +210,12 @@ async def _stream_turn(
     # 事件未捕获到 final_answer 时，从 checkpoint 兜底提取
     if not final_answer:
         try:
-            cpt = await session.checkpointer.aget_tuple(config)
-            if cpt is not None:
-                messages = cpt.checkpoint.get("channel_values", {}).get("messages", [])
-                if messages:
-                    last = messages[-1]
-                    candidate = last.content if hasattr(last, "content") else str(last)
-                    if candidate:
-                        final_answer = candidate
+            messages = await session.get_messages()
+            if messages:
+                last = messages[-1]
+                candidate = last.content if hasattr(last, "content") else str(last)
+                if candidate:
+                    final_answer = candidate
         except Exception:
             pass
     return final_answer
@@ -276,7 +275,7 @@ async def _build_turn_context(
         model=llm_conf.llm,
         tools=tools,
         system_prompt=system_prompt,
-        checkpointer=session.checkpointer,
+        checkpointer=get_checkpointer(),
     )
     session.set_graph(agent)
 
@@ -385,10 +384,7 @@ async def _postprocess_turn(
     # Const 会话持久化
     if result.final_answer and session.is_const:
         try:
-            cpt = await session.checkpointer.aget_tuple(
-                {"configurable": {"thread_id": session.session_id}}
-            )
-            raw_messages = cpt.checkpoint.get("channel_values", {}).get("messages", []) if cpt else []
+            raw_messages = await session.get_messages()
             metadata = {
                 "created_at": session.created_at,
                 "last_active": session.last_active,

--- a/api/memory/narrative.py
+++ b/api/memory/narrative.py
@@ -358,14 +358,11 @@ class LongTermMemoryInterface:
 
     @staticmethod
     async def _extract_session_messages(session: SessionState) -> list[dict[str, str]]:
-        """从 LangGraph checkpointer 提取全量会话消息并映射为记忆 Agent 格式。"""
+        """从短期记忆提取全量会话消息并映射为记忆 Agent 格式。"""
         try:
-            cpt = await session.checkpointer.aget_tuple(
-                {"configurable": {"thread_id": session.session_id}}
-            )
-            if cpt is None:
+            raw = await session.get_messages()
+            if not raw:
                 return []
-            raw = cpt.checkpoint.get("channel_values", {}).get("messages", [])
         except Exception:
             return []
 

--- a/api/memory/short_term.py
+++ b/api/memory/short_term.py
@@ -1,0 +1,19 @@
+"""短期记忆管理 — 全局 MemorySaver 单例。
+
+所有会话的 LangGraph 检查点（对话上下文）共享同一个 MemorySaver，
+通过 thread_id = session.session_id 区分隔离。
+"""
+
+from langgraph.checkpoint.memory import MemorySaver
+
+_global_checkpointer = MemorySaver()
+
+
+def get_checkpointer() -> MemorySaver:
+    """返回全局单例 checkpointer。"""
+    return _global_checkpointer
+
+
+def delete_thread(thread_id: str) -> None:
+    """删除指定 thread_id 的全部检查点，释放内存。"""
+    _global_checkpointer.delete_thread(thread_id)

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -56,12 +56,7 @@ async def get_messages(session_id: str, request: Request) -> dict:
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
     try:
-        cpt = await session.checkpointer.aget_tuple(
-            {"configurable": {"thread_id": session.session_id}}
-        )
-        msgs = (
-            cpt.checkpoint.get("channel_values", {}).get("messages", []) if cpt else []
-        )
+        msgs = await session.get_messages()
     except Exception:
         msgs = []
     return {
@@ -140,14 +135,9 @@ async def constify_session(session_id: str, body: ConstifyRequest, request: Requ
     if session.has_active_task():
         raise HTTPException(status_code=409, detail="Agent 仍在运行中，无法固定会话")
 
-    # 从 checkpointer 提取消息
+    # 从短期记忆提取消息
     try:
-        cpt = await session.checkpointer.aget_tuple(
-            {"configurable": {"thread_id": session.session_id}}
-        )
-        raw_messages = (
-            cpt.checkpoint.get("channel_values", {}).get("messages", []) if cpt else []
-        )
+        raw_messages = await session.get_messages()
     except Exception:
         raw_messages = []
 
@@ -179,14 +169,9 @@ async def generate_session_title(session_id: str, request: Request) -> dict:
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    # 从 checkpointer 提取消息
+    # 从短期记忆提取消息
     try:
-        cpt = await session.checkpointer.aget_tuple(
-            {"configurable": {"thread_id": session.session_id}}
-        )
-        messages = (
-            cpt.checkpoint.get("channel_values", {}).get("messages", []) if cpt else []
-        )
+        messages = await session.get_messages()
     except Exception:
         messages = []
 

--- a/api/server.py
+++ b/api/server.py
@@ -46,7 +46,7 @@ async def _load_const_sessions(app: FastAPI):
         print(f"[const] Skipping {len(const_list)} const session(s) — no LLM available")
         return
 
-    from langgraph.checkpoint.memory import MemorySaver
+    from api.memory.short_term import get_checkpointer
 
     loaded = 0
     for const_data in const_list:
@@ -58,10 +58,10 @@ async def _load_const_sessions(app: FastAPI):
         const_name = const_data.get("const_name", "")
         messages = const_data.get("messages", [])
 
-        # 重建 checkpointer
+        # 用全局单例 checkpointer 重建
         try:
             reconstructed = deserialize_messages(messages)
-            checkpointer = MemorySaver()
+            checkpointer = get_checkpointer()
             if reconstructed:
                 agent = build_agent(
                     model=get_default_llm(),
@@ -82,7 +82,6 @@ async def _load_const_sessions(app: FastAPI):
             created_at=metadata.get("created_at", time.time()),
             last_active=metadata.get("last_active", time.time()),
             message_count=metadata.get("message_count", 0),
-            checkpointer=checkpointer,
             is_const=True,
             const_name=const_name,
         )

--- a/api/session/manager.py
+++ b/api/session/manager.py
@@ -6,8 +6,11 @@ import uuid
 from dataclasses import dataclass, field
 
 from fastapi import WebSocket
+from langchain_core.messages import BaseMessage
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph.state import CompiledStateGraph
+
+from api.memory.short_term import get_checkpointer, delete_thread as _delete_memory_thread
 
 
 # ── 子数据类：会话元信息 ──────────────────────────────────────────
@@ -27,7 +30,7 @@ class SessionMeta:
 class AgentRuntime:
     """Agent 运行时状态：活动任务、检查点、编译图。"""
     _active_task: asyncio.Task | None = field(default=None, repr=False)
-    checkpointer: MemorySaver = field(default_factory=MemorySaver)
+    checkpointer: MemorySaver | None = field(default=None, repr=False)
     _graph: CompiledStateGraph | None = field(default=None, repr=False)
 
     # ── _graph 封装 ─────────────────────────────────────────
@@ -141,7 +144,7 @@ class SessionState:
         )
         self.runtime = AgentRuntime(
             _active_task=kwargs.pop("_active_task", None),
-            checkpointer=kwargs.pop("checkpointer", MemorySaver()),
+            checkpointer=kwargs.pop("checkpointer", None),
             _graph=kwargs.pop("_graph", None),
         )
         self.sub_agent = SubAgentData(
@@ -181,9 +184,14 @@ class SessionState:
     def message_count(self) -> int:
         return self.meta.message_count
 
-    @property
-    def checkpointer(self) -> MemorySaver:
-        return self.runtime.checkpointer
+    async def get_messages(self) -> list[BaseMessage]:
+        """获取当前会话的对话消息列表（从全局 checkpointer 按 thread_id 查询）。"""
+        cpt = await get_checkpointer().aget_tuple(
+            {"configurable": {"thread_id": self.session_id}}
+        )
+        if cpt is not None:
+            return cpt.checkpoint.get("channel_values", {}).get("messages", [])
+        return []
 
     @property
     def is_subagent(self) -> bool:
@@ -331,6 +339,7 @@ class SessionManager:
     def delete(self, session_id: str) -> bool:
         if session_id in self._sessions:
             del self._sessions[session_id]
+            _delete_memory_thread(session_id)
             return True
         return False
 
@@ -368,6 +377,7 @@ class SessionManager:
         ]
         for sid in expired:
             del self._sessions[sid]
+            _delete_memory_thread(sid)
         return len(expired)
 
 

--- a/dev_docs/backend-architecture/agent-layer.md
+++ b/dev_docs/backend-architecture/agent-layer.md
@@ -32,12 +32,14 @@
 | `model_name` | `str` | 当前使用的模型名称（如 `gpt-4o`、`deepseek-chat`） |
 | `max_tokens` | `int` | 模型最大上下文窗口大小（token 数） |
 
+> `_LlmConfig` 通过 `_resolve_llm()` 构建，内部调用 `provider_manager.get_model_metadata()` 统一查询模型上下文窗口、视觉能力等元数据，替代了之前分散在各处的内联 `model_vision` 检测。
+
 **`_TurnContext`** — 一轮 Agent 执行所需的全部上下文（构建后不可变）：
 
 | 字段 | 类型 | 说明 |
 |---|---|---|
 | `system_prompt` | `str` | 当前会话的系统提示词 |
-| `agent` | `Sonetto` | 编译后的 LangGraph Agent |
+| `agent` | `Sonetto` | 编译后的 LangGraph Agent（绑定全局 MemorySaver 单例） |
 | `inputs` | `dict[str, list[HumanMessage]]` | 本轮输入消息 |
 | `config` | `dict[str, Any]` | 运行配置（`thread_id`、`callbacks`、`recursion_limit`） |
 
@@ -53,8 +55,8 @@
 
 ### 1. 编排 LLM 对话轮次
 
-- 解析 LLM 配置（模型选择、上下文窗口参数）
-- 构建 LangGraph Agent 图（`Sonetto`），注入工具、系统提示、checkpointer
+- 解析 LLM 配置（模型选择、上下文窗口参数）：通过 `provider_manager.get_model_metadata()` 统一查询模型上下文窗口和多模态能力
+- 构建 LangGraph Agent 图（`Sonetto`），注入工具、系统提示、全局 checkpointer
 - 流式执行 Agent 图，收集最终回答
 - 后处理：消息计数、LTM 持久化、Const 会话保存、Sub-agent 回调
 
@@ -84,7 +86,6 @@
 async def _build_turn_context(
     tools: list,
     session: SessionState,
-    ws: WebSocket,
     llm_conf: _LlmConfig,
     user_message: str,
     image_recognition: bool,
@@ -92,14 +93,14 @@ async def _build_turn_context(
 ) -> _TurnContext:
     """构建 Agent 图、输入消息和执行配置。"""
     system_prompt = build_system_prompt()
-    cb_sender = CallbackSender.from_ws(ws)
+    cb_sender = CallbackSender.from_context()
     ws_callback = WebSocketCallback(cb_sender)
 
     agent = build_agent(
         model=llm_conf.llm,
         tools=tools,
         system_prompt=system_prompt,
-        checkpointer=session.checkpointer,
+        checkpointer=get_checkpointer(),   # 全局 MemorySaver 单例
     )
     session.set_graph(agent)
 
@@ -120,6 +121,10 @@ async def _build_turn_context(
 
     return _TurnContext(system_prompt, agent, inputs, config)
 ```
+
+**关键变更**：
+- `checkpointer=session.checkpointer` → `checkpointer=get_checkpointer()`：所有会话共享同一个 MemorySaver 全局单例，通过 `thread_id = session.session_id` 区分隔离
+- `CallbackSender.from_ws(ws)` → `CallbackSender.from_context()`：回调发送器不再从参数接收 `ws`，改为从 `contextvars` 自动获取当前轮次的 WebSocket
 
 ### 流式执行（`turn.py`）
 
@@ -227,14 +232,17 @@ async def undo_rounds(graph, config, n: int = 1) -> int:
 run_agent_turn()                    ← 顶层编排入口
     │
     ├── 阶段 1: _resolve_llm()
+    │   │  provider_manager.get_model_metadata()  ← 统一查询上下文窗口 + 多模态
     │   │  provider_manager.create_llm() / 回退 default_llm
     │   │  返回 _LlmConfig (llm + model_name + max_tokens)
     │   ▼
     ├── 阶段 2: _build_turn_context()
     │   │  build_system_prompt() → system_prompt
     │   │  CallbackSender.from_context() → WebSocketCallback → 注入 LangChain 事件链路
-    │   │  build_agent() → graph (LangGraph CompiledStateGraph)
+    │   │  build_agent(checkpointer=get_checkpointer()) → graph
+    │   │      │ 全局 MemorySaver 单例，thread_id = session.session_id 隔离
     │   │  处理多模态输入（图片 base64 编码）
+    │   │  ToolManager.get_all(multimodal=image_recognition)  ← 按需过滤工具集
     │   │  返回 _TurnContext (system_prompt, agent, inputs, config)
     │   ▼
     ├── 阶段 3: _execute_agent_turn()
@@ -300,6 +308,37 @@ run_agent_turn()                    ← 顶层编排入口
 - `run_agent_turn()` 为唯一公共入口，内部按 4 个阶段分步执行
 - 各阶段独立为私有函数（`_resolve_llm`, `_build_turn_context`, `_execute_agent_turn`, `_postprocess_turn`），职责单一
 - 数据对象（`_LlmConfig`, `_TurnContext`, `_TurnResult`）在各阶段之间传递，避免共享可变状态
+
+### 模型元数据统一查询（PR #248）
+
+`ProviderManager.get_model_metadata(model_name)` 将之前分散在各处的模型元数据查询集中管理：
+
+```python
+# api/providers/manager.py
+def get_model_metadata(self, model_name: str) -> dict:
+    """返回模型上下文窗口、视觉能力等元数据。"""
+    return {
+        "context_window": ...,
+        "vision": ...,
+    }
+```
+
+- `_resolve_llm()` 通过此方法统一获取上下文窗口和多模态信息，替代了之前 `create_llm()` 返回三元组的内联检测
+- `create_llm()` 简化，仅返回 `BaseChatModel | None`
+
+### 工具集按需过滤（PR #248）
+
+`ToolManager.get_all(multimodal: bool | None = None)` 支持根据当前会话是否需要多模态能力来过滤工具集：
+
+```python
+# api/tools/manager.py
+def get_all(self, multimodal: bool | None = None) -> list[BaseTool]:
+    """获取工具列表，multimodal=True 时仅保留多模态工具，False 时排除。"""
+```
+
+- `multimodal=True`：仅保留需要视觉输入的工具（如 `read_image`），配合图片理解场景
+- `multimodal=False`：排除多模态工具（非图片会话不暴露图片相关工具）
+- `multimodal=None`（默认）：返回全部工具，保持向后兼容
 
 ## 设计约定评估
 

--- a/dev_docs/backend-architecture/memory-layer.md
+++ b/dev_docs/backend-architecture/memory-layer.md
@@ -17,7 +17,10 @@
 | `manager.py` | MemoryManager + MemoryItem — YAML 持久化 CRUD，文件锁并发安全 |
 | `narrative.py` | LongTermMemoryInterface — 后台 LLM 增量总结管线 + 5 个模块级 `@tool` |
 | `callback.py` | MemoryToolCallback — CRUD 工具事件 → WebSocket 前端推送 |
+| `short_term.py` | **短期记忆管理器** — 全局 MemorySaver 单例，所有会话的 LangGraph 检查点共享此实例，通过 `thread_id = session.session_id` 区分隔离 |
 | `user_init.py` | 首次运行初始化：USER.md / SOUL.md / .env 文件复制 |
+
+> **长期记忆 vs 短期记忆**：`memory/` 层管理两种不同生命周期的记忆。长期记忆（`manager.py` + `narrative.py`）通过 LLM 总结写入 YAML，跨会话持久化。短期记忆（`short_term.py`）管理运行时对话上下文（MemorySaver 检查点），跟随会话生命周期，过期即清理。
 
 ## 职责描述
 
@@ -194,9 +197,11 @@ _consumer()                      — 后台协程，逐条消费
 |----------|----------|------|
 | `narrative.py →` | `manager.py` | MemoryManager + MemoryItem |
 | `narrative.py →` | `callback.py` | MemoryToolCallback |
-| `narrative.py →` | `api.session.manager` | SessionState（用于提取 checkpointer 消息） |
+| `narrative.py →` | `api.session.manager` | SessionState（`session.get_messages()` 提取消息） |
 | `narrative.py →` | `api.session.manager` | session_manager（通过 `session_manager.get(sid).ws` 获取 WebSocket） |
 | `callback.py →` | `api.session.manager` | session_manager（通过 `session_manager.get(sid).ws` 获取 WebSocket） |
+| `short_term.py →` | `langgraph.checkpoint.memory` | MemorySaver 全局单例 |
+| `api.session.manager →` | `short_term.py` | `get_checkpointer()` / `delete_thread()` — 会话层倒依赖短期记忆模块 |
 | `narrative.py →` | `api.providers` | 通过 `create_agent` 间接调用（LLM 由外部注入） |
 
 ### 设计约定评估
@@ -205,7 +210,7 @@ _consumer()                      — 后台协程，逐条消费
 
 1. **模块级全局变量**：`narrative.py` 中的 `_current_mm` 是模块级可变全局状态，通过 `_set_current_mm()` 注入。这种设计在单消费者场景下工作正常，但若并发存在多个 `LongTermMemoryInterface` 实例（如多租户），全局状态会互相覆盖。建议改为实例级别的依赖注入，使 `@tool` 函数与具体的 `MemoryManager` 实例绑定。
 
-2. **Session 依赖方向**：`narrative.py` 和 `callback.py` 都通过 `api.session.manager.session_manager` 访问会话状态。这属于同一层级（第⑥层）内的模块间依赖，不违反分层规则。但应注意：`session/` 与 `memory/` 同层，彼此引入时需要避免循环依赖。
+2. **Session 依赖方向**：`narrative.py` 和 `callback.py` 都通过 `api.session.manager.session_manager` 访问会话状态。`api.session.manager` 也反向依赖 `memory/short_term.py` 获取全局 checkpointer。这属于同一层级（第⑥层）内的模块间依赖，不违反分层规则。但应注意：`session/` 与 `memory/` 同层，彼此引入时需要避免循环依赖（当前 `short_term.py` 不依赖 `session/`，所以无风险）。
 
 3. **模块级 @tool 的测试性**：`@tool` 函数是模块级函数而非类方法，无法在单元测试中轻松替换 `_current_mm`。当前通过 `lru_cache` 的 `get_narrative()` 也存在静态文件路径的硬编码（`MEMORY_PATH` 在第 29 行硬编码为 `config/personas/memory.yaml`）。
 

--- a/dev_docs/backend-architecture/session-layer.md
+++ b/dev_docs/backend-architecture/session-layer.md
@@ -24,6 +24,12 @@
 | `manager.py` | `SessionMeta` / `AgentRuntime` / `SubAgentData` / `ConstSession` / `SessionState` / `SessionManager` / `session_manager` | 会话状态管理：多会话隔离 + TTL 过期清理（模块级单例）。`SessionState` 组合四个子数据类，通过属性/方法转发保持对外接口不变 |
 | `const_store.py` | `save_const_session` / `delete_const_session` / `serialize_messages` | Const 固定会话 YAML 持久化 |
 
+### 外部依赖
+
+| 外部模块 | 用途 |
+|---|---|
+| `api/memory/short_term.py` | 全局 MemorySaver 单例 — `SessionState` 通过 `short_term.get_checkpointer()` 获取短期记忆存储，`cleanup_expired()` / `delete()` 通过 `short_term.delete_thread(sid)` 释放记忆内存 |
+
 ## 职责描述
 
 - **会话生命周期管理**：创建、获取、删除运行时会话，维护 `SessionState` 中的 Agent 编译图、检查点、消息计数等运行时状态
@@ -67,6 +73,7 @@ class SessionManager:
         """删除指定会话。"""
         if session_id in self._sessions:
             del self._sessions[session_id]
+            _delete_memory_thread(session_id)  # 释放短期记忆
             return True
         return False
 
@@ -79,6 +86,7 @@ class SessionManager:
         ]
         for sid in expired:
             del self._sessions[sid]
+            _delete_memory_thread(sid)  # 释放短期记忆
         return len(expired)
 ```
 
@@ -99,7 +107,7 @@ class SessionMeta:
 class AgentRuntime:
     """Agent 运行时状态"""
     _active_task: asyncio.Task | None    # 当前正在运行的 Agent 任务
-    checkpointer: MemorySaver             # LangGraph 检查点（支持 undo/重放）
+    checkpointer: MemorySaver | None      # 可选的自定义 checkpointer（默认 None → 回退到全局单例）
     _graph: CompiledStateGraph | None     # 缓存的 Agent 编译图
 
 @dataclass
@@ -122,7 +130,12 @@ class SessionState:
     sub_agent: SubAgentData
     const: ConstSession
     ws: WebSocket | None                 # 当前 WebSocket 连接，供后台推送事件
+
+    async def get_messages(self) -> list[BaseMessage]:
+        """获取当前会话的对话消息列表（从全局 checkpointer 按 thread_id 查询）"""
 ```
+
+- **无 `checkpointer` 属性**：`SessionState` 不再暴露整个 MemorySaver。图编译所需的 checkpointer 通过 `short_term.get_checkpointer()` 直接获取；消息读取通过 `session.get_messages()` 封装，内部自动用 `session_id` 作 `thread_id` 查询全局单例
 
 ### SessionState.ws — WebSocket 引用
 
@@ -139,10 +152,10 @@ class SessionState:
 | `api/server.py` | `SessionState`、`session_manager`、`const_store` 函数 | 应用启动时 `_load_const_sessions` 重建固定会话 |
 | `api/routes/chat.py` | `SessionState`、`session_manager` | WebSocket 聊天端点获取/创建会话，设置 `session.ws` |
 | `api/routes/sessions.py` | `session_manager`、`const_store`（`flatten_content`、`save_const_session`、`delete_const_session`） | REST API：会话 CRUD + 固定会话 CRUD |
-| `api/agent/turn.py` | `SessionState`、`const_store`（`save_const_session`、`serialize_messages`） | Agent 轮次结束时持久化固定会话 |
-| `api/agent/context_usage.py` | `SessionState` | Agent 上下文用量追踪 |
+| `api/agent/turn.py` | `SessionState`、`const_store`（`save_const_session`、`serialize_messages`）、`api.memory.short_term.get_checkpointer` | Agent 轮次编排：`session.get_messages()` 读取消息，`get_checkpointer()` 构建图 |
+| `api/agent/context_usage.py` | `SessionState` | Agent 上下文用量追踪（通过 `session.get_messages()`） |
 | `api/memory/callback.py` | `session_manager`（通过 `session_manager.get(sid).ws`） | LangChain 回调中获取 ws 引用推送事件到前端 |
-| `api/memory/narrative.py` | `SessionState`、`session_manager`（通过 `session_manager.get(sid).ws`） | 叙事生成时广播事件 |
+| `api/memory/narrative.py` | `SessionState`（`session.get_messages()`）、`session_manager` | 叙事生成：提取会话消息并广播事件 |
 | `tools/sub_agent/tool_call_sub_agent.py` | `session_manager` | 创建子会话 |
 
 ## 设计要点
@@ -163,12 +176,14 @@ def cleanup_expired(self) -> int:
     ]
     for sid in expired:
         del self._sessions[sid]
+        _delete_memory_thread(sid)  # 同步清理全局 MemorySaver 中该 thread_id 的检查点
     return len(expired)
 ```
 
 - 默认 TTL：1800 秒（30 分钟），在 `SessionManager.__init__` 中配置
 - 过期判定：`last_active > ttl`，每次 `get()` 调用会自动刷新 `last_active`
 - 惰性清理策略：`cleanup_expired()` 不由定时器触发，而是在请求路径中按需调用（如 `list_sessions` 时附带清理）
+- **记忆回收**：会话过期时同步调用 `short_term.delete_thread(sid)`，从全局 MemorySaver 单例中删除该 thread_id 的所有检查点，防止内存泄漏
 
 ### 3. 惰性清理
 
@@ -225,7 +240,7 @@ session_manager = SessionManager()
 
 | 检查项 | 结果 |
 |---|---|
-| `manager.py` 是否导入上层业务模块（routes / agent / providers）？ | 通过 — 仅依赖 `langgraph`、`fastapi`、`asyncio`、标准库 |
+| `manager.py` 是否导入上层业务模块（routes / agent / providers）？ | 通过 — 仅依赖 `langgraph`、`fastapi`、`asyncio`、`langchain_core.messages`、同级 `api.memory.short_term`、标准库 |
 | `const_store.py` 是否导入上层业务模块？ | 通过 — 仅依赖 `yaml`、`pathlib`、标准库 |
 | `SessionState` 中的 `ws` 字段类型为 `WebSocket` 是否合理？ | 通过 — `WebSocket` 仅作为引用存储（不在此层创建或管理连接生命周期），且依赖方向为框架级（非业务模块） |
 | 会话层是否包含 HTTP 请求处理逻辑？ | 通过 — 无 `Request` / `Response` 处理逻辑 |

--- a/tools/sub_agent/tool_call_sub_agent.py
+++ b/tools/sub_agent/tool_call_sub_agent.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 
 from api.agent import interaction
 from api.events import ToolSender
+from api.memory.short_term import get_checkpointer
 from api.providers.default_llm import get_default_llm
 from tools.base import ToolBase, format_success, format_error
 
@@ -182,7 +183,7 @@ class CallSubAgentTool(ToolBase):
             model=get_default_llm(),
             tools=app_state.tool_manager.get_all(),
             system_prompt=system_prompt,
-            checkpointer=sub.checkpointer,
+            checkpointer=get_checkpointer(),
         )
         inputs = {"messages": [HumanMessage(content=task)]}
         config = {"configurable": {"thread_id": sub.session_id}, "recursion_limit": 72}
@@ -207,18 +208,14 @@ class CallSubAgentTool(ToolBase):
             # 事件未捕获到 final_answer 时，从 checkpoint 兜底提取
             if not final_answer:
                 try:
-                    cpt = await sub.checkpointer.aget_tuple(config)
-                    if cpt is not None:
-                        messages = cpt.checkpoint.get("channel_values", {}).get(
-                            "messages", []
+                    messages = await sub.get_messages()
+                    if messages:
+                        last = messages[-1]
+                        candidate = (
+                            last.content if hasattr(last, "content") else str(last)
                         )
-                        if messages:
-                            last = messages[-1]
-                            candidate = (
-                                last.content if hasattr(last, "content") else str(last)
-                            )
-                            if candidate:
-                                final_answer = candidate
+                        if candidate:
+                            final_answer = candidate
                 except Exception:
                     pass
         except Exception as e:


### PR DESCRIPTION
## Summary

- **新模块** `api/memory/short_term.py`：短期记忆管理器，持有全局 MemorySaver 单例，提供 `get_checkpointer()` 和 `delete_thread()`
- **`SessionState`** 不再暴露 `checkpointer` 属性，改为 `get_messages()` 方法封装 thread_id 查询
- **TTL 过期清理**同步调用 `delete_thread()` 释放记忆内存
- **`build_agent()`** 参数类型放宽为 `BaseCheckpointSaver`
- **架构文档**同步更新 session/memory/agent 三层
- **文档同步**：session-layer.md / memory-layer.md / agent-layer.md 反映新架构及 PR #248 变更

## Test plan

- [x] 语法检查：所有 9 个修改文件解析通过
- [x] 导入验证：`api.memory.short_term`、`api.session.manager`、`api.server` 等全部模块导入正常
- [x] 会话隔离验证：多 SessionState 共享同一 MemorySaver 实例，thread_id 分区互不干扰
- [x] delete_thread 验证：调用后可释放指定 thread_id 的检查点

🤖 Generated with [Claude Code](https://claude.com/claude-code)