### PR TITLE
fix(providers): 所有提供商类型统一映射到 OpenAIProvider

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -14,7 +14,7 @@ class ProviderConfig:
     """单个 LLM 提供商的配置，对应 providers.yaml 中的一项。"""
 
     id: str
-    provider_type: str  # "openai" — 目前仅此一种
+    provider_type: str  # 如 "openai"、"openrouter"、"deepseek" 等 OpenAI 兼容 API
     label: str
     api_key: str
     base_url: str

--- a/api/providers/manager.py
+++ b/api/providers/manager.py
@@ -140,12 +140,9 @@ class ProviderManager:
 
     @staticmethod
     def _build_provider(config: ProviderConfig) -> Provider:
-        if config.provider_type == "openai":
-            from api.providers.openai_provider import OpenAIProvider
+        from api.providers.openai_provider import OpenAIProvider
 
-            return OpenAIProvider(config)
-        msg = f"Unknown provider type: {config.provider_type}"
-        raise ValueError(msg)
+        return OpenAIProvider(config)
 
 
 # ── 模块级单例 ──────────────────────────────────────────────


### PR DESCRIPTION
## 问题

添加 OpenRouter 等非 `openai` 类型的提供商时，`_build_provider()` 抛出 `ValueError: Unknown provider type`。

## 修复

移除 `_build_provider()` 中的类型检查，所有提供商类型统一走 `OpenAIProvider`。因为所有第三方 LLM API 都兼容 OpenAI chat completions 格式。

## 变更文件

- `api/providers/manager.py` — 移除 provider_type 硬编码检查
- `api/providers/__init__.py` — 更新注释