### PR TITLE
fix: 修复长期记忆测试套件和 memory_done 丢失问题

### DIFF
--- a/api/memory/narrative.py
+++ b/api/memory/narrative.py
@@ -427,7 +427,6 @@ class LongTermMemoryInterface:
             )
 
             # 无论后续成功与否，先通知前端「开始处理」
-            _sent_done = False
             if session_id:
                 sender = MemorySender.from_session_id(session_id)
                 if sender is not None:
@@ -438,6 +437,11 @@ class LongTermMemoryInterface:
 
             if get_default_llm() is None:
                 print("[ltm] no LLM available — skipping memory update")
+                # 发送 memory_done 避免前端一直显示「处理中…」
+                if session_id:
+                    sender = MemorySender.from_session_id(session_id)
+                    if sender is not None:
+                        await sender.memory_done(turn_id or "")
                 continue
 
             try:

--- a/tests/test_memory/test_narrative.py
+++ b/tests/test_memory/test_narrative.py
@@ -369,8 +369,9 @@ class TestLongTermMemoryInterface:
 
         fake_agent = _fake_agent_factory()
         monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
+        monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "msg1"}])
         await ltm.stop_listening()
@@ -388,7 +389,7 @@ class TestLongTermMemoryInterface:
         fake_agent = _fake_agent_factory()
         monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
         await ltm.send_history([])
         await ltm.stop_listening()
@@ -408,7 +409,8 @@ class TestLongTermMemoryInterface:
         fake_agent = _fake_agent_factory(entries_setup=agent_populates_entries)
         monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "我叫Miso"}])
         await ltm.stop_listening()
@@ -429,7 +431,8 @@ class TestLongTermMemoryInterface:
 
         monkeypatch.setattr(narrative, "create_agent", capture_agent)
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "你好"}])
         await ltm.stop_listening()
@@ -461,7 +464,8 @@ class TestLongTermMemoryInterface:
 
         monkeypatch.setattr(narrative, "create_agent", capture_agent)
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "新消息"}])
         await ltm.stop_listening()
@@ -500,7 +504,8 @@ class TestLongTermMemoryInterface:
 
         monkeypatch.setattr(narrative, "create_agent", capture_agent)
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
 
         await ltm.send_history([{"role": "user", "content": "我叫Miso"}])
@@ -526,7 +531,8 @@ class TestLongTermMemoryInterface:
         fake_agent.ainvoke = AsyncMock(side_effect=failing_ainvoke)
         monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
@@ -547,7 +553,8 @@ class TestLongTermMemoryInterface:
         fake_agent = _fake_agent_factory()
         monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
@@ -566,7 +573,8 @@ class TestLongTermMemoryInterface:
         fake_agent = _fake_agent_factory()
         monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "测试"}])
         await ltm.stop_listening()
@@ -587,7 +595,8 @@ class TestLongTermMemoryInterface:
         )
         monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
 
-        ltm = LongTermMemoryInterface(path, llm=MagicMock())
+        monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
+        ltm = LongTermMemoryInterface(path)
         ltm.start_listening()
         await ltm.send_history([{"role": "user", "content": "msg1"}])
         await ltm.send_history([{"role": "user", "content": "msg2"}])

--- a/tests/test_memory/test_narrative_integration.py
+++ b/tests/test_memory/test_narrative_integration.py
@@ -73,9 +73,10 @@ async def test_full_pipeline_cold_start_to_update(tmp_path, monkeypatch):
             return _make_fake_agent(entries_setup=setup3)
 
     monkeypatch.setattr(narrative, "create_agent", agent_factory)
+    monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
 
     # ── 初始化管线 ──
-    ltm = LongTermMemoryInterface(path, llm=MagicMock())
+    ltm = LongTermMemoryInterface(path)
     ltm.start_listening()
 
     # ── 第一轮对话 ──
@@ -141,8 +142,9 @@ async def test_pipeline_handles_concurrent_sends(tmp_path, monkeypatch):
         return _make_fake_agent(entries_setup=setup)
 
     monkeypatch.setattr(narrative, "create_agent", agent_factory)
+    monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
 
-    ltm = LongTermMemoryInterface(path, llm=MagicMock())
+    ltm = LongTermMemoryInterface(path)
     ltm.start_listening()
 
     # 快速连续投放 5 轮对话
@@ -175,8 +177,9 @@ async def test_send_history_is_non_blocking(tmp_path, monkeypatch):
     fake_agent = MagicMock()
     fake_agent.ainvoke = AsyncMock(side_effect=slow_ainvoke)
     monkeypatch.setattr(narrative, "create_agent", lambda **kw: fake_agent)
+    monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())
 
-    ltm = LongTermMemoryInterface(path, llm=MagicMock())
+    ltm = LongTermMemoryInterface(path)
     ltm.start_listening()
 
     import time


### PR DESCRIPTION
## Summary

### Bug fix

修复 `_consumer()` 中 LLM 不可用时的缺失 `memory_done` 发送：
- `get_default_llm() is None → continue` 位于 `try/finally` 块之前，跳过 `memory_done`
- 导致前端 WebSocket 持续显示"处理中…"而不是关闭占位
- 补充 `memory_done` 发送后再 `continue`，避免前端卡死

### Dead code cleanup

移除 `_consumer()` 中未使用的 `_sent_done = False` 变量。

### Test fix

commit `e4b2fd5` 移除了 `LongTermMemoryInterface.__init__` 的 `llm` 参数（改用内部 `get_default_llm()`），但 13 个测试未同步更新，全部因 `TypeError: unexpected keyword argument 'llm'` 失败：

- 移除 `llm=MagicMock()` 传参
- 补充 `monkeypatch.setattr(narrative, "get_default_llm", lambda: MagicMock())` 使消费者通过 LLM 可用性检查

## Test plan

- [x] `python -m pytest tests/test_memory/ -v` → 72 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)