### PR TITLE
feat(memory): 二维网格记忆看板

### DIFF
--- a/api/memory/long_term.py
+++ b/api/memory/long_term.py
@@ -356,6 +356,10 @@ class LongTermMemory:
             pass
         return []
 
+    def delete_memory(self, id: str) -> str:
+        """删除指定 ID 的单条记忆，返回被删除条目的描述。"""
+        return self._mm.delete(id)
+
     def inject_all(self) -> None:
         """向所有需要 mm 的地方注入当前 MemoryManager 实例。
 

--- a/api/memory/manager/base.py
+++ b/api/memory/manager/base.py
@@ -194,13 +194,12 @@ class BaseMemoryManager(ABC):
                     "description": item.description,
                     "history": item.show_description_history(),
                     "_sort_time": item.latest_update_time,
+                    "hit": item.hit,
                 }
             )
         # 每组内按更新时间倒序
         for theme in groups:
             groups[theme].sort(key=lambda x: x["_sort_time"], reverse=True)
-            for entry in groups[theme]:
-                del entry["_sort_time"]
         # 分区间按条目数降序
         sections = [
             {"theme": theme, "items": items}

--- a/api/routes/memory.py
+++ b/api/routes/memory.py
@@ -2,7 +2,7 @@
 
 import random
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 
 router = APIRouter()
 
@@ -17,6 +17,17 @@ async def get_long_term(request: Request) -> dict:
 async def get_memories(request: Request) -> dict:
     ltm = request.app.state.ltm
     return ltm._mm.get_memories_grouped()
+
+
+@router.delete("/memories/{memory_id}")
+async def delete_memory(memory_id: str, request: Request) -> dict:
+    """删除指定 ID 的单条记忆。"""
+    ltm = request.app.state.ltm
+    try:
+        description = ltm.delete_memory(memory_id)
+        return {"status": "deleted", "id": memory_id, "description": description}
+    except ValueError:
+        raise HTTPException(status_code=404, detail=f"Memory '{memory_id}' not found")
 
 
 @router.get("/moment")

--- a/api/routes/memory.py
+++ b/api/routes/memory.py
@@ -24,7 +24,7 @@ async def delete_memory(memory_id: str, request: Request) -> dict:
     """删除指定 ID 的单条记忆。"""
     ltm = request.app.state.ltm
     try:
-        description = ltm.delete_memory(memory_id)
+        description = ltm._mm.delete(memory_id)
         return {"status": "deleted", "id": memory_id, "description": description}
     except ValueError:
         raise HTTPException(status_code=404, detail=f"Memory '{memory_id}' not found")

--- a/api/routes/memory.py
+++ b/api/routes/memory.py
@@ -24,7 +24,7 @@ async def delete_memory(memory_id: str, request: Request) -> dict:
     """删除指定 ID 的单条记忆。"""
     ltm = request.app.state.ltm
     try:
-        description = ltm._mm.delete(memory_id)
+        description = ltm.delete_memory(memory_id)
         return {"status": "deleted", "id": memory_id, "description": description}
     except ValueError:
         raise HTTPException(status_code=404, detail=f"Memory '{memory_id}' not found")

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -80,6 +80,9 @@ export const api = {
   getMemories: () =>
     request<VignetteResponse>('/memories'),
 
+  deleteMemory: (id: string) =>
+    request<{ status: string; id: string; description: string }>(`/memories/${id}`, { method: 'DELETE' }),
+
   getContextUsage: (sessionId: string) =>
     request<ContextUsage & { session_id: string }>(`/sessions/${sessionId}/context-usage`),
 

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -1,0 +1,444 @@
+<template>
+  <div class="memory-grid">
+    <!-- ── 加载态 ── -->
+    <template v-if="loading">
+      <div class="loading-bar">加载记忆网格…</div>
+    </template>
+
+    <!-- ── 空态 ── -->
+    <template v-else-if="sections.length === 0">
+      <div class="empty-state">
+        <div class="empty-icon">🧠</div>
+        <p>还没有记忆，开始对话吧。</p>
+      </div>
+    </template>
+
+    <!-- ── 数据 ── -->
+    <template v-else>
+      <!-- 搜索条 -->
+      <div class="search-widget">
+        <span class="search-icon">🔍</span>
+        <input
+          ref="searchRef"
+          v-model="searchQuery"
+          type="text"
+          placeholder="在所有记忆中搜索…"
+          @input="onSearch"
+        />
+        <span class="search-count">{{ filteredSections.reduce((s, sec) => s + sec.items.length, 0) }}/{{ sections.reduce((s, sec) => s + sec.items.length, 0) }}</span>
+      </div>
+
+      <!-- 统计条 -->
+      <div class="stat-grid">
+        <div class="stat-cell">
+          <div class="stat-num">{{ totalItems }}</div>
+          <div class="stat-label">记忆条目</div>
+        </div>
+        <div class="stat-cell">
+          <div class="stat-num">{{ sections.length }}</div>
+          <div class="stat-label">分区</div>
+        </div>
+        <div class="stat-cell">
+          <div class="stat-num">{{ totalHits }}</div>
+          <div class="stat-label">总引用</div>
+        </div>
+        <div class="stat-cell">
+          <div class="stat-num">{{ avgHits }}</div>
+          <div class="stat-label">均引用</div>
+        </div>
+      </div>
+
+      <!-- 二维网格 -->
+      <div class="grid">
+        <!-- 热门记忆 -->
+        <div v-if="hotMemories.length" class="widget hot-widget">
+          <div class="widget-header">
+            <span class="widget-title">🔥 热门记忆</span>
+            <span class="widget-badge">引用最多</span>
+          </div>
+          <div class="widget-body">
+            <div class="hot-list">
+              <div v-for="(item, i) in hotMemories" :key="'hot-' + i" class="hot-item">
+                <span class="hot-rank" :class="'rank-' + (i + 1)">{{ i + 1 }}</span>
+                <span class="hot-desc">{{ item.description }}</span>
+                <span class="hot-num">📌 {{ item.hit }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 最近活动 -->
+        <div v-if="recentMemories.length" class="widget recent-widget">
+          <div class="widget-header">
+            <span class="widget-title">🕐 最近活动</span>
+            <span class="widget-badge">最新更新</span>
+          </div>
+          <div class="widget-body">
+            <div class="timeline">
+              <div v-for="item in recentMemories" :key="'recent-' + item.id" class="tl-item">
+                <div class="tl-time">{{ item._sort_time }}</div>
+                <div class="tl-desc">{{ item.description }}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 分区卡片 -->
+        <div
+          v-for="(section, si) in filteredSections"
+          :key="'sec-' + si"
+          class="widget section-widget"
+          :style="{ gridRow: 'span ' + sectionRowSpan(section) }"
+        >
+          <div class="widget-header">
+            <span class="widget-title">
+              <span class="theme-dot" :style="{ background: themeColor(si) }"></span>
+              {{ section.theme }}
+            </span>
+            <span class="widget-badge">{{ section.items.length }}</span>
+          </div>
+          <div class="widget-body">
+            <div class="memory-list">
+              <div v-for="item in section.items" :key="item.id" class="memory-item">
+                <div class="item-meta">
+                  <span class="item-tag">{{ item.id }}</span>
+                  <span class="item-hit">📌 <strong>{{ item.hit }}</strong></span>
+                  <span class="item-time">{{ item._sort_time }}</span>
+                  <span
+                    v-if="item.history && item.history.length > 0"
+                    class="item-history-toggle"
+                    @click="toggleHistory(item.id)"
+                  >📜</span>
+                </div>
+                <div class="item-desc" v-html="highlight(item.description)"></div>
+                <div
+                  v-if="item.history && item.history.length > 0 && expandedHistory === item.id"
+                  class="history-pop"
+                >
+                  <div v-for="(h, hi) in item.history" :key="'h-' + hi" class="h-row">
+                    <span class="h-text">{{ h.description }}</span>
+                    <span class="h-time">{{ h.time }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, nextTick } from 'vue'
+import { api } from '@/api'
+import type { VignetteSection } from '@/types'
+
+// ── 状态 ──
+const loading = ref(true)
+const sections = ref<VignetteSection[]>([])
+const searchQuery = ref('')
+const expandedHistory = ref<string | null>(null)
+const searchRef = ref<HTMLInputElement>()
+
+// ── 数据加载 ──
+async function loadMemories() {
+  loading.value = true
+  try {
+    const res = await api.getMemories()
+    sections.value = res.sections || []
+  } catch {
+    sections.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+// ── 统计计算 ──
+const allItems = computed(() => sections.value.flatMap(s => s.items))
+const totalItems = computed(() => allItems.value.length)
+const totalHits = computed(() => allItems.value.reduce((s, i) => s + (i.hit || 0), 0))
+const avgHits = computed(() => {
+  const n = totalItems.value
+  return n ? (totalHits.value / n).toFixed(1) : '0'
+})
+
+// ── 搜索 ──
+const filteredSections = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return sections.value
+  return sections.value
+    .map(s => ({
+      ...s,
+      items: s.items.filter(i => i.description.toLowerCase().includes(q)),
+    }))
+    .filter(s => s.items.length > 0)
+})
+
+function onSearch() {
+  // 高亮重新渲染，无需额外操作
+}
+
+// ── 热门记忆 Top 3 ──
+const hotMemories = computed(() =>
+  [...allItems.value]
+    .sort((a, b) => (b.hit || 0) - (a.hit || 0))
+    .slice(0, 3)
+)
+
+// ── 最近活动 Top 5 ──
+const recentMemories = computed(() =>
+  [...allItems.value]
+    .sort((a, b) => b._sort_time.localeCompare(a._sort_time))
+    .slice(0, 5)
+)
+
+// ── 辅助 ──
+const THEME_COLORS = ['#000', '#444', '#666', '#888', '#aaa', '#bbb', '#ccc']
+
+function themeColor(index: number): string {
+  return THEME_COLORS[index % THEME_COLORS.length]
+}
+
+function sectionRowSpan(section: VignetteSection): number {
+  const len = section.items.length
+  if (len <= 2) return 1
+  if (len <= 4) return 2
+  return 3
+}
+
+function toggleHistory(id: string) {
+  expandedHistory.value = expandedHistory.value === id ? null : id
+}
+
+function highlight(text: string): string {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return escapeHtml(text)
+  const re = new RegExp('(' + q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'gi')
+  return escapeHtml(text).replace(new RegExp(escapeHtml(q), 'gi'), m => '<mark>' + m + '</mark>')
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+onMounted(loadMemories)
+</script>
+
+<style scoped>
+.memory-grid {
+  max-width: 1200px;
+}
+
+/* ── 加载态 ── */
+.loading-bar {
+  text-align: center;
+  padding: 40px 0;
+  color: var(--text-tertiary);
+  font-size: 14px;
+}
+
+/* ── 空态 ── */
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.empty-icon { font-size: 36px; margin-bottom: 10px; }
+.empty-state p { font-size: 14px; color: var(--text-tertiary); }
+
+/* ── 搜索条 ── */
+.search-widget {
+  display: flex; align-items: center;
+  padding: 8px 10px 8px 18px;
+  margin-bottom: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  gap: 10px;
+}
+.search-icon { color: var(--text-tertiary); font-size: 15px; }
+.search-widget input {
+  flex: 1; border: none; outline: none; font-size: 14px;
+  color: var(--text-primary); background: transparent;
+  font-family: inherit;
+}
+.search-widget input::placeholder { color: var(--text-tertiary); }
+.search-count {
+  font-size: 12px; color: var(--text-tertiary); white-space: nowrap;
+  padding: 2px 10px; background: var(--bg-secondary);
+  border-radius: 999px;
+}
+
+/* ── 统计条 ── */
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-bottom: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.stat-cell {
+  text-align: center; padding: 16px 8px;
+  border-right: 1px solid var(--border);
+}
+.stat-cell:last-child { border-right: none; }
+.stat-num {
+  font-size: 26px; font-weight: 700; color: var(--accent);
+  line-height: 1.2; letter-spacing: -0.5px;
+}
+.stat-label {
+  font-size: 12px; color: var(--text-tertiary); margin-top: 2px;
+}
+
+/* ── 网格 ── */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+/* ── 通用组件 ── */
+.widget {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition: box-shadow 0.2s;
+}
+.widget:hover {
+  box-shadow: 0 2px 12px rgba(0,0,0,0.06);
+}
+.hot-widget { grid-column: span 2; grid-row: span 2; }
+.recent-widget { grid-column: span 2; grid-row: span 1; }
+.section-widget { grid-column: span 1; }
+
+.widget-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+.widget-title {
+  font-size: 12px; font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.4px; color: var(--text-tertiary);
+  display: flex; align-items: center; gap: 6px;
+}
+.widget-badge {
+  font-size: 10px; padding: 1px 8px; border-radius: 999px;
+  background: var(--bg-card); color: var(--text-tertiary);
+  font-weight: 500; border: 1px solid var(--border);
+}
+.widget-body { padding: 10px 14px; }
+
+/* ── 热门记忆 ── */
+.hot-list { display: flex; flex-direction: column; gap: 8px; }
+.hot-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px; border-radius: 6px;
+  background: var(--bg-secondary);
+}
+.hot-rank {
+  width: 22px; height: 22px; display: flex; align-items: center;
+  justify-content: center; border-radius: 999px;
+  font-size: 11px; font-weight: 700; flex-shrink: 0;
+  background: var(--border); color: var(--text-tertiary);
+}
+.hot-rank.rank-1 { background: #1a1a1a; color: #fff; }
+.hot-rank.rank-2 { background: #555; color: #fff; }
+.hot-rank.rank-3 { background: #999; color: #fff; }
+.hot-desc {
+  flex: 1; font-size: 13px; line-height: 1.5;
+  overflow: hidden; text-overflow: ellipsis;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+}
+.hot-num { font-size: 11px; color: var(--text-tertiary); white-space: nowrap; }
+
+/* ── 时间线 ── */
+.timeline { position: relative; padding-left: 16px; }
+.timeline::before {
+  content: ''; position: absolute; left: 4px; top: 4px; bottom: 4px;
+  width: 1px; background: var(--border);
+}
+.tl-item { position: relative; margin-bottom: 12px; }
+.tl-item:last-child { margin-bottom: 0; }
+.tl-item::before {
+  content: ''; position: absolute; left: -12px; top: 5px;
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--accent); border: 2px solid var(--bg-card);
+}
+.tl-time { font-size: 11px; color: var(--text-tertiary); margin-bottom: 2px; }
+.tl-desc { font-size: 13px; line-height: 1.5; color: var(--text-primary); }
+
+/* ── 分区条目 ── */
+.memory-list { display: flex; flex-direction: column; gap: 6px; }
+.memory-item {
+  padding: 8px 10px; border-radius: 6px;
+  background: var(--bg-secondary);
+}
+.item-meta {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 3px; font-size: 11px; color: var(--text-tertiary);
+}
+.item-tag {
+  font-family: 'SF Mono', 'Consolas', monospace; font-size: 10px;
+  padding: 1px 5px; border-radius: 3px;
+  background: var(--bg-card); color: var(--text-tertiary);
+  border: 1px solid var(--border);
+}
+.item-hit strong { color: var(--text-secondary); }
+.item-time { color: var(--text-tertiary); }
+.item-history-toggle {
+  cursor: pointer; margin-left: auto;
+  opacity: 0.5; transition: opacity 0.12s;
+}
+.item-history-toggle:hover { opacity: 1; }
+.item-desc {
+  font-size: 13px; line-height: 1.6; color: var(--text-primary);
+}
+.item-desc :deep(mark) {
+  background: #fef9c3; color: #854d0e; border-radius: 2px; padding: 0 2px;
+}
+
+/* ── 历史追溯 ── */
+.history-pop {
+  margin-top: 6px; padding: 6px 8px; background: var(--bg-card);
+  border-radius: 4px; font-size: 12px; line-height: 1.6;
+  border-left: 2px solid var(--border);
+}
+.h-row {
+  padding: 3px 0; border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+.h-row:last-child { border-bottom: none; }
+.h-time { font-size: 10px; color: var(--text-tertiary); margin-left: 6px; }
+
+/* ── 圆点 ── */
+.theme-dot {
+  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ── 响应式 ── */
+@media (max-width: 900px) {
+  .grid { grid-template-columns: repeat(2, 1fr); }
+  .hot-widget { grid-column: span 2; grid-row: span 1; }
+  .recent-widget { grid-column: span 2; }
+  .section-widget { grid-column: span 1; }
+}
+@media (max-width: 560px) {
+  .grid { grid-template-columns: 1fr; }
+  .hot-widget,
+  .recent-widget,
+  .section-widget { grid-column: 1; }
+  .stat-grid { grid-template-columns: repeat(2, 1fr); }
+  .stat-cell:nth-child(2) { border-right: none; }
+}
+</style>

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -32,7 +32,7 @@
       <div class="stats-bar">
         <div class="stats-brand">
           <span class="stats-title">Memory</span>
-          <span class="stats-subtitle">remembered for you</span>
+          <span class="stats-subtitle">Remembered For You</span>
         </div>
         <div class="stats-metrics">
           <div class="stats-donut">

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -28,23 +28,23 @@
         <span class="search-count">{{ filteredSections.reduce((s, sec) => s + sec.items.length, 0) }}/{{ sections.reduce((s, sec) => s + sec.items.length, 0) }}</span>
       </div>
 
-      <!-- 统计条 -->
-      <div class="stat-grid">
-        <div class="stat-cell">
-          <div class="stat-num">{{ totalItems }}</div>
-          <div class="stat-label">记忆条目</div>
-        </div>
-        <div class="stat-cell">
-          <div class="stat-num">{{ sections.length }}</div>
-          <div class="stat-label">分区</div>
-        </div>
-        <div class="stat-cell">
-          <div class="stat-num">{{ totalHits }}</div>
-          <div class="stat-label">总引用</div>
-        </div>
-        <div class="stat-cell">
-          <div class="stat-num">{{ avgHits }}</div>
-          <div class="stat-label">均引用</div>
+      <!-- 统计环形图 -->
+      <div class="donut-row">
+        <div class="donut-cell" v-for="s in stats" :key="s.label">
+          <svg viewBox="0 0 80 80" width="80" height="80">
+            <circle cx="40" cy="40" r="28" fill="none" stroke="var(--border)" stroke-width="5" />
+            <circle
+              cx="40" cy="40" r="28" fill="none"
+              stroke="var(--accent)" stroke-width="5" stroke-linecap="round"
+              :stroke-dasharray="s.dashArray"
+              transform="rotate(-90 40 40)"
+            />
+            <text x="40" y="36" text-anchor="middle" fill="var(--text-primary)"
+              font-size="16" font-weight="700">{{ s.value }}</text>
+            <text x="40" y="50" text-anchor="middle" fill="var(--text-tertiary)"
+              font-size="9">{{ s.unit }}</text>
+          </svg>
+          <div class="donut-label">{{ s.label }}</div>
         </div>
       </div>
 
@@ -163,6 +163,21 @@ const avgHits = computed(() => {
   return n ? (totalHits.value / n).toFixed(1) : '0'
 })
 
+const R = 28
+const CIRCUM = 2 * Math.PI * R
+
+function dash(ratio: number): string {
+  const clamped = Math.min(ratio, 1)
+  return `${clamped * CIRCUM} ${(1 - clamped) * CIRCUM}`
+}
+
+const stats = computed(() => [
+  { value: totalItems.value, unit: '条', label: '记忆条目', dashArray: dash(totalItems.value / 50) },
+  { value: sections.value.length, unit: '个', label: '分区', dashArray: dash(sections.value.length / 10) },
+  { value: totalHits.value, unit: '次', label: '总引用', dashArray: dash(totalHits.value / 100) },
+  { value: parseFloat(avgHits.value), unit: '次', label: '均引用', dashArray: dash(parseFloat(avgHits.value) / 10) },
+])
+
 // ── 搜索 ──
 const filteredSections = computed(() => {
   const q = searchQuery.value.trim().toLowerCase()
@@ -277,26 +292,26 @@ onMounted(loadMemories)
   border-radius: 999px;
 }
 
-/* ── 统计条 ── */
-.stat-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
+/* ── 统计环形图 ── */
+.donut-row {
+  display: flex;
+  justify-content: center;
+  gap: 32px;
   margin-bottom: 12px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
+  padding: 16px 8px;
 }
-.stat-cell {
-  text-align: center; padding: 16px 8px;
-  border-right: 1px solid var(--border);
+.donut-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
 }
-.stat-cell:last-child { border-right: none; }
-.stat-num {
-  font-size: 26px; font-weight: 700; color: var(--accent);
-  line-height: 1.2; letter-spacing: -0.5px;
-}
-.stat-label {
-  font-size: 12px; color: var(--text-tertiary); margin-top: 2px;
+.donut-label {
+  font-size: 11px;
+  color: var(--text-tertiary);
 }
 
 /* ── 网格 ── */
@@ -439,7 +454,7 @@ onMounted(loadMemories)
   .hot-widget,
   .recent-widget,
   .section-widget { grid-column: 1; }
-  .stat-grid { grid-template-columns: repeat(2, 1fr); }
-  .stat-cell:nth-child(2) { border-right: none; }
+  .donut-row { gap: 12px; flex-wrap: wrap; }
+  .donut-cell { width: 80px; }
 }
 </style>

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -28,7 +28,7 @@
         <span class="search-count">{{ filteredSections.reduce((s, sec) => s + sec.items.length, 0) }}/{{ sections.reduce((s, sec) => s + sec.items.length, 0) }}</span>
       </div>
 
-      <!-- 统计栏：左环形图 + 右数字 -->
+      <!-- 统计栏：左环形图 + 右标题与数字 -->
       <div class="stats-bar">
         <div class="stats-donut">
           <svg viewBox="0 0 120 120" width="120" height="120" class="donut-svg">
@@ -45,18 +45,24 @@
             <span class="donut-unit">均引用</span>
           </div>
         </div>
-        <div class="stats-list">
-          <div class="stats-item">
-            <span class="stats-item-num">{{ totalItems }}</span>
-            <span class="stats-item-label">记忆条目</span>
+        <div class="stats-right">
+          <div class="stats-brand">
+            <span class="stats-title">Memory</span>
+            <span class="stats-subtitle">remembered for you</span>
           </div>
-          <div class="stats-item">
-            <span class="stats-item-num">{{ sections.length }}</span>
-            <span class="stats-item-label">分区</span>
-          </div>
-          <div class="stats-item">
-            <span class="stats-item-num">{{ totalHits }}</span>
-            <span class="stats-item-label">总引用</span>
+          <div class="stats-figures">
+            <div class="stat-figure">
+              <span class="figure-num">{{ totalItems }}</span>
+              <span class="figure-label">记忆条目</span>
+            </div>
+            <div class="stat-figure">
+              <span class="figure-num">{{ sections.length }}</span>
+              <span class="figure-label">分区</span>
+            </div>
+            <div class="stat-figure">
+              <span class="figure-num">{{ totalHits }}</span>
+              <span class="figure-label">总引用</span>
+            </div>
           </div>
         </div>
       </div>
@@ -338,24 +344,46 @@ onMounted(loadMemories)
   color: var(--text-tertiary);
   line-height: 1;
 }
-.stats-list {
+.stats-right {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 14px;
 }
-.stats-item {
+.stats-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.stats-title {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.5px;
+  line-height: 1.1;
+}
+.stats-subtitle {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-weight: 400;
+  letter-spacing: 0.2px;
+}
+.stats-figures {
+  display: flex;
+  gap: 24px;
+}
+.stat-figure {
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: 8px;
 }
-.stats-item-num {
-  font-size: 22px;
+.figure-num {
+  font-size: 20px;
   font-weight: 700;
   color: var(--accent);
   letter-spacing: -0.3px;
-  min-width: 3ch;
 }
-.stats-item-label {
+.figure-label {
   font-size: 13px;
   color: var(--text-tertiary);
 }
@@ -501,5 +529,6 @@ onMounted(loadMemories)
   .recent-widget,
   .section-widget { grid-column: 1; }
   .stats-bar { flex-direction: column; align-items: flex-start; gap: 16px; }
+  .stats-figures { flex-wrap: wrap; gap: 16px; }
 }
 </style>

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -117,7 +117,7 @@
           </div>
           <div class="widget-body">
             <div class="memory-list">
-              <div v-for="item in section.items" :key="item.id" class="memory-item">
+              <div v-for="item in visibleItems(section, si)" :key="item.id" class="memory-item">
                 <div class="item-meta">
                   <span class="item-tag">{{ item.id }}</span>
                   <span class="item-hit">📌 <strong>{{ item.hit }}</strong></span>
@@ -140,6 +140,11 @@
                 </div>
               </div>
             </div>
+            <button
+              v-if="section.items.length > MAX_VISIBLE"
+              class="expand-btn"
+              @click="toggleSection(si)"
+            >{{ expandedSections.has(si) ? '收起' : `展开全部 ${section.items.length} 条` }}</button>
           </div>
         </div>
       </div>
@@ -158,6 +163,9 @@ const sections = ref<VignetteSection[]>([])
 const searchQuery = ref('')
 const expandedHistory = ref<string | null>(null)
 const searchRef = ref<HTMLInputElement>()
+const expandedSections = ref<Set<number>>(new Set())
+
+const MAX_VISIBLE = 20
 
 // ── 数据加载 ──
 async function loadMemories() {
@@ -228,6 +236,17 @@ function themeColor(index: number): string {
 
 function toggleHistory(id: string) {
   expandedHistory.value = expandedHistory.value === id ? null : id
+}
+
+function visibleItems(section: VignetteSection, index: number) {
+  if (expandedSections.value.has(index)) return section.items
+  return section.items.slice(0, MAX_VISIBLE)
+}
+
+function toggleSection(index: number) {
+  const s = new Set(expandedSections.value)
+  if (s.has(index)) s.delete(index) else s.add(index)
+  expandedSections.value = s
 }
 
 function highlight(text: string): string {
@@ -402,7 +421,7 @@ onMounted(loadMemories)
   box-shadow: 0 2px 12px rgba(0,0,0,0.06);
 }
 .hot-widget { grid-column: span 2; grid-row: span 2; }
-.recent-widget { grid-column: span 2; grid-row: span 1; }
+.recent-widget { grid-column: span 2; grid-row: span 2; }
 .section-widget { grid-column: span 1; }
 
 .widget-header {
@@ -504,6 +523,26 @@ onMounted(loadMemories)
 }
 .h-row:last-child { border-bottom: none; }
 .h-time { font-size: 10px; color: var(--text-tertiary); margin-left: 6px; }
+
+/* ── 展开按钮 ── */
+.expand-btn {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  padding: 6px 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.expand-btn:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
 
 /* ── 圆点 ── */
 .theme-dot {

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -144,7 +144,7 @@
               v-if="section.items.length > MAX_VISIBLE"
               class="expand-btn"
               @click="toggleSection(si)"
-            >{{ expandedSections.has(si) ? '收起' : `展开全部 ${section.items.length} 条` }}</button>
+            >{{ expandedSections.includes(si) ? '收起' : `展开全部 ${section.items.length} 条` }}</button>
           </div>
         </div>
       </div>
@@ -163,7 +163,7 @@ const sections = ref<VignetteSection[]>([])
 const searchQuery = ref('')
 const expandedHistory = ref<string | null>(null)
 const searchRef = ref<HTMLInputElement>()
-const expandedSections = ref<Set<number>>(new Set())
+const expandedSections = ref<number[]>([])
 
 const MAX_VISIBLE = 20
 
@@ -239,14 +239,16 @@ function toggleHistory(id: string) {
 }
 
 function visibleItems(section: VignetteSection, index: number) {
-  if (expandedSections.value.has(index)) return section.items
+  if (expandedSections.value.includes(index)) return section.items
   return section.items.slice(0, MAX_VISIBLE)
 }
 
 function toggleSection(index: number) {
-  const s = new Set(expandedSections.value)
-  if (s.has(index)) s.delete(index) else s.add(index)
-  expandedSections.value = s
+  if (expandedSections.value.includes(index)) {
+    expandedSections.value = expandedSections.value.filter(i => i !== index)
+  } else {
+    expandedSections.value = [...expandedSections.value, index]
+  }
 }
 
 function highlight(text: string): string {

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -127,6 +127,7 @@
                     class="item-history-toggle"
                     @click="toggleHistory(item.id)"
                   >📜</span>
+                  <span class="item-delete" @click="handleDelete(item.id, $event)">✕</span>
                 </div>
                 <div class="item-desc" v-html="highlight(item.description)"></div>
                 <div
@@ -153,7 +154,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, nextTick } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { api } from '@/api'
 import type { VignetteSection } from '@/types'
 
@@ -241,6 +242,18 @@ function toggleHistory(id: string) {
 function visibleItems(section: VignetteSection, index: number) {
   if (expandedSections.value.includes(index)) return section.items
   return section.items.slice(0, MAX_VISIBLE)
+}
+
+async function handleDelete(id: string, event: MouseEvent) {
+  event.stopPropagation()
+  if (!confirm(`确定删除记忆「${id}」？`)) return
+  try {
+    await api.deleteMemory(id)
+    const res = await api.getMemories()
+    sections.value = res.sections || []
+  } catch (e: any) {
+    alert('删除失败: ' + (e.message || e))
+  }
 }
 
 function toggleSection(index: number) {
@@ -506,6 +519,21 @@ onMounted(loadMemories)
   opacity: 0.5; transition: opacity 0.12s;
 }
 .item-history-toggle:hover { opacity: 1; }
+.item-delete {
+  cursor: pointer;
+  opacity: 0;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  transition: opacity 0.12s, color 0.12s;
+  padding: 0 4px;
+}
+.memory-item:hover .item-delete {
+  opacity: 0.5;
+}
+.item-delete:hover {
+  color: var(--status-error) !important;
+  opacity: 1 !important;
+}
 .item-desc {
   font-size: 13px; line-height: 1.6; color: var(--text-primary);
 }

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -28,27 +28,27 @@
         <span class="search-count">{{ filteredSections.reduce((s, sec) => s + sec.items.length, 0) }}/{{ sections.reduce((s, sec) => s + sec.items.length, 0) }}</span>
       </div>
 
-      <!-- 统计栏：左环形图 + 右标题与数字 -->
+      <!-- 统计栏：左标题 + 右环形图与数字 -->
       <div class="stats-bar">
-        <div class="stats-donut">
-          <svg viewBox="0 0 120 120" width="120" height="120" class="donut-svg">
-            <circle cx="60" cy="60" r="42" fill="none" stroke="var(--border)" stroke-width="12" />
-            <circle
-              cx="60" cy="60" r="42" fill="none"
-              stroke="var(--accent)" stroke-width="12"
-              :stroke-dasharray="avgDash"
-              transform="rotate(-90 60 60)"
-            />
-          </svg>
-          <div class="donut-text">
-            <span class="donut-value">{{ avgHits }}</span>
-            <span class="donut-unit">均引用</span>
-          </div>
+        <div class="stats-brand">
+          <span class="stats-title">Memory</span>
+          <span class="stats-subtitle">remembered for you</span>
         </div>
-        <div class="stats-right">
-          <div class="stats-brand">
-            <span class="stats-title">Memory</span>
-            <span class="stats-subtitle">remembered for you</span>
+        <div class="stats-metrics">
+          <div class="stats-donut">
+            <svg viewBox="0 0 120 120" width="104" height="104" class="donut-svg">
+              <circle cx="60" cy="60" r="42" fill="none" stroke="var(--border)" stroke-width="12" />
+              <circle
+                cx="60" cy="60" r="42" fill="none"
+                stroke="var(--accent)" stroke-width="12"
+                :stroke-dasharray="avgDash"
+                transform="rotate(-90 60 60)"
+              />
+            </svg>
+            <div class="donut-text">
+              <span class="donut-value">{{ avgHits }}</span>
+              <span class="donut-unit">均引用</span>
+            </div>
           </div>
           <div class="stats-figures">
             <div class="stat-figure">
@@ -315,11 +315,35 @@ onMounted(loadMemories)
   border-radius: var(--radius);
   padding: 20px 24px;
 }
+.stats-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.stats-title {
+  font-size: 40px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.8px;
+  line-height: 1.05;
+}
+.stats-subtitle {
+  font-size: 14px;
+  color: var(--text-tertiary);
+  font-weight: 400;
+  letter-spacing: 0.4px;
+}
+.stats-metrics {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-left: auto;
+}
 .stats-donut {
   flex-shrink: 0;
   position: relative;
-  width: 120px;
-  height: 120px;
+  width: 104px;
+  height: 104px;
 }
 .donut-svg {
   display: block;
@@ -334,7 +358,7 @@ onMounted(loadMemories)
   pointer-events: none;
 }
 .donut-value {
-  font-size: 26px;
+  font-size: 24px;
   font-weight: 700;
   color: var(--text-primary);
   line-height: 1.2;
@@ -344,33 +368,10 @@ onMounted(loadMemories)
   color: var(--text-tertiary);
   line-height: 1;
 }
-.stats-right {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-.stats-brand {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-.stats-title {
-  font-size: 32px;
-  font-weight: 700;
-  color: var(--text-primary);
-  letter-spacing: -0.5px;
-  line-height: 1.1;
-}
-.stats-subtitle {
-  font-size: 13px;
-  color: var(--text-tertiary);
-  font-weight: 400;
-  letter-spacing: 0.2px;
-}
 .stats-figures {
   display: flex;
-  gap: 24px;
+  flex-direction: column;
+  gap: 6px;
 }
 .stat-figure {
   display: flex;
@@ -378,10 +379,11 @@ onMounted(loadMemories)
   gap: 8px;
 }
 .figure-num {
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 700;
   color: var(--accent);
   letter-spacing: -0.3px;
+  min-width: 3ch;
 }
 .figure-label {
   font-size: 13px;
@@ -529,6 +531,6 @@ onMounted(loadMemories)
   .recent-widget,
   .section-widget { grid-column: 1; }
   .stats-bar { flex-direction: column; align-items: flex-start; gap: 16px; }
-  .stats-figures { flex-wrap: wrap; gap: 16px; }
+  .stats-metrics { margin-left: 0; }
 }
 </style>

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -28,23 +28,36 @@
         <span class="search-count">{{ filteredSections.reduce((s, sec) => s + sec.items.length, 0) }}/{{ sections.reduce((s, sec) => s + sec.items.length, 0) }}</span>
       </div>
 
-      <!-- 统计环形图 -->
-      <div class="donut-row">
-        <div class="donut-cell" v-for="s in stats" :key="s.label">
-          <svg viewBox="0 0 80 80" width="80" height="80">
-            <circle cx="40" cy="40" r="28" fill="none" stroke="var(--border)" stroke-width="5" />
+      <!-- 统计栏：左环形图 + 右数字 -->
+      <div class="stats-bar">
+        <div class="stats-donut">
+          <svg viewBox="0 0 120 120" width="120" height="120">
+            <circle cx="60" cy="60" r="42" fill="none" stroke="var(--border)" stroke-width="12" />
             <circle
-              cx="40" cy="40" r="28" fill="none"
-              stroke="var(--accent)" stroke-width="5" stroke-linecap="round"
-              :stroke-dasharray="s.dashArray"
-              transform="rotate(-90 40 40)"
+              cx="60" cy="60" r="42" fill="none"
+              stroke="var(--accent)" stroke-width="12"
+              :stroke-dasharray="avgDash"
+              transform="rotate(-90 60 60)"
             />
-            <text x="40" y="36" text-anchor="middle" fill="var(--text-primary)"
-              font-size="16" font-weight="700">{{ s.value }}</text>
-            <text x="40" y="50" text-anchor="middle" fill="var(--text-tertiary)"
-              font-size="9">{{ s.unit }}</text>
+            <text x="60" y="52" text-anchor="middle" fill="var(--text-primary)"
+              font-size="26" font-weight="700">{{ avgHits }}</text>
+            <text x="60" y="70" text-anchor="middle" fill="var(--text-tertiary)"
+              font-size="11">均引用</text>
           </svg>
-          <div class="donut-label">{{ s.label }}</div>
+        </div>
+        <div class="stats-list">
+          <div class="stats-item">
+            <span class="stats-item-num">{{ totalItems }}</span>
+            <span class="stats-item-label">记忆条目</span>
+          </div>
+          <div class="stats-item">
+            <span class="stats-item-num">{{ sections.length }}</span>
+            <span class="stats-item-label">分区</span>
+          </div>
+          <div class="stats-item">
+            <span class="stats-item-num">{{ totalHits }}</span>
+            <span class="stats-item-label">总引用</span>
+          </div>
         </div>
       </div>
 
@@ -163,20 +176,13 @@ const avgHits = computed(() => {
   return n ? (totalHits.value / n).toFixed(1) : '0'
 })
 
-const R = 28
-const CIRCUM = 2 * Math.PI * R
-
-function dash(ratio: number): string {
-  const clamped = Math.min(ratio, 1)
-  return `${clamped * CIRCUM} ${(1 - clamped) * CIRCUM}`
-}
-
-const stats = computed(() => [
-  { value: totalItems.value, unit: '条', label: '记忆条目', dashArray: dash(totalItems.value / 50) },
-  { value: sections.value.length, unit: '个', label: '分区', dashArray: dash(sections.value.length / 10) },
-  { value: totalHits.value, unit: '次', label: '总引用', dashArray: dash(totalHits.value / 100) },
-  { value: parseFloat(avgHits.value), unit: '次', label: '均引用', dashArray: dash(parseFloat(avgHits.value) / 10) },
-])
+const avgR = 42
+const avgCircum = 2 * Math.PI * avgR
+const avgDash = computed(() => {
+  const val = parseFloat(avgHits.value)
+  const r = Math.min(val / 10, 1)
+  return `${r * avgCircum} ${(1 - r) * avgCircum}`
+})
 
 // ── 搜索 ──
 const filteredSections = computed(() => {
@@ -292,25 +298,40 @@ onMounted(loadMemories)
   border-radius: 999px;
 }
 
-/* ── 统计环形图 ── */
-.donut-row {
+/* ── 统计栏：左环形图 + 右数字 ── */
+.stats-bar {
   display: flex;
-  justify-content: center;
-  gap: 32px;
+  align-items: center;
+  gap: 24px;
   margin-bottom: 12px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 16px 8px;
+  padding: 20px 24px;
 }
-.donut-cell {
+.stats-donut {
+  flex-shrink: 0;
+  line-height: 0;
+}
+.stats-list {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 4px;
+  gap: 10px;
 }
-.donut-label {
-  font-size: 11px;
+.stats-item {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.stats-item-num {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: -0.3px;
+  min-width: 3ch;
+}
+.stats-item-label {
+  font-size: 13px;
   color: var(--text-tertiary);
 }
 
@@ -454,7 +475,6 @@ onMounted(loadMemories)
   .hot-widget,
   .recent-widget,
   .section-widget { grid-column: 1; }
-  .donut-row { gap: 12px; flex-wrap: wrap; }
-  .donut-cell { width: 80px; }
+  .stats-bar { flex-direction: column; align-items: flex-start; gap: 16px; }
 }
 </style>

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -39,9 +39,9 @@
               :stroke-dasharray="avgDash"
               transform="rotate(-90 60 60)"
             />
-            <text x="60" y="52" text-anchor="middle" fill="var(--text-primary)"
-              font-size="26" font-weight="700">{{ avgHits }}</text>
-            <text x="60" y="70" text-anchor="middle" fill="var(--text-tertiary)"
+            <text x="60" y="58" text-anchor="middle" fill="var(--text-primary)"
+              font-size="26" font-weight="700" dominant-baseline="central">{{ avgHits }}</text>
+            <text x="60" y="84" text-anchor="middle" fill="var(--text-tertiary)"
               font-size="11">均引用</text>
           </svg>
         </div>

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -107,7 +107,6 @@
           v-for="(section, si) in filteredSections"
           :key="'sec-' + si"
           class="widget section-widget"
-          :style="{ gridRow: 'span ' + sectionRowSpan(section) }"
         >
           <div class="widget-header">
             <span class="widget-title">
@@ -225,13 +224,6 @@ const THEME_COLORS = ['#000', '#444', '#666', '#888', '#aaa', '#bbb', '#ccc']
 
 function themeColor(index: number): string {
   return THEME_COLORS[index % THEME_COLORS.length]
-}
-
-function sectionRowSpan(section: VignetteSection): number {
-  const len = section.items.length
-  if (len <= 2) return 1
-  if (len <= 4) return 2
-  return 3
 }
 
 function toggleHistory(id: string) {
@@ -395,6 +387,7 @@ onMounted(loadMemories)
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 12px;
+  align-items: start;
 }
 
 /* ── 通用组件 ── */

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -232,6 +232,7 @@ onMounted(loadMemories)
 <style scoped>
 .memory-grid {
   max-width: 1200px;
+  margin: 0 auto;
 }
 
 /* ── 加载态 ── */

--- a/web/src/components/MemoryGrid.vue
+++ b/web/src/components/MemoryGrid.vue
@@ -31,7 +31,7 @@
       <!-- 统计栏：左环形图 + 右数字 -->
       <div class="stats-bar">
         <div class="stats-donut">
-          <svg viewBox="0 0 120 120" width="120" height="120">
+          <svg viewBox="0 0 120 120" width="120" height="120" class="donut-svg">
             <circle cx="60" cy="60" r="42" fill="none" stroke="var(--border)" stroke-width="12" />
             <circle
               cx="60" cy="60" r="42" fill="none"
@@ -39,11 +39,11 @@
               :stroke-dasharray="avgDash"
               transform="rotate(-90 60 60)"
             />
-            <text x="60" y="58" text-anchor="middle" fill="var(--text-primary)"
-              font-size="26" font-weight="700" dominant-baseline="central">{{ avgHits }}</text>
-            <text x="60" y="84" text-anchor="middle" fill="var(--text-tertiary)"
-              font-size="11">均引用</text>
           </svg>
+          <div class="donut-text">
+            <span class="donut-value">{{ avgHits }}</span>
+            <span class="donut-unit">均引用</span>
+          </div>
         </div>
         <div class="stats-list">
           <div class="stats-item">
@@ -311,7 +311,32 @@ onMounted(loadMemories)
 }
 .stats-donut {
   flex-shrink: 0;
-  line-height: 0;
+  position: relative;
+  width: 120px;
+  height: 120px;
+}
+.donut-svg {
+  display: block;
+}
+.donut-text {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.donut-value {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.2;
+}
+.donut-unit {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  line-height: 1;
 }
 .stats-list {
   display: flex;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -306,6 +306,8 @@ export interface VignetteMemoryItem {
   id: string
   description: string
   history: MemoryHistoryEntry[]
+  hit: number
+  _sort_time: string
 }
 
 export interface VignetteSection {

--- a/web/src/views/MemoryView.vue
+++ b/web/src/views/MemoryView.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="memory-view">
-    <MemoryPanel />
+    <MemoryGrid />
   </div>
 </template>
 
 <script setup lang="ts">
-import MemoryPanel from '@/components/MemoryPanel.vue'
+import MemoryGrid from '@/components/MemoryGrid.vue'
 </script>
 
 <style scoped>


### PR DESCRIPTION
## 概述

重新设计记忆展示页面，从原来的单条轮播（SectionCard）改为二维 widget 网格布局。

## 新增

### 前端 — MemoryGrid.vue
- **二维网格布局**：4 列 CSS Grid， 内容弹性高度
- **统计栏**：左侧大环形图（均引用比例）+ 右侧三个数字指标
- **品牌标题**："Memory / Remembered For You"
- **热门记忆**：引用 Top 3 排行（2×2 widget）
- **最近活动**：时间线展示最近 5 条更新（2×2 widget）
- **主题分区卡片**：每个 theme 独立 widget，按条目数自适应高度
- **搜索+高亮**：实时过滤所有条目，匹配文字高亮
- **条目删除**：hover 显示 ✕ 按钮，调用 DELETE 接口
- **展开/收起**：主题栏默认最多显示 20 条

### 后端
- LongTermMemory 新增  方法
-  端点
-  返回  计数和 

### 类型
- VignetteMemoryItem 增加  和  字段

## 截图

布局示意：

```
Memory                    ┌──────────┐  22 记忆条目
Remembered For You        │   3.5    │  6 分区
                          │          │  42 总引用
                          └──────────┘
┌──────────────────────┬──────────────────────┐
│  🔥 热门记忆 (2×2)   │  🕐 最近活动 (2×2)   │
├──────────┬───────────┼──────────┬───────────┤
│  身份     │  品味     │  音乐    │  瞬间     │
│  2 条     │  2 条     │  1 条    │  2 条     │
└──────────┴───────────┴──────────┴───────────┘
```

## 备注

需要重启后端服务器（新路由 ）