### PR TITLE
fix(events): 延迟创建 asyncio.Lock 避免事件循环绑定错误

### DIFF
--- a/api/events/transport.py
+++ b/api/events/transport.py
@@ -33,7 +33,9 @@ class WsTransport:
 
     def __init__(self, ws: WebSocket | None) -> None:
         self._ws = ws
-        self._write_lock = asyncio.Lock()
+        # 延迟初始化锁，确保锁在 _send() 调用的事件循环中创建，
+        # 避免 LTM 后台 consumer 等场景下锁绑定到错误的事件循环。
+        self._write_lock: asyncio.Lock | None = None
 
     # ── 工厂方法 ─────────────────────────────────────────────
 
@@ -88,6 +90,10 @@ class WsTransport:
         """
         if self._ws is None:
             return
+
+        # 延迟创建锁，确保绑定到 _send 调用时的事件循环
+        if self._write_lock is None:
+            self._write_lock = asyncio.Lock()
 
         async with self._write_lock:
             try:


### PR DESCRIPTION
## Summary

- WsTransport 的 `_write_lock` 在 `__init__` 中立即创建，导致锁绑定到初始化时的事件循环
- LTM 后台 consumer 中创建的 MemorySender 在 LangChain callback 调度时被不同事件循环访问，抛出 RuntimeError（导致 LTM 长期记忆系统失效）
- 将锁改为 `_send()` 首次调用时惰性创建，确保绑定到实际调用方的事件循环

## Test plan
- [x] 惰性锁创建/复用测试通过
- [x] `ws=None` 时跳过锁创建
- [x] 并发 `_send` 调用正常
- [x] 现有 LTM 集成测试全部通过 (3/3)