### PR TITLE
refactor(api): 按领域拆分 api 模块并补充 JSDoc 注释

### DIFF
--- a/web/src/api/anthropic.ts
+++ b/web/src/api/anthropic.ts
@@ -1,0 +1,17 @@
+import type {
+  ListSkillsResponse,
+  ListToolsResponse,
+  ListMacrosResponse,
+} from '@/types'
+import { request } from './client'
+
+export const anthropicApi = {
+  listSkills: () =>
+    request<ListSkillsResponse>('/skills'),
+
+  listTools: () =>
+    request<ListToolsResponse>('/tools'),
+
+  listMacros: () =>
+    request<ListMacrosResponse>('/macros'),
+}

--- a/web/src/api/anthropic.ts
+++ b/web/src/api/anthropic.ts
@@ -6,12 +6,15 @@ import type {
 import { request } from './client'
 
 export const anthropicApi = {
+  /** 获取所有 Anthropic Skills */
   listSkills: () =>
     request<ListSkillsResponse>('/skills'),
 
+  /** 获取所有内置工具列表 */
   listTools: () =>
     request<ListToolsResponse>('/tools'),
 
+  /** 获取所有宏列表 */
   listMacros: () =>
     request<ListMacrosResponse>('/macros'),
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,0 +1,66 @@
+declare const __API_TOKEN__: string
+
+const BASE = '/api'
+
+let token: string = typeof __API_TOKEN__ !== 'undefined' ? __API_TOKEN__ : ''
+
+export function getToken(): string {
+  return token
+}
+
+export function setToken(t: string) {
+  token = t
+}
+
+export type ConnectionTestInput = {
+  api_key: string
+  base_url: string
+  provider_type?: string
+}
+
+export async function request<T>(url: string, options?: RequestInit): Promise<T> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  if (token) {
+    headers['X-Sonetto-Token'] = token
+  }
+  const res = await fetch(`${BASE}${url}`, {
+    headers,
+    ...options,
+  })
+  if (!res.ok) {
+    let detail = `API ${url} 返回 ${res.status}`
+    try {
+      const body = await res.json()
+      if (body.detail) detail += `: ${body.detail}`
+    } catch { /* ignore parse errors */ }
+    throw new Error(detail)
+  }
+  return res.json()
+}
+
+/** 发起请求并返回 Blob（用于图片等二进制资源） */
+export async function requestBlob(url: string, options?: RequestInit): Promise<Blob> {
+  const headers: Record<string, string> = {}
+  if (token) headers['X-Sonetto-Token'] = token
+  const res = await fetch(`${BASE}${url}`, { headers, ...options })
+  if (!res.ok) {
+    let detail = `API ${url} 返回 ${res.status}`
+    try {
+      const body = await res.json()
+      if (body.detail) detail += `: ${body.detail}`
+    } catch { /* ignore parse errors */ }
+    throw new Error(detail)
+  }
+  return res.blob()
+}
+
+/** 发起请求但忽略响应（用于服务器断开连接的场景，如重启） */
+export async function requestFireAndForget(url: string, options?: RequestInit): Promise<void> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) headers['X-Sonetto-Token'] = token
+  try {
+    await fetch(`${BASE}${url}`, { headers, ...options })
+  } catch { /* expected when server closes connection */ }
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4,6 +4,7 @@ const BASE = '/api'
 
 let token: string = typeof __API_TOKEN__ !== 'undefined' ? __API_TOKEN__ : ''
 
+/** 获取当前 API Token */
 export function getToken(): string {
   return token
 }
@@ -18,6 +19,12 @@ export type ConnectionTestInput = {
   provider_type?: string
 }
 
+/**
+ * 通用 API 请求
+ * @param url - 请求路径（自动拼接 BASE）
+ * @param options - 额外的 fetch 配置
+ * @returns 解析后的 JSON 响应
+ */
 export async function request<T>(url: string, options?: RequestInit): Promise<T> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -56,7 +63,10 @@ export async function requestBlob(url: string, options?: RequestInit): Promise<B
   return res.blob()
 }
 
-/** 发起请求但忽略响应（用于服务器断开连接的场景，如重启） */
+/**
+ * 发起请求但忽略响应（用于服务器断开连接的场景，如重启）
+ * 服务器关闭连接导致 fetch 抛错属于预期行为，由本函数静默吞掉
+ */
 export async function requestFireAndForget(url: string, options?: RequestInit): Promise<void> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (token) headers['X-Sonetto-Token'] = token

--- a/web/src/api/files.ts
+++ b/web/src/api/files.ts
@@ -1,0 +1,15 @@
+import { request, requestBlob } from './client'
+
+export const filesApi = {
+  selectFile: (type: 'file' | 'folder') =>
+    request<{ path: string | null }>(`/select-file?type=${type}`),
+
+  selectFolder: () =>
+    request<{ path: string | null }>('/select-file?type=folder'),
+
+  /** 将本地图片路径转为 blob URL，供 <img> 展示。返回的 URL 需在适当时机 revoke。 */
+  getImageBlobUrl: async (path: string): Promise<string> => {
+    const blob = await requestBlob(`/images/serve?path=${encodeURIComponent(path)}`)
+    return URL.createObjectURL(blob)
+  },
+}

--- a/web/src/api/files.ts
+++ b/web/src/api/files.ts
@@ -1,13 +1,18 @@
 import { request, requestBlob } from './client'
 
 export const filesApi = {
+  /** 打开系统文件/文件夹选择器 */
   selectFile: (type: 'file' | 'folder') =>
     request<{ path: string | null }>(`/select-file?type=${type}`),
 
+  /** 打开系统文件夹选择器（selectFile 的快捷方式） */
   selectFolder: () =>
     request<{ path: string | null }>('/select-file?type=folder'),
 
-  /** 将本地图片路径转为 blob URL，供 <img> 展示。返回的 URL 需在适当时机 revoke。 */
+  /**
+   * 将本地图片路径转为 blob URL，供 <img> 展示
+   * 注意：调用方需在适当时机执行 URL.revokeObjectURL() 释放内存
+   */
   getImageBlobUrl: async (path: string): Promise<string> => {
     const blob = await requestBlob(`/images/serve?path=${encodeURIComponent(path)}`)
     return URL.createObjectURL(blob)

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -1,269 +1,39 @@
-import type {
-  CreateSessionResponse,
-  ListSessionsResponse,
-  SessionInfo,
-  NarrativeResponse,
-  MomentResponse,
-  VignetteResponse,
-  ContextUsage,
-  DeepSeekBalanceResponse,
-  HealthResponse,
-  ListProvidersResponse,
-  ListNewsResponse,
-  ListSkillsResponse,
-  ListToolsResponse,
-  ListMacrosResponse,
-  ProviderConfig,
-  TestConnectionResponse,
-  DiscoverModelsResponse,
-  ConstifyResponse,
-  WhitelistEntry,
-  ListWhitelistResponse,
-  BlockerEntry,
-  ListBlockerResponse,
-  ListEnvVarsResponse,
-  UpdateEnvVarResponse,
-} from '@/types'
+/**
+ * API 客户端 — 统一导出
+ *
+ * 各领域模块按职责拆分到独立文件：
+ *   client.ts     — 基础 request 函数、token、共用类型
+ *   sessions.ts   — 会话管理
+ *   providers.ts  — 供应商管理
+ *   memories.ts   — 记忆/叙事
+ *   personas.ts   — 人设
+ *   settings.ts   — 白名单、拒止锚、环境变量
+ *   system.ts     — 健康检查、系统动态、DeepSeek 余额
+ *   anthropic.ts  — Skills / Tools / Macros
+ *   files.ts      — 文件选择、图片服务
+ */
 
-declare const __API_TOKEN__: string
+import { sessionsApi } from './sessions'
+import { providersApi } from './providers'
+import { memoriesApi } from './memories'
+import { personasApi } from './personas'
+import { settingsApi } from './settings'
+import { systemApi } from './system'
+import { anthropicApi } from './anthropic'
+import { filesApi } from './files'
+import { getToken, setToken } from './client'
 
-const BASE = '/api'
+export { getToken, setToken }
 
-/** 从 Vite 编译期注入的 Token */
-let token: string = typeof __API_TOKEN__ !== 'undefined' ? __API_TOKEN__ : ''
-
-export function getToken(): string {
-  return token
-}
-
-async function request<T>(url: string, options?: RequestInit): Promise<T> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  }
-  if (token) {
-    headers['X-Sonetto-Token'] = token
-  }
-  const res = await fetch(`${BASE}${url}`, {
-    headers,
-    ...options,
-  })
-  if (!res.ok) {
-    let detail = `API ${url} 返回 ${res.status}`
-    try {
-      const body = await res.json()
-      if (body.detail) detail += `: ${body.detail}`
-    } catch { /* ignore parse errors */ }
-    throw new Error(detail)
-  }
-  return res.json()
-}
-
+/** 扁平 API 对象，保持与消费者（组件/stores）的兼容 */
 export const api = {
-  createSession: () =>
-    request<CreateSessionResponse>('/sessions', { method: 'POST' }),
-
-  listSessions: () =>
-    request<ListSessionsResponse>('/sessions'),
-
-  getSession: (id: string) =>
-    request<SessionInfo>(`/sessions/${id}`),
-
-  deleteSession: (id: string) =>
-    request<{ status: string }>(`/sessions/${id}`, { method: 'DELETE' }),
-
-  getNarrative: () =>
-    request<NarrativeResponse>('/long-term'),
-
-  getMoment: () =>
-    request<MomentResponse>('/moment'),
-
-  getMemories: () =>
-    request<VignetteResponse>('/memories'),
-
-  deleteMemory: (id: string) =>
-    request<{ status: string; id: string; description: string }>(`/memories/${id}`, { method: 'DELETE' }),
-
-  getContextUsage: (sessionId: string) =>
-    request<ContextUsage & { session_id: string }>(`/sessions/${sessionId}/context-usage`),
-
-  undoMessages: (sessionId: string, n: number = 1) =>
-    request<{ deleted_count: number }>(`/sessions/${sessionId}/undo?n=${n}`, { method: 'POST' }),
-
-  getDeepSeekBalance: () =>
-    request<DeepSeekBalanceResponse>('/deepseek-balance'),
-
-  health: () =>
-    request<HealthResponse>('/health'),
-
-  restart: async () => {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-    if (token) headers['X-Sonetto-Token'] = token
-    try {
-      await fetch(`${BASE}/restart`, { method: 'POST', headers })
-    } catch { /* server will close connection, expected */ }
-  },
-
-  // ── Provider ──
-
-  listProviders: () =>
-    request<ListProvidersResponse>('/providers'),
-
-  getProvider: (id: string) =>
-    request<ProviderConfig>(`/providers/${id}`),
-
-  createProvider: (body: Partial<ProviderConfig>) =>
-    request<ProviderConfig>('/providers', {
-      method: 'POST',
-      body: JSON.stringify(body),
-    }),
-
-  updateProvider: (id: string, body: Partial<ProviderConfig>) =>
-    request<ProviderConfig>(`/providers/${id}`, {
-      method: 'PUT',
-      body: JSON.stringify(body),
-    }),
-
-  deleteProvider: (id: string) =>
-    request<{ status: string }>(`/providers/${id}`, { method: 'DELETE' }),
-
-  testConnection: (body: { api_key: string; base_url: string; provider_type?: string }) =>
-    request<TestConnectionResponse>('/providers/test', {
-      method: 'POST',
-      body: JSON.stringify(body),
-    }),
-
-  discoverModels: (body: { api_key: string; base_url: string; provider_type?: string }) =>
-    request<DiscoverModelsResponse>('/providers/discover-models', {
-      method: 'POST',
-      body: JSON.stringify(body),
-    }),
-
-  discoverModelsForExisting: (id: string) =>
-    request<DiscoverModelsResponse>(`/providers/${id}/discover-models`, {
-      method: 'POST',
-    }),
-
-  testExistingProvider: (id: string) =>
-    request<TestConnectionResponse>(`/providers/${id}/test`, {
-      method: 'POST',
-    }),
-
-  // ── News ──
-
-  listNews: () =>
-    request<ListNewsResponse>('/news'),
-
-  // ── Anthropic Skills ──
-
-  listSkills: () =>
-    request<ListSkillsResponse>('/skills'),
-
-  listTools: () =>
-    request<ListToolsResponse>('/tools'),
-
-  listMacros: () =>
-    request<ListMacrosResponse>('/macros'),
-
-  // ── Const 固定会话 ──
-
-  constifySession: (id: string, name: string) =>
-    request<ConstifyResponse>(`/sessions/${id}/const`, {
-      method: 'POST',
-      body: JSON.stringify({ name }),
-    }),
-
-  unconstifySession: (id: string) =>
-    request<{ status: string }>(`/sessions/${id}/const`, { method: 'DELETE' }),
-
-  generateSessionTitle: (id: string) =>
-    request<{ title: string }>(`/sessions/${id}/generate-title`, { method: 'POST' }),
-
-  // ── Persona 人设 ──
-
-  getPersona: (type: 'soul' | 'user') =>
-    request<{ content: string; type: string }>(`/persona?type=${type}`),
-
-  updatePersona: (type: 'soul' | 'user', content: string) =>
-    request<{ content: string; type: string }>(`/persona?type=${type}`, {
-      method: 'PUT',
-      body: JSON.stringify({ content }),
-    }),
-
-  // ── Path Whitelist 路径白名单 ──
-
-  listWhitelist: () =>
-    request<ListWhitelistResponse>('/path-whitelist'),
-
-  addWhitelistEntry: (entry: { path: string; description: string }) =>
-    request<WhitelistEntry>('/path-whitelist', {
-      method: 'POST',
-      body: JSON.stringify(entry),
-    }),
-
-  updateWhitelistEntry: (index: number, entry: { path: string; description: string }) =>
-    request<WhitelistEntry>(`/path-whitelist/${index}`, {
-      method: 'PUT',
-      body: JSON.stringify(entry),
-    }),
-
-  deleteWhitelistEntry: (index: number) =>
-    request<{ status: string }>(`/path-whitelist/${index}`, { method: 'DELETE' }),
-
-  // ── 文件选择器 ──
-
-  selectFile: (type: 'file' | 'folder') =>
-    request<{ path: string | null }>(`/select-file?type=${type}`),
-
-  selectFolder: () =>
-    request<{ path: string | null }>('/select-file?type=folder'),
-
-  // ── 路径安全检查 ──
-
-  checkPathBlocked: (path: string) =>
-    request<{ blocked: boolean; reason: string | null; blocker_path: string | null }>(
-      `/check-path-blocked?path=${encodeURIComponent(path)}`
-    ),
-
-  // ── 图片服务（用于缩略图渲染）──
-
-  /** 将本地图片路径转为 blob URL，供 <img> 展示。返回的 URL 需在适当时机 revoke。 */
-  getImageBlobUrl: async (path: string): Promise<string> => {
-    const headers: Record<string, string> = {}
-    if (token) headers['X-Sonetto-Token'] = token
-    const res = await fetch(`${BASE}/images/serve?path=${encodeURIComponent(path)}`, { headers })
-    if (!res.ok) throw new Error(`加载图片失败: ${res.status}`)
-    const blob = await res.blob()
-    return URL.createObjectURL(blob)
-  },
-
-  // ── SonettoBlocker 拒止锚 ──
-
-  listBlockers: () =>
-    request<ListBlockerResponse>('/sonetto-blocker'),
-
-  addBlocker: (entry: { path: string; description: string }) =>
-    request<BlockerEntry>('/sonetto-blocker', {
-      method: 'POST',
-      body: JSON.stringify(entry),
-    }),
-
-  deleteBlocker: (index: number) =>
-    request<{ status: string }>(`/sonetto-blocker/${index}`, { method: 'DELETE' }),
-
-  // ── 工具环境变量 ──
-
-  listEnvVars: () =>
-    request<ListEnvVarsResponse>('/env-vars'),
-
-  updateEnvVar: (key: string, value: string) =>
-    request<UpdateEnvVarResponse>('/env-vars', {
-      method: 'PUT',
-      body: JSON.stringify({ key, value }),
-    }),
-
-  batchUpdateEnvVars: (env_vars: { key: string; value: string }[]) =>
-    request<{ status: string; updated: { key: string; masked_value: string }[] }>('/env-vars/batch', {
-      method: 'PUT',
-      body: JSON.stringify({ env_vars }),
-    }),
+  ...sessionsApi,
+  ...providersApi,
+  ...memoriesApi,
+  ...personasApi,
+  ...settingsApi,
+  ...systemApi,
+  ...anthropicApi,
+  ...filesApi,
 }
+

--- a/web/src/api/memories.ts
+++ b/web/src/api/memories.ts
@@ -6,15 +6,22 @@ import type {
 import { request } from './client'
 
 export const memoriesApi = {
+  /** 获取长篇叙事记忆 */
   getNarrative: () =>
     request<NarrativeResponse>('/long-term'),
 
+  /** 获取当前"瞬间"记忆卡片 */
   getMoment: () =>
     request<MomentResponse>('/moment'),
 
+  /** 获取所有记忆分区（按主题分组的瀑布流数据） */
   getMemories: () =>
     request<VignetteResponse>('/memories'),
 
+  /**
+   * 删除一条记忆
+   * @param id - 记忆 ID
+   */
   deleteMemory: (id: string) =>
     request<{ status: string; id: string; description: string }>(`/memories/${id}`, { method: 'DELETE' }),
 }

--- a/web/src/api/memories.ts
+++ b/web/src/api/memories.ts
@@ -1,0 +1,20 @@
+import type {
+  NarrativeResponse,
+  MomentResponse,
+  VignetteResponse,
+} from '@/types'
+import { request } from './client'
+
+export const memoriesApi = {
+  getNarrative: () =>
+    request<NarrativeResponse>('/long-term'),
+
+  getMoment: () =>
+    request<MomentResponse>('/moment'),
+
+  getMemories: () =>
+    request<VignetteResponse>('/memories'),
+
+  deleteMemory: (id: string) =>
+    request<{ status: string; id: string; description: string }>(`/memories/${id}`, { method: 'DELETE' }),
+}

--- a/web/src/api/personas.ts
+++ b/web/src/api/personas.ts
@@ -1,0 +1,12 @@
+import { request } from './client'
+
+export const personasApi = {
+  getPersona: (type: 'soul' | 'user') =>
+    request<{ content: string; type: string }>(`/persona?type=${type}`),
+
+  updatePersona: (type: 'soul' | 'user', content: string) =>
+    request<{ content: string; type: string }>(`/persona?type=${type}`, {
+      method: 'PUT',
+      body: JSON.stringify({ content }),
+    }),
+}

--- a/web/src/api/personas.ts
+++ b/web/src/api/personas.ts
@@ -1,9 +1,15 @@
 import { request } from './client'
 
 export const personasApi = {
+  /** 获取人设内容（soul = AI 人设，user = 用户人设） */
   getPersona: (type: 'soul' | 'user') =>
     request<{ content: string; type: string }>(`/persona?type=${type}`),
 
+  /**
+   * 更新人设内容
+   * @param type - soul（AI）或 user（用户）
+   * @param content - 人设文本
+   */
   updatePersona: (type: 'soul' | 'user', content: string) =>
     request<{ content: string; type: string }>(`/persona?type=${type}`, {
       method: 'PUT',

--- a/web/src/api/providers.ts
+++ b/web/src/api/providers.ts
@@ -1,0 +1,52 @@
+import type {
+  ProviderConfig,
+  ListProvidersResponse,
+  TestConnectionResponse,
+  DiscoverModelsResponse,
+} from '@/types'
+import { request, type ConnectionTestInput } from './client'
+
+export const providersApi = {
+  listProviders: () =>
+    request<ListProvidersResponse>('/providers'),
+
+  getProvider: (id: string) =>
+    request<ProviderConfig>(`/providers/${id}`),
+
+  createProvider: (body: Partial<ProviderConfig>) =>
+    request<ProviderConfig>('/providers', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  updateProvider: (id: string, body: Partial<ProviderConfig>) =>
+    request<ProviderConfig>(`/providers/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    }),
+
+  deleteProvider: (id: string) =>
+    request<{ status: string }>(`/providers/${id}`, { method: 'DELETE' }),
+
+  testConnection: (body: ConnectionTestInput) =>
+    request<TestConnectionResponse>('/providers/test', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  discoverModels: (body: ConnectionTestInput) =>
+    request<DiscoverModelsResponse>('/providers/discover-models', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  discoverModelsForExisting: (id: string) =>
+    request<DiscoverModelsResponse>(`/providers/${id}/discover-models`, {
+      method: 'POST',
+    }),
+
+  testExistingProvider: (id: string) =>
+    request<TestConnectionResponse>(`/providers/${id}/test`, {
+      method: 'POST',
+    }),
+}

--- a/web/src/api/providers.ts
+++ b/web/src/api/providers.ts
@@ -7,44 +7,77 @@ import type {
 import { request, type ConnectionTestInput } from './client'
 
 export const providersApi = {
+  /** 获取所有供应商列表 */
   listProviders: () =>
     request<ListProvidersResponse>('/providers'),
 
+  /** 获取指定供应商详情 */
   getProvider: (id: string) =>
     request<ProviderConfig>(`/providers/${id}`),
 
+  /**
+   * 新增供应商
+   * @param body - 供应商配置（id 由后端生成，可不传）
+   */
   createProvider: (body: Partial<ProviderConfig>) =>
     request<ProviderConfig>('/providers', {
       method: 'POST',
       body: JSON.stringify(body),
     }),
 
+  /**
+   * 更新供应商配置
+   * @param id - 供应商 ID
+   * @param body - 要更新的字段
+   */
   updateProvider: (id: string, body: Partial<ProviderConfig>) =>
     request<ProviderConfig>(`/providers/${id}`, {
       method: 'PUT',
       body: JSON.stringify(body),
     }),
 
+  /**
+   * 删除供应商
+   * @param id - 供应商 ID
+   */
   deleteProvider: (id: string) =>
     request<{ status: string }>(`/providers/${id}`, { method: 'DELETE' }),
 
+  /**
+   * 测试供应商连接是否可用
+   * @param body - 连接信息（API Key、Base URL 等）
+   * @returns 连接状态和延迟
+   */
   testConnection: (body: ConnectionTestInput) =>
     request<TestConnectionResponse>('/providers/test', {
       method: 'POST',
       body: JSON.stringify(body),
     }),
 
+  /**
+   * 从供应商拉取可用模型列表
+   * @param body - 连接信息
+   * @returns 模型 ID 列表
+   */
   discoverModels: (body: ConnectionTestInput) =>
     request<DiscoverModelsResponse>('/providers/discover-models', {
       method: 'POST',
       body: JSON.stringify(body),
     }),
 
+  /**
+   * 为已有供应商重新拉取可用模型
+   * @param id - 供应商 ID
+   */
   discoverModelsForExisting: (id: string) =>
     request<DiscoverModelsResponse>(`/providers/${id}/discover-models`, {
       method: 'POST',
     }),
 
+  /**
+   * 测试已保存的供应商连接
+   * @param id - 供应商 ID
+   */
   testExistingProvider: (id: string) =>
     request<TestConnectionResponse>(`/providers/${id}/test`, {
       method: 'POST',

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -1,0 +1,40 @@
+import type {
+  CreateSessionResponse,
+  ListSessionsResponse,
+  SessionInfo,
+  ContextUsage,
+  ConstifyResponse,
+} from '@/types'
+import { request } from './client'
+
+export const sessionsApi = {
+  createSession: () =>
+    request<CreateSessionResponse>('/sessions', { method: 'POST' }),
+
+  listSessions: () =>
+    request<ListSessionsResponse>('/sessions'),
+
+  getSession: (id: string) =>
+    request<SessionInfo>(`/sessions/${id}`),
+
+  deleteSession: (id: string) =>
+    request<{ status: string }>(`/sessions/${id}`, { method: 'DELETE' }),
+
+  getContextUsage: (sessionId: string) =>
+    request<ContextUsage & { session_id: string }>(`/sessions/${sessionId}/context-usage`),
+
+  undoMessages: (sessionId: string, n: number = 1) =>
+    request<{ deleted_count: number }>(`/sessions/${sessionId}/undo?n=${n}`, { method: 'POST' }),
+
+  constifySession: (id: string, name: string) =>
+    request<ConstifyResponse>(`/sessions/${id}/const`, {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    }),
+
+  unconstifySession: (id: string) =>
+    request<{ status: string }>(`/sessions/${id}/const`, { method: 'DELETE' }),
+
+  generateSessionTitle: (id: string) =>
+    request<{ title: string }>(`/sessions/${id}/generate-title`, { method: 'POST' }),
+}

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -8,33 +8,65 @@ import type {
 import { request } from './client'
 
 export const sessionsApi = {
+  // ── 会话生命周期 ──
+
+  /** 创建新会话 */
   createSession: () =>
     request<CreateSessionResponse>('/sessions', { method: 'POST' }),
 
+  /** 获取所有会话列表 */
   listSessions: () =>
     request<ListSessionsResponse>('/sessions'),
 
+  /** 获取指定会话信息 */
   getSession: (id: string) =>
     request<SessionInfo>(`/sessions/${id}`),
 
+  /**
+   * 删除指定会话及其所有消息
+   * @param id - 会话 ID
+   */
   deleteSession: (id: string) =>
     request<{ status: string }>(`/sessions/${id}`, { method: 'DELETE' }),
 
+  // ── 会话控制 ──
+
+  /**
+   * 获取指定会话的上下文窗口用量
+   * @param sessionId - 会话 ID
+   */
   getContextUsage: (sessionId: string) =>
     request<ContextUsage & { session_id: string }>(`/sessions/${sessionId}/context-usage`),
 
+  /**
+   * 撤销指定会话最近 n 条消息
+   * @param sessionId - 会话 ID
+   * @param n - 撤销条数，默认 1
+   * @returns 实际删除的消息数量
+   */
   undoMessages: (sessionId: string, n: number = 1) =>
     request<{ deleted_count: number }>(`/sessions/${sessionId}/undo?n=${n}`, { method: 'POST' }),
 
+  /**
+   * 将会话设为固定（const），固定在侧边栏顶部不被自动清理
+   * @param id - 会话 ID
+   * @param name - 固定后显示的名称
+   */
   constifySession: (id: string, name: string) =>
     request<ConstifyResponse>(`/sessions/${id}/const`, {
       method: 'POST',
       body: JSON.stringify({ name }),
     }),
 
+  /** 取消会话固定 */
   unconstifySession: (id: string) =>
     request<{ status: string }>(`/sessions/${id}/const`, { method: 'DELETE' }),
 
+  /**
+   * 让 AI 根据会话内容自动生成标题
+   * @param id - 会话 ID
+   * @returns 生成的标题
+   */
   generateSessionTitle: (id: string) =>
     request<{ title: string }>(`/sessions/${id}/generate-title`, { method: 'POST' }),
 }

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -11,49 +11,82 @@ import { request } from './client'
 export const settingsApi = {
   // ── Path Whitelist 路径白名单 ──
 
+  /** 获取路径白名单列表 */
   listWhitelist: () =>
     request<ListWhitelistResponse>('/path-whitelist'),
 
+  /**
+   * 添加路径白名单条目
+   * @param entry - 路径和描述
+   */
   addWhitelistEntry: (entry: { path: string; description: string }) =>
     request<WhitelistEntry>('/path-whitelist', {
       method: 'POST',
       body: JSON.stringify(entry),
     }),
 
+  /**
+   * 更新指定白名单条目
+   * @param index - 条目序号
+   * @param entry - 新路径和描述
+   */
   updateWhitelistEntry: (index: number, entry: { path: string; description: string }) =>
     request<WhitelistEntry>(`/path-whitelist/${index}`, {
       method: 'PUT',
       body: JSON.stringify(entry),
     }),
 
+  /**
+   * 删除白名单条目
+   * @param index - 条目序号
+   */
   deleteWhitelistEntry: (index: number) =>
     request<{ status: string }>(`/path-whitelist/${index}`, { method: 'DELETE' }),
 
   // ── SonettoBlocker 拒止锚 ──
 
+  /** 获取拒止锚列表 */
   listBlockers: () =>
     request<ListBlockerResponse>('/sonetto-blocker'),
 
+  /**
+   * 添加拒止锚
+   * @param entry - 路径和描述
+   */
   addBlocker: (entry: { path: string; description: string }) =>
     request<BlockerEntry>('/sonetto-blocker', {
       method: 'POST',
       body: JSON.stringify(entry),
     }),
 
+  /**
+   * 删除拒止锚
+   * @param index - 条目序号
+   */
   deleteBlocker: (index: number) =>
     request<{ status: string }>(`/sonetto-blocker/${index}`, { method: 'DELETE' }),
 
   // ── 工具环境变量 ──
 
+  /** 获取所有工具环境变量 */
   listEnvVars: () =>
     request<ListEnvVarsResponse>('/env-vars'),
 
+  /**
+   * 更新单个环境变量
+   * @param key - 变量名
+   * @param value - 变量值
+   */
   updateEnvVar: (key: string, value: string) =>
     request<UpdateEnvVarResponse>('/env-vars', {
       method: 'PUT',
       body: JSON.stringify({ key, value }),
     }),
 
+  /**
+   * 批量更新环境变量
+   * @param env_vars - 变量键值对列表
+   */
   batchUpdateEnvVars: (env_vars: { key: string; value: string }[]) =>
     request<{ status: string; updated: { key: string; masked_value: string }[] }>('/env-vars/batch', {
       method: 'PUT',
@@ -62,6 +95,11 @@ export const settingsApi = {
 
   // ── 路径安全检查 ──
 
+  /**
+   * 检查路径是否被拒止锚拦截
+   * @param path - 待检查的绝对路径
+   * @returns 是否被拦截及原因
+   */
   checkPathBlocked: (path: string) =>
     request<{ blocked: boolean; reason: string | null; blocker_path: string | null }>(
       `/check-path-blocked?path=${encodeURIComponent(path)}`

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -1,0 +1,69 @@
+import type {
+  ListWhitelistResponse,
+  WhitelistEntry,
+  ListBlockerResponse,
+  BlockerEntry,
+  ListEnvVarsResponse,
+  UpdateEnvVarResponse,
+} from '@/types'
+import { request } from './client'
+
+export const settingsApi = {
+  // ── Path Whitelist 路径白名单 ──
+
+  listWhitelist: () =>
+    request<ListWhitelistResponse>('/path-whitelist'),
+
+  addWhitelistEntry: (entry: { path: string; description: string }) =>
+    request<WhitelistEntry>('/path-whitelist', {
+      method: 'POST',
+      body: JSON.stringify(entry),
+    }),
+
+  updateWhitelistEntry: (index: number, entry: { path: string; description: string }) =>
+    request<WhitelistEntry>(`/path-whitelist/${index}`, {
+      method: 'PUT',
+      body: JSON.stringify(entry),
+    }),
+
+  deleteWhitelistEntry: (index: number) =>
+    request<{ status: string }>(`/path-whitelist/${index}`, { method: 'DELETE' }),
+
+  // ── SonettoBlocker 拒止锚 ──
+
+  listBlockers: () =>
+    request<ListBlockerResponse>('/sonetto-blocker'),
+
+  addBlocker: (entry: { path: string; description: string }) =>
+    request<BlockerEntry>('/sonetto-blocker', {
+      method: 'POST',
+      body: JSON.stringify(entry),
+    }),
+
+  deleteBlocker: (index: number) =>
+    request<{ status: string }>(`/sonetto-blocker/${index}`, { method: 'DELETE' }),
+
+  // ── 工具环境变量 ──
+
+  listEnvVars: () =>
+    request<ListEnvVarsResponse>('/env-vars'),
+
+  updateEnvVar: (key: string, value: string) =>
+    request<UpdateEnvVarResponse>('/env-vars', {
+      method: 'PUT',
+      body: JSON.stringify({ key, value }),
+    }),
+
+  batchUpdateEnvVars: (env_vars: { key: string; value: string }[]) =>
+    request<{ status: string; updated: { key: string; masked_value: string }[] }>('/env-vars/batch', {
+      method: 'PUT',
+      body: JSON.stringify({ env_vars }),
+    }),
+
+  // ── 路径安全检查 ──
+
+  checkPathBlocked: (path: string) =>
+    request<{ blocked: boolean; reason: string | null; blocker_path: string | null }>(
+      `/check-path-blocked?path=${encodeURIComponent(path)}`
+    ),
+}

--- a/web/src/api/system.ts
+++ b/web/src/api/system.ts
@@ -1,0 +1,20 @@
+import type {
+  HealthResponse,
+  DeepSeekBalanceResponse,
+  ListNewsResponse,
+} from '@/types'
+import { request, requestFireAndForget } from './client'
+
+export const systemApi = {
+  health: () =>
+    request<HealthResponse>('/health'),
+
+  restart: () =>
+    requestFireAndForget('/restart', { method: 'POST' }),
+
+  listNews: () =>
+    request<ListNewsResponse>('/news'),
+
+  getDeepSeekBalance: () =>
+    request<DeepSeekBalanceResponse>('/deepseek-balance'),
+}

--- a/web/src/api/system.ts
+++ b/web/src/api/system.ts
@@ -6,15 +6,22 @@ import type {
 import { request, requestFireAndForget } from './client'
 
 export const systemApi = {
+  /** 健康检查 */
   health: () =>
     request<HealthResponse>('/health'),
 
+  /**
+   * 重启后端服务
+   * 服务器关闭连接会导致 fetch 抛错，由 client.requestFireAndForget 静默处理
+   */
   restart: () =>
     requestFireAndForget('/restart', { method: 'POST' }),
 
+  /** 获取系统更新动态列表 */
   listNews: () =>
     request<ListNewsResponse>('/news'),
 
+  /** 查询 DeepSeek API 余额 */
   getDeepSeekBalance: () =>
     request<DeepSeekBalanceResponse>('/deepseek-balance'),
 }


### PR DESCRIPTION
### 变更内容

#### 1. 按领域拆分（45 个方法 → 9 个模块）

| 模块 | 方法数 | 职责 |
|---|---|---|
| `client.ts` | 3 函数 + 1 类型 | 基础 request、token、共用类型 |
| `sessions.ts` | 9 | 会话 CRUD、undo、constify |
| `providers.ts` | 9 | 供应商 CRUD、连接测试、模型发现 |
| `memories.ts` | 4 | 叙事、瞬间、记忆分区 |
| `personas.ts` | 2 | 人设读写 |
| `settings.ts` | 11 | 白名单、拒止锚、环境变量、路径检查 |
| `system.ts` | 4 | 健康检查、重启、系统动态、DeepSeek 余额 |
| `anthropic.ts` | 3 | Skills / Tools / Macros |
| `files.ts` | 3 | 文件选择、图片服务 |

#### 2. 基础函数增强
- 提取 `requestBlob()` — 二进制请求（图片服务）
- 提取 `requestFireAndForget()` — 预期断连场景（重启）
- 消除原 `restart`/`getImageBlobUrl` 中的 headers 重复

#### 3. 分级 JSDoc 注释
- 简单 GET → 一行 JSDoc
- 有副作用操作 → 含 `@param`
- 特殊逻辑 → 含注意事项（如 `getImageBlobUrl` 需 revoke）

### 兼容性
- `index.ts` 保持扁平 `api` 对象导出
- 所有消费者 `import { api } from '@/api'` 无需任何改动

Closes #262