### PR TITLE
feat(agent+web): 添加回忆/失忆模式切换开关

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -34,12 +34,16 @@ Sonetto = CompiledStateGraph
 # ── 条件路由 ──────────────────────────────────────────
 
 
-def _route_after_agent(state: MessagesState) -> Literal["tools", "__end__"]:
-    """模型节点后的条件边路由器。"""
+def _route_after_agent(state: MessagesState) -> Literal["tools", "ltm_write"]:
+    """模型节点后的条件边路由器。
+
+    带 tool_calls → tools 节点执行工具；
+    无 tool_calls → ltm_write 节点持久化本轮对话至长期记忆后结束。
+    """
     last = state["messages"][-1]
     if isinstance(last, AIMessage) and last.tool_calls:
         return "tools"
-    return END
+    return "ltm_write"
 
 
 # ── 图构建 ──────────────────────────────────────────────
@@ -59,13 +63,42 @@ def build_agent(
     system_prompt: str,
     checkpointer: BaseCheckpointSaver,
     memory_retriever: Callable[[str], Awaitable[list[dict[str, str]]]] | None = None,
+    ltm: Any | None = None,
 ) -> Sonetto:
     """构建 ReAct Agent 图。
 
+    .. rubric:: 图结构
+
+    ::
+
+        START ──→ [retrieve_memory] ──→ [agent] ──→ [tools] ──→ [agent] ──→ ...
+                                                              │              │
+                                                              └── [ltm_write] ──→ END
+
+    - **retrieve_memory** — 每轮 HumanMessage 时检索长期记忆，以 HumanMessage 追加到 messages
+    - **agent** — 调用 LLM，可绑定工具
+    - **tools** — 执行工具调用
+    - **ltm_write** — 将本轮对话投递到 LTM 后台队列以更新 memory.yaml
+
+    .. rubric:: config.configurable 支持的键
+
+    传入 ``astream_events(inputs, config={"configurable": {...}})`` 时：
+
+    ==============  =====  ====================================================
+    键              类型    说明
+    ==============  =====  ====================================================
+    ``thread_id``    str    **必需**。会话 ID，传给 checkpointer 读写状态。
+    ``private_mode``  bool  可选。为 ``True`` 时跳过 ltm_write 节点。
+    ==============  =====  ====================================================
+
     Args:
-        memory_retriever: 可选。异步函数，接收用户消息文本，返回相关记忆条目列表。
-            检索结果由 ``retrieve_memory`` 节点以 HumanMessage 的形式追加到
-            ``messages`` 中，紧随触发检索的用户消息之后。
+        model: LangChain 聊天模型实例（如 ChatOpenAI）。
+        tools: 工具列表，传给 ToolNode 统一调度。
+        system_prompt: 系统提示词，作为 SystemMessage 注入每次模型调用。
+        checkpointer: 检查点存储器（必填，由调用方提供）。
+        memory_retriever: 可选。异步函数，接收用户消息文本，返回相关记忆条目列表
+            （每项含 id / description / theme）。
+        ltm: 可选。LongTermMemory 实例。提供时启用 ``ltm_write`` 节点。
 
     Returns:
         编译后的 ``CompiledStateGraph``（即 ``Sonetto``）。
@@ -127,6 +160,33 @@ def build_agent(
         response = await model_with_tools.ainvoke(messages, config)
         return {"messages": [response]}
 
+    # ── LTM 写入节点（ltm_write） ─────────────────────
+    async def ltm_write(
+        state: MessagesState, config: RunnableConfig
+    ) -> dict[str, Any]:
+        """将本轮对话投递到 LTM 后台队列，异步更新 memory.yaml。
+
+        仅在 ``config.configurable.private_mode`` 不为 ``True`` 且 ltm 可用时执行。
+        不阻塞——send_history_from_session 仅做 queue.put 后立即返回。
+        """
+        if ltm is None:
+            return {}
+
+        private = config["configurable"].get("private_mode", False)
+        if private:
+            return {}
+
+        # 延迟导入避免循环依赖
+        from api.session.manager import session_manager  # noqa: PLC0415
+
+        sid = config["configurable"]["thread_id"]
+        session = session_manager.get(sid)
+        if session is None:
+            return {}
+
+        await ltm.send_history_from_session(session)
+        return {}
+
     # ── 组装图 ────────────────────────────────────────
     builder = StateGraph(MessagesState)
 
@@ -138,10 +198,14 @@ def build_agent(
         "agent", RunnableCallable(None, call_agent, name="agent", trace=False),
     )
     builder.add_node("tools", tool_node)
+    builder.add_node(
+        "ltm_write", RunnableCallable(None, ltm_write, name="ltm_write", trace=False),
+    )
 
     builder.add_edge(START, "retrieve_memory")
     builder.add_edge("retrieve_memory", "agent")
     builder.add_conditional_edges("agent", _route_after_agent)
     builder.add_edge("tools", "agent")
+    builder.add_edge("ltm_write", END)
 
     return builder.compile(checkpointer=checkpointer)

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -16,9 +16,11 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from langchain_core.language_models import BaseChatModel
+from api.memory import LongTermMemory
+
+from langchain_core.language_models import BaseChatModel, LanguageModelInput
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
-from langchain_core.runnables import RunnableConfig
+from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.checkpoint.base import BaseCheckpointSaver
@@ -35,7 +37,7 @@ Sonetto = CompiledStateGraph
 # ── 条件路由 ──────────────────────────────────────────
 
 
-def _route_after_agent(state: MessagesState) -> Literal["tools", "ltm_write"]:
+def route_after_agent(state: MessagesState) -> Literal["tools", "ltm_write"]:
     """模型节点后的条件边路由器。
 
     带 tool_calls → tools 节点执行工具；
@@ -47,17 +49,116 @@ def _route_after_agent(state: MessagesState) -> Literal["tools", "ltm_write"]:
     return "ltm_write"
 
 
+# ── 图节点类 ──────────────────────────────────────────
+
+
+class RetrieveMemoryNode:
+    """检索长期记忆，以 HumanMessage 追加到 messages 中。
+
+    仅当最后一条是 HumanMessage（用户本轮新输入）且 ltm 可用时检索；
+    工具回圈（ToolMessage 结尾）时不检索，但此前追加的记忆保留在历史中。
+    """
+
+    def __init__(self, ltm: LongTermMemory | None) -> None:
+        self._ltm = ltm
+
+    async def __call__(self, state: MessagesState) -> dict[str, list[BaseMessage]]:
+        last = state["messages"][-1] if state["messages"] else None
+        if not isinstance(last, HumanMessage) or self._ltm is None:
+            return {}
+
+        query = last.content
+        if isinstance(query, list):
+            text_parts = [
+                p.get("text", "")
+                for p in query
+                if isinstance(p, dict) and p.get("type") == "text"
+            ]
+            query = " ".join(text_parts) if text_parts else ""
+
+        if not query:
+            return {}
+
+        # 延迟导入避免循环依赖
+        from api.events.memory import MemorySender  # noqa: PLC0415
+        from api.memory import RetrievalMode  # noqa: PLC0415
+
+        # 通知前端开始搜索
+        ws_sender = MemorySender.from_context()
+        if ws_sender:
+            await ws_sender.memory_search_start()
+
+        # 检索记忆
+        results = self._ltm.get_related_memory_from(query, mode=RetrievalMode.LLM)
+
+        # 通知前端搜索完成
+        if ws_sender:
+            await ws_sender.memory_search_done(count=len(results))
+
+        if not results:
+            return {}
+
+        return {"messages": [self._build_memory_message(results)]}
+
+    @staticmethod
+    def _build_memory_message(results: list[dict[str, str]]) -> HumanMessage:
+        """将记忆检索结果格式化为一条 HumanMessage。"""
+        from api.memory.long_term import MEMORY_INJECTION_MARKER  # noqa: PLC0415
+
+        lines = [MEMORY_INJECTION_MARKER]
+        for r in results:
+            lines.append(f"- [{r['theme']}] {r['description']}")
+        return HumanMessage(content="\n".join(lines))
+
+
+class CallAgentNode:
+    """调用 LLM，返回新的 AIMessage。"""
+
+    def __init__(self, system_message: SystemMessage, model_with_tools: Runnable[LanguageModelInput, AIMessage]) -> None:
+        self._system_message = system_message
+        self._model_with_tools = model_with_tools
+
+    async def __call__(
+        self, state: MessagesState, config: RunnableConfig
+    ) -> dict[str, Any]:
+        messages = [self._system_message] + state["messages"]
+        response = await self._model_with_tools.ainvoke(messages, config)
+        return {"messages": [response]}
+
+
+class LtmWriteNode:
+    """将本轮对话投递到 LTM 后台队列，异步更新 memory.yaml。
+
+    不阻塞——send_history_from_session 仅做 queue.put 后立即返回。
+    当 ``ltm is None`` 或 ``private_mode is True`` 时跳过。
+    """
+
+    def __init__(self, ltm: LongTermMemory | None) -> None:
+        self._ltm = ltm
+
+    async def __call__(
+        self, state: MessagesState, config: RunnableConfig
+    ) -> dict[str, Any]:
+        if self._ltm is None:
+            return {}
+
+        if config["configurable"]["private_mode"]:
+            return {}
+
+        # 延迟导入避免循环依赖
+        from api.session.manager import session_manager  # noqa: PLC0415
+
+        sid = config["configurable"]["thread_id"]
+        session = session_manager.get(sid)
+        if session is None:
+            return {}
+
+        turn_id = config["configurable"].get("turn_id", "")
+        await self._ltm.send_history_from_session(session, turn_id=turn_id)
+        return {}
+
+
 # ── 图构建 ──────────────────────────────────────────────
-
-
-def _build_memory_message(results: list[dict[str, str]]) -> HumanMessage:
-    """将记忆检索结果格式化为一条 HumanMessage。"""
-    from api.memory.long_term import MEMORY_INJECTION_MARKER  # noqa: PLC0415
-
-    lines = [MEMORY_INJECTION_MARKER]
-    for r in results:
-        lines.append(f"- [{r['theme']}] {r['description']}")
-    return HumanMessage(content="\n".join(lines))
 
 
 def build_agent(
@@ -65,7 +166,7 @@ def build_agent(
     tools: list[BaseTool],
     system_prompt: str,
     checkpointer: BaseCheckpointSaver,
-    ltm: Any | None = None,
+    ltm: LongTermMemory | None = None,
 ) -> Sonetto:
     """构建 ReAct Agent 图。
 
@@ -107,109 +208,35 @@ def build_agent(
         编译后的 ``CompiledStateGraph``（即 ``Sonetto``）。
     """
 
-    # ── 将外部依赖转换为图内可运行对象 ────────────────
-    system_message = SystemMessage(content=system_prompt)
-    model_with_tools = model.bind_tools(tools)
+    # ── 构造节点实例 ─────────────────────────────────
+    retrieve_memory_node = RetrieveMemoryNode(ltm)
+    agent_node = CallAgentNode(
+        SystemMessage(content=system_prompt),
+        model.bind_tools(tools),
+    )
+    ltm_write_node = LtmWriteNode(ltm)
     tool_node = ToolNode(tools)
-
-    # ── 记忆检索节点（retrieve_memory） ──────────────
-    async def retrieve_memory(state: MessagesState) -> dict[str, list[BaseMessage]]:
-        """检索长期记忆，以 HumanMessage 追加到 messages 中。
-
-        仅当最后一条是 HumanMessage（用户本轮新输入）且 ltm 可用时检索；
-        工具回圈（ToolMessage 结尾）时不检索，但此前追加的记忆保留在历史中。
-        """
-        last = state["messages"][-1] if state["messages"] else None
-        if not isinstance(last, HumanMessage) or ltm is None:
-            return {}
-
-        query = last.content
-        if isinstance(query, list):
-            text_parts = [
-                p.get("text", "")
-                for p in query
-                if isinstance(p, dict) and p.get("type") == "text"
-            ]
-            query = " ".join(text_parts) if text_parts else ""
-
-        if not query:
-            return {}
-
-        # 延迟导入避免循环依赖
-        from api.events.memory import MemorySender  # noqa: PLC0415
-        from api.memory import RetrievalMode  # noqa: PLC0415
-
-        # 通知前端开始搜索
-        ws_sender = MemorySender.from_context()
-        if ws_sender:
-            await ws_sender.memory_search_start()
-
-        # 检索记忆
-        results = ltm.get_related_memory_from(query, mode=RetrievalMode.LLM)
-
-        # 通知前端搜索完成
-        if ws_sender:
-            await ws_sender.memory_search_done(count=len(results))
-
-        if not results:
-            return {}
-
-        return {"messages": [_build_memory_message(results)]}
-
-    # ── 模型节点（agent） ─────────────────────────────
-    async def call_agent(
-        state: MessagesState, config: RunnableConfig
-    ) -> dict[str, Any]:
-        """调用 LLM，返回新的 AIMessage。"""
-        messages = [system_message] + state["messages"]
-        response = await model_with_tools.ainvoke(messages, config)
-        return {"messages": [response]}
-
-    # ── LTM 写入节点（ltm_write） ─────────────────────
-    async def ltm_write(
-        state: MessagesState, config: RunnableConfig
-    ) -> dict[str, Any]:
-        """将本轮对话投递到 LTM 后台队列，异步更新 memory.yaml。
-
-        不阻塞——send_history_from_session 仅做 queue.put 后立即返回。
-        当 ``ltm is None`` 或 ``private_mode is True`` 时跳过。
-        """
-        if ltm is None:
-            return {}
-
-        if config["configurable"]["private_mode"]:
-            return {}
-
-        # 延迟导入避免循环依赖
-        from api.session.manager import session_manager  # noqa: PLC0415
-
-        sid = config["configurable"]["thread_id"]
-        session = session_manager.get(sid)
-        if session is None:
-            return {}
-
-        turn_id = config["configurable"].get("turn_id", "")
-        await ltm.send_history_from_session(session, turn_id=turn_id)
-        return {}
 
     # ── 组装图 ────────────────────────────────────────
     builder = StateGraph(MessagesState)
 
     builder.add_node(
         "retrieve_memory",
-        RunnableCallable(None, retrieve_memory, name="retrieve_memory", trace=False),
+        RunnableCallable(None, retrieve_memory_node, name="retrieve_memory", trace=False),
     )
     builder.add_node(
-        "agent", RunnableCallable(None, call_agent, name="agent", trace=False),
+        "agent",
+        RunnableCallable(None, agent_node, name="agent", trace=False),
     )
     builder.add_node("tools", tool_node)
     builder.add_node(
-        "ltm_write", RunnableCallable(None, ltm_write, name="ltm_write", trace=False),
+        "ltm_write",
+        RunnableCallable(None, ltm_write_node, name="ltm_write", trace=False),
     )
 
     builder.add_edge(START, "retrieve_memory")
     builder.add_edge("retrieve_memory", "agent")
-    builder.add_conditional_edges("agent", _route_after_agent)
+    builder.add_conditional_edges("agent", route_after_agent)
     builder.add_edge("tools", "agent")
     builder.add_edge("ltm_write", END)
 

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -12,7 +12,7 @@
 用户消息之后。旧轮次的记忆消息随历史保留，不会主动清除。
 """
 
-from collections.abc import Awaitable, Callable
+import asyncio
 from typing import Any, Literal
 
 from langchain_core.language_models import BaseChatModel
@@ -62,7 +62,6 @@ def build_agent(
     tools: list[BaseTool],
     system_prompt: str,
     checkpointer: BaseCheckpointSaver,
-    memory_retriever: Callable[[str], Awaitable[list[dict[str, str]]]] | None = None,
     ltm: Any | None = None,
 ) -> Sonetto:
     """构建 ReAct Agent 图。
@@ -75,7 +74,8 @@ def build_agent(
                                                               │              │
                                                               └── [ltm_write] ──→ END
 
-    - **retrieve_memory** — 每轮 HumanMessage 时检索长期记忆，以 HumanMessage 追加到 messages
+    - **retrieve_memory** — 每轮 HumanMessage 时通过 ``ltm`` 语义检索长期记忆，
+      以 HumanMessage 追加到 messages
     - **agent** — 调用 LLM，可绑定工具
     - **tools** — 执行工具调用
     - **ltm_write** — 将本轮对话投递到 LTM 后台队列以更新 memory.yaml
@@ -88,7 +88,7 @@ def build_agent(
     键              类型    说明
     ==============  =====  ====================================================
     ``thread_id``    str    **必需**。会话 ID，传给 checkpointer 读写状态。
-    ``private_mode``  bool  可选。为 ``True`` 时跳过 ltm_write 节点。
+    ``private_mode``  bool   **必需**。为 ``True`` 时跳过 ltm_write 节点。
     ==============  =====  ====================================================
 
     Args:
@@ -96,9 +96,8 @@ def build_agent(
         tools: 工具列表，传给 ToolNode 统一调度。
         system_prompt: 系统提示词，作为 SystemMessage 注入每次模型调用。
         checkpointer: 检查点存储器（必填，由调用方提供）。
-        memory_retriever: 可选。异步函数，接收用户消息文本，返回相关记忆条目列表
-            （每项含 id / description / theme）。
-        ltm: 可选。LongTermMemory 实例。提供时启用 ``ltm_write`` 节点。
+        ltm: LongTermMemory 实例。提供时启用 ``retrieve_memory`` 和
+            ``ltm_write`` 节点；为 ``None`` 时两节点均为空操作。
 
     Returns:
         编译后的 ``CompiledStateGraph``（即 ``Sonetto``）。
@@ -113,11 +112,11 @@ def build_agent(
     async def retrieve_memory(state: MessagesState) -> dict[str, list[BaseMessage]]:
         """检索长期记忆，以 HumanMessage 追加到 messages 中。
 
-        仅当最后一条是 HumanMessage（用户本轮新输入）时检索；
+        仅当最后一条是 HumanMessage（用户本轮新输入）且 ltm 可用时检索；
         工具回圈（ToolMessage 结尾）时不检索，但此前追加的记忆保留在历史中。
         """
         last = state["messages"][-1] if state["messages"] else None
-        if not isinstance(last, HumanMessage) or not memory_retriever:
+        if not isinstance(last, HumanMessage) or ltm is None:
             return {}
 
         query = last.content
@@ -140,7 +139,10 @@ def build_agent(
         if ws_sender:
             await ws_sender.memory_search_start()
 
-        results = await memory_retriever(query)
+        # ltm.get_related_memory_from 是同步 LLM 调用，通过 run_in_executor
+        # 避免阻塞事件循环
+        loop = asyncio.get_event_loop()
+        results = await loop.run_in_executor(None, ltm.get_related_memory_from, query)
 
         # 通知前端搜索完成
         if ws_sender:
@@ -166,14 +168,13 @@ def build_agent(
     ) -> dict[str, Any]:
         """将本轮对话投递到 LTM 后台队列，异步更新 memory.yaml。
 
-        仅在 ``config.configurable.private_mode`` 不为 ``True`` 且 ltm 可用时执行。
         不阻塞——send_history_from_session 仅做 queue.put 后立即返回。
+        当 ``ltm is None`` 或 ``private_mode is True`` 时跳过。
         """
         if ltm is None:
             return {}
 
-        private = config["configurable"].get("private_mode", False)
-        if private:
+        if config["configurable"]["private_mode"]:
             return {}
 
         # 延迟导入避免循环依赖

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -186,7 +186,8 @@ def build_agent(
         if session is None:
             return {}
 
-        await ltm.send_history_from_session(session)
+        turn_id = config["configurable"].get("turn_id", "")
+        await ltm.send_history_from_session(session, turn_id=turn_id)
         return {}
 
     # ── 组装图 ────────────────────────────────────────

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -1,28 +1,25 @@
 """Agent 图构建 — 自建 ReAct StateGraph。
 
-等价于 langchain.agents.create_agent() 在项目当前使用场景（无 middleware /
-无 structured output / 无 return_direct）下的行为。移除了未使用的逻辑，
-保留了完整的等效语义，并为后续扩展预留了显式插入点。
 
 图结构：（箭头为固定/条件边）
 
-    START ──→ [agent] ──→ [tools] ──→ [agent] ──→ ... ──→ END
-                          │                            ↑
-                          └── 无 tool_calls → END ──────┘
+    START ──→ [retrieve_memory] ──→ [agent] ──→ [tools] ──→ [agent] ──→ ... ──→ END
+                                            │                              ↑
+                                            └── 无 tool_calls → END ──────┘
 
-扩展点（tools → agent）：
-    将 builder.add_edge("tools", "agent") 替换为
-    builder.add_edge("tools", "compress") 即可在每轮工具执行后
-    插入上下文自动压缩节点。
+`retrieve_memory` 节点在每轮用户输入时，根据最新的 HumanMessage 语义检索长期记忆，
+将结果以 HumanMessage（【相关记忆】…）的形式追加到 `messages` 列表中，紧随触发它的
+用户消息之后。旧轮次的记忆消息随历史保留，不会主动清除。
 """
 
+from collections.abc import Awaitable, Callable
 from typing import Any, Literal
 
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
-from langgraph._internal._runnable import RunnableCallable
 from langchain_core.tools import BaseTool
+from langgraph._internal._runnable import RunnableCallable
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.constants import END, START
 from langgraph.graph import StateGraph
@@ -33,17 +30,11 @@ from langgraph.prebuilt import ToolNode
 # 彩蛋：Sonetto 就是这个 CompiledStateGraph ✨
 Sonetto = CompiledStateGraph
 
-
 # ── 条件路由 ──────────────────────────────────────────
 
 
 def _route_after_agent(state: MessagesState) -> Literal["tools", "__end__"]:
-    """模型节点后的条件边路由器。
-
-    检查最后一条消息是否为带 tool_calls 的 AIMessage：
-    - 是 → 路由到 tools 节点执行工具
-    - 否 → 结束本轮执行（抵达 END）
-    """
+    """模型节点后的条件边路由器。"""
     last = state["messages"][-1]
     if isinstance(last, AIMessage) and last.tool_calls:
         return "tools"
@@ -53,27 +44,30 @@ def _route_after_agent(state: MessagesState) -> Literal["tools", "__end__"]:
 # ── 图构建 ──────────────────────────────────────────────
 
 
+def _build_memory_message(results: list[dict[str, str]]) -> HumanMessage:
+    """将记忆检索结果格式化为一条 HumanMessage。"""
+    lines = ["【相关记忆】"]
+    for r in results:
+        lines.append(f"- [{r['theme']}] {r['description']}")
+    return HumanMessage(content="\n".join(lines))
+
+
 def build_agent(
     model: BaseChatModel,
     tools: list[BaseTool],
     system_prompt: str,
     checkpointer: BaseCheckpointSaver,
+    memory_retriever: Callable[[str], Awaitable[list[dict[str, str]]]] | None = None,
 ) -> Sonetto:
     """构建 ReAct Agent 图。
 
-    等价于 ``langchain.agents.create_agent()`` 在当前项目所有使用场景
-    （chat 主回路、const session 重建、sub-agent 后台执行）下的行为。
-
     Args:
-        model: LangChain 聊天模型实例（如 ChatOpenAI）。
-        tools: 工具列表，传给 ToolNode 统一调度。
-        system_prompt: 系统提示词，作为 SystemMessage 注入每次模型调用。
-        checkpointer: 检查点存储器（必填，由调用方提供）。
+        memory_retriever: 可选。异步函数，接收用户消息文本，返回相关记忆条目列表。
+            检索结果由 ``retrieve_memory`` 节点以 HumanMessage 的形式追加到
+            ``messages`` 中，紧随触发检索的用户消息之后。
 
     Returns:
-        编译后的 ``CompiledStateGraph``（即 ``Sonetto``），
-        支持 ``astream_events``、``aget_state``、``aupdate_state`` 等
-        所有下游依赖的方法。
+        编译后的 ``CompiledStateGraph``（即 ``Sonetto``）。
     """
 
     # ── 将外部依赖转换为图内可运行对象 ────────────────
@@ -81,26 +75,58 @@ def build_agent(
     model_with_tools = model.bind_tools(tools)
     tool_node = ToolNode(tools)
 
+    # ── 记忆检索节点（retrieve_memory） ──────────────
+    async def retrieve_memory(state: MessagesState) -> dict[str, list[BaseMessage]]:
+        """检索长期记忆，以 HumanMessage 追加到 messages 中。
+
+        仅当最后一条是 HumanMessage（用户本轮新输入）时检索；
+        工具回圈（ToolMessage 结尾）时不检索，但此前追加的记忆保留在历史中。
+        """
+        last = state["messages"][-1] if state["messages"] else None
+        if not isinstance(last, HumanMessage) or not memory_retriever:
+            return {}
+
+        query = last.content
+        if isinstance(query, list):
+            text_parts = [
+                p.get("text", "")
+                for p in query
+                if isinstance(p, dict) and p.get("type") == "text"
+            ]
+            query = " ".join(text_parts) if text_parts else ""
+
+        if not query:
+            return {}
+
+        results = await memory_retriever(query)
+        if not results:
+            return {}
+
+        return {"messages": [_build_memory_message(results)]}
+
     # ── 模型节点（agent） ─────────────────────────────
     async def call_agent(
         state: MessagesState, config: RunnableConfig
     ) -> dict[str, Any]:
-        """调用 LLM，返回新的 AIMessage。
-
-        将 system_prompt 前置到消息列表头部，调用绑定了工具的模型，
-        返回结果作为 ``messages`` 的增量更新。
-        """
+        """调用 LLM，返回新的 AIMessage。"""
         messages = [system_message] + state["messages"]
         response = await model_with_tools.ainvoke(messages, config)
         return {"messages": [response]}
 
     # ── 组装图 ────────────────────────────────────────
-    builder = StateGraph(MessagesState)  # type: ignore[type-arg]
+    builder = StateGraph(MessagesState)
 
-    builder.add_node("agent", RunnableCallable(None, call_agent, name="agent", trace=False))
+    builder.add_node(
+        "retrieve_memory",
+        RunnableCallable(None, retrieve_memory, name="retrieve_memory", trace=False),
+    )
+    builder.add_node(
+        "agent", RunnableCallable(None, call_agent, name="agent", trace=False),
+    )
     builder.add_node("tools", tool_node)
 
-    builder.add_edge(START, "agent")
+    builder.add_edge(START, "retrieve_memory")
+    builder.add_edge("retrieve_memory", "agent")
     builder.add_conditional_edges("agent", _route_after_agent)
     builder.add_edge("tools", "agent")
 

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -52,7 +52,9 @@ def _route_after_agent(state: MessagesState) -> Literal["tools", "ltm_write"]:
 
 def _build_memory_message(results: list[dict[str, str]]) -> HumanMessage:
     """将记忆检索结果格式化为一条 HumanMessage。"""
-    lines = ["【相关记忆】"]
+    from api.memory.long_term import MEMORY_INJECTION_MARKER  # noqa: PLC0415
+
+    lines = [MEMORY_INJECTION_MARKER]
     for r in results:
         lines.append(f"- [{r['theme']}] {r['description']}")
     return HumanMessage(content="\n".join(lines))

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -70,9 +70,10 @@ def build_agent(
 
     ::
 
-        START ──→ [retrieve_memory] ──→ [agent] ──→ [tools] ──→ [agent] ──→ ...
-                                                              │              │
-                                                              └── [ltm_write] ──→ END
+                                    ↓←  [tools] ←↑
+        START ──→ [retrieve_memory] ──→ [agent] ──→  [ltm_write] ──→ END
+
+
 
     - **retrieve_memory** — 每轮 HumanMessage 时通过 ``ltm`` 语义检索长期记忆，
       以 HumanMessage 追加到 messages

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -144,8 +144,8 @@ def build_agent(
         if ws_sender:
             await ws_sender.memory_search_start()
 
-        # BM25 机械检索（~2ms），直接同步调用
-        results = ltm.get_related_memory_from(query, mode=RetrievalMode.MECHANICAL)
+        # 检索记忆
+        results = ltm.get_related_memory_from(query, mode=RetrievalMode.LLM)
 
         # 通知前端搜索完成
         if ws_sender:

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -27,6 +27,7 @@ from langgraph.graph.message import MessagesState
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt import ToolNode
 
+
 # 彩蛋：Sonetto 就是这个 CompiledStateGraph ✨
 Sonetto = CompiledStateGraph
 
@@ -98,7 +99,20 @@ def build_agent(
         if not query:
             return {}
 
+        # 延迟导入避免循环依赖
+        from api.events.memory import MemorySender  # noqa: PLC0415
+
+        # 通知前端开始搜索
+        ws_sender = MemorySender.from_context()
+        if ws_sender:
+            await ws_sender.memory_search_start()
+
         results = await memory_retriever(query)
+
+        # 通知前端搜索完成
+        if ws_sender:
+            await ws_sender.memory_search_done(count=len(results))
+
         if not results:
             return {}
 

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -70,6 +70,10 @@ class RetrieveMemoryNode:
         if not isinstance(last, HumanMessage) or self._ltm is None:
             return {}
 
+        # 失忆模式：跳过记忆提取
+        if config["configurable"].get("skip_recall", False):
+            return {}
+
         query = last.content
         if isinstance(query, list):
             text_parts = [
@@ -213,6 +217,7 @@ def build_agent(
     ==============  =====  ====================================================
     ``thread_id``    str    **必需**。会话 ID，传给 checkpointer 读写状态。
     ``private_mode``  bool   **必需**。为 ``True`` 时跳过 ltm_write 节点。
+    ``skip_recall``   bool   **必需**。为 ``True`` 时跳过 retrieve_memory 节点（失忆模式）。
     ==============  =====  ====================================================
 
     Args:

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -3,9 +3,8 @@
 
 图结构：（箭头为固定/条件边）
 
-    START ──→ [retrieve_memory] ──→ [agent] ──→ [tools] ──→ [agent] ──→ ... ──→ END
-                                            │                              ↑
-                                            └── 无 tool_calls → END ──────┘
+                                    ↓←  [tools] ←↑
+        START ──→ [retrieve_memory] ──→ [agent] ──→  [ltm_write] ──→ END
 
 `retrieve_memory` 节点在每轮用户输入时，根据最新的 HumanMessage 语义检索长期记忆，
 将结果以 HumanMessage（【相关记忆】…）的形式追加到 `messages` 列表中，紧随触发它的
@@ -55,14 +54,18 @@ def route_after_agent(state: MessagesState) -> Literal["tools", "ltm_write"]:
 class RetrieveMemoryNode:
     """检索长期记忆，以 HumanMessage 追加到 messages 中。
 
-    仅当最后一条是 HumanMessage（用户本轮新输入）且 ltm 可用时检索；
-    工具回圈（ToolMessage 结尾）时不检索，但此前追加的记忆保留在历史中。
+    按 (session_id, memory_id) 去重——同一会话中已注入过的记忆不再重复注入。
     """
+
+    # 跨实例去重状态（key=session_id, value=已注入的记忆 ID 集合）
+    _seen: dict[str, set[str]] = {}
 
     def __init__(self, ltm: LongTermMemory | None) -> None:
         self._ltm = ltm
 
-    async def __call__(self, state: MessagesState) -> dict[str, list[BaseMessage]]:
+    async def __call__(
+        self, state: MessagesState, config: RunnableConfig
+    ) -> dict[str, list[BaseMessage]]:
         last = state["messages"][-1] if state["messages"] else None
         if not isinstance(last, HumanMessage) or self._ltm is None:
             return {}
@@ -91,14 +94,30 @@ class RetrieveMemoryNode:
         # 检索记忆
         results = self._ltm.get_related_memory_from(query, mode=RetrievalMode.LLM)
 
-        # 通知前端搜索完成
-        if ws_sender:
-            await ws_sender.memory_search_done(count=len(results))
-
         if not results:
+            if ws_sender:
+                await ws_sender.memory_search_done(total=0, fresh=0)
             return {}
 
-        return {"messages": [self._build_memory_message(results)]}
+        # 按会话去重（以记忆 ID 为标识）
+        session_id = config["configurable"]["thread_id"]
+        seen_ids = RetrieveMemoryNode._seen.setdefault(session_id, set())
+        fresh: list[dict[str, str]] = []
+        for r in results:
+            mid = r["id"]
+            if mid in seen_ids:
+                continue
+            seen_ids.add(mid)
+            fresh.append(r)
+
+        # 通知前端搜索完成（含重复量和净增量）
+        if ws_sender:
+            await ws_sender.memory_search_done(total=len(results), fresh=len(fresh))
+
+        if not fresh:
+            return {}
+
+        return {"messages": [self._build_memory_message(fresh)]}
 
     @staticmethod
     def _build_memory_message(results: list[dict[str, str]]) -> HumanMessage:

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -12,7 +12,8 @@
 用户消息之后。旧轮次的记忆消息随历史保留，不会主动清除。
 """
 
-import asyncio
+from __future__ import annotations
+
 from typing import Any, Literal
 
 from langchain_core.language_models import BaseChatModel
@@ -134,16 +135,15 @@ def build_agent(
 
         # 延迟导入避免循环依赖
         from api.events.memory import MemorySender  # noqa: PLC0415
+        from api.memory import RetrievalMode  # noqa: PLC0415
 
         # 通知前端开始搜索
         ws_sender = MemorySender.from_context()
         if ws_sender:
             await ws_sender.memory_search_start()
 
-        # ltm.get_related_memory_from 是同步 LLM 调用，通过 run_in_executor
-        # 避免阻塞事件循环
-        loop = asyncio.get_event_loop()
-        results = await loop.run_in_executor(None, ltm.get_related_memory_from, query)
+        # BM25 机械检索（~2ms），直接同步调用
+        results = ltm.get_related_memory_from(query, mode=RetrievalMode.MECHANICAL)
 
         # 通知前端搜索完成
         if ws_sender:

--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -4,7 +4,6 @@ import re
 from functools import lru_cache
 from pathlib import Path
 
-from api.memory.long_term import get_narrative
 from api.memory.user_init import ensure_user_md
 
 PERSONAS_DIR = Path(__file__).resolve().parent.parent / "config" / "personas"
@@ -111,8 +110,6 @@ def get_system_prompt_parts() -> list[dict]:
          "content": "## 性格设定\n" + _read_persona("SOUL.md")},
         {"key": "user_self_report", "label": "用户自述",
          "content": "## 用户自述\n" + _read_if_exists("USER.md")},
-        {"key": "long_term_memory", "label": "长期记忆",
-         "content": "## 我对用户的记忆\n" + get_narrative()},
         {"key": "skills", "label": "Skills 清单",
          "content": _scan_anthropic_skills()},
         {"key": "macros", "label": "宏清单",
@@ -134,8 +131,8 @@ def build_system_prompt() -> str:
         "## 用户自述",
         _read_if_exists("USER.md"),
         "",
-        "## 我对用户的记忆",
-        get_narrative(),
+        "## 记忆检索说明",
+        "在对话中，你有时会看到一条以 【相关记忆】 开头的消息。这是系统根据用户当前输入自动检索的长期记忆摘要，帮助你了解与当前话题相关的过往记录。请将这些记忆信息当作背景知识使用。",
         "",
         _scan_anthropic_skills(),
         "",

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -257,6 +257,15 @@ def _resolve_llm(
 # ── 阶段 2：构建 Agent 与输入 ──────────────────────────────
 
 
+async def _search_memories(
+    ltm: Any,
+    query: str,
+) -> list[dict[str, str]]:
+    """在长期记忆中语义搜索与查询相关的条目（通过 run_in_executor 避免阻塞事件循环）。"""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, ltm.get_related_memory_from, query)
+
+
 async def _build_turn_context(
     tools: list,
     session: SessionState,
@@ -264,17 +273,26 @@ async def _build_turn_context(
     user_message: str,
     image_recognition: bool,
     image_refs: list[str] | None,
+    ltm: Any | None = None,
 ) -> _TurnContext:
     """构建 Agent 图、输入消息和执行配置。"""
     system_prompt = build_system_prompt()
     cb_sender = CallbackSender.from_context()
     ws_callback = WebSocketCallback(cb_sender)
 
+    # 若 LTM 可用，创建记忆检索器注入 graph，由 call_agent 按需调用
+    memory_retriever = None
+    if ltm is not None:
+        async def _retriever(query: str) -> list[dict[str, str]]:
+            return await _search_memories(ltm, query)
+        memory_retriever = _retriever
+
     agent = build_agent(
         model=llm_conf.llm,
         tools=tools,
         system_prompt=system_prompt,
         checkpointer=get_checkpointer(),
+        memory_retriever=memory_retriever,
     )
     session.set_graph(agent)
 
@@ -453,6 +471,7 @@ async def run_agent_turn(
         user_message=user_message,
         image_recognition=image_recognition,
         image_refs=image_refs,
+        ltm=app_state.ltm,
     )
 
     # 3. 执行轮次

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -55,11 +55,13 @@ class _TurnContext:
         agent:         编译后的 LangGraph Agent (Sonetto)
         inputs:        本轮输入消息字典（含 HumanMessage 列表）
         config:        运行配置（thread_id、callbacks、recursion_limit）
+        turn_id:       本轮唯一标识（UUID hex），用于关联记忆事件
     """
     system_prompt: str
     agent: Sonetto
     inputs: dict[str, list[HumanMessage]]
     config: dict[str, Any]
+    turn_id: str
 
 
 @dataclass
@@ -68,11 +70,9 @@ class _TurnResult:
 
     Attributes:
         final_answer: Agent 产出的最终文本回答（空串表示无回答）
-        turn_id:      本轮唯一标识（UUID hex），用于关联记忆事件
         error:        执行过程中抛出的异常信息；成功时为 None
     """
     final_answer: str
-    turn_id: str
     error: str | None
 
 
@@ -301,16 +301,22 @@ async def _build_turn_context(
     else:
         inputs = {"messages": [HumanMessage(content=user_message)]}
 
+    turn_id = uuid.uuid4().hex
+
     config = {
         "configurable": {
             "thread_id": session.session_id,
             "private_mode": private_mode,
+            "turn_id": turn_id,
         },
         "callbacks": [ws_callback],
         "recursion_limit": 120,
     }
 
-    return _TurnContext(system_prompt=system_prompt, agent=agent, inputs=inputs, config=config)
+    return _TurnContext(
+        system_prompt=system_prompt, agent=agent,
+        inputs=inputs, config=config, turn_id=turn_id,
+    )
 
 
 # ── 阶段 3：执行轮次 ──────────────────────────────────────
@@ -325,7 +331,6 @@ async def _execute_agent_turn(
     """流式执行 Agent 轮次，处理取消与异常，返回结果。"""
     final_answer = ""
     error: str | None = None
-    turn_id = ""
 
     try:
         # 推送初始上下文用量（含刚加入的 user message）
@@ -361,10 +366,9 @@ async def _execute_agent_turn(
             session, ctx.system_prompt,
             max_tokens=llm_conf.max_tokens, model_name=llm_conf.model_name,
         )
-        turn_id = uuid.uuid4().hex
-        await sender.done(turn_id, context_usage)
+        await sender.done(ctx.turn_id, context_usage)
 
-    return _TurnResult(final_answer=final_answer, turn_id=turn_id, error=error)
+    return _TurnResult(final_answer=final_answer, error=error)
 
 
 # ── 阶段 4：后处理 ────────────────────────────────────────

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -257,15 +257,6 @@ def _resolve_llm(
 # ── 阶段 2：构建 Agent 与输入 ──────────────────────────────
 
 
-async def _search_memories(
-    ltm: Any,
-    query: str,
-) -> list[dict[str, str]]:
-    """在长期记忆中语义搜索与查询相关的条目（通过 run_in_executor 避免阻塞事件循环）。"""
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, ltm.get_related_memory_from, query)
-
-
 async def _build_turn_context(
     tools: list,
     session: SessionState,
@@ -281,19 +272,11 @@ async def _build_turn_context(
     cb_sender = CallbackSender.from_context()
     ws_callback = WebSocketCallback(cb_sender)
 
-    # 若 LTM 可用，创建记忆检索器注入 graph
-    memory_retriever = None
-    if ltm is not None:
-        async def _retriever(query: str) -> list[dict[str, str]]:
-            return await _search_memories(ltm, query)
-        memory_retriever = _retriever
-
     agent = build_agent(
         model=llm_conf.llm,
         tools=tools,
         system_prompt=system_prompt,
         checkpointer=get_checkpointer(),
-        memory_retriever=memory_retriever,
         ltm=ltm,
     )
     session.set_graph(agent)

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -266,6 +266,7 @@ async def _build_turn_context(
     image_refs: list[str] | None,
     ltm: Any | None = None,
     private_mode: bool = False,
+    skip_recall: bool = False,
 ) -> _TurnContext:
     """构建 Agent 图、输入消息和执行配置。"""
     system_prompt = build_system_prompt()
@@ -307,6 +308,7 @@ async def _build_turn_context(
         "configurable": {
             "thread_id": session.session_id,
             "private_mode": private_mode,
+            "skip_recall": skip_recall,
             "turn_id": turn_id,
         },
         "callbacks": [ws_callback],
@@ -419,6 +421,7 @@ async def run_agent_turn(
     session: SessionState,
     user_message: str,
     private_mode: bool = False,
+    skip_recall: bool = False,
     provider_id: str | None = None,
     model_name: str | None = None,
     image_recognition: bool = False,
@@ -460,6 +463,7 @@ async def run_agent_turn(
         image_refs=image_refs,
         ltm=app_state.ltm,
         private_mode=private_mode,
+        skip_recall=skip_recall,
     )
 
     # 3. 执行轮次

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -274,13 +274,14 @@ async def _build_turn_context(
     image_recognition: bool,
     image_refs: list[str] | None,
     ltm: Any | None = None,
+    private_mode: bool = False,
 ) -> _TurnContext:
     """构建 Agent 图、输入消息和执行配置。"""
     system_prompt = build_system_prompt()
     cb_sender = CallbackSender.from_context()
     ws_callback = WebSocketCallback(cb_sender)
 
-    # 若 LTM 可用，创建记忆检索器注入 graph，由 call_agent 按需调用
+    # 若 LTM 可用，创建记忆检索器注入 graph
     memory_retriever = None
     if ltm is not None:
         async def _retriever(query: str) -> list[dict[str, str]]:
@@ -293,6 +294,7 @@ async def _build_turn_context(
         system_prompt=system_prompt,
         checkpointer=get_checkpointer(),
         memory_retriever=memory_retriever,
+        ltm=ltm,
     )
     session.set_graph(agent)
 
@@ -317,7 +319,10 @@ async def _build_turn_context(
         inputs = {"messages": [HumanMessage(content=user_message)]}
 
     config = {
-        "configurable": {"thread_id": session.session_id},
+        "configurable": {
+            "thread_id": session.session_id,
+            "private_mode": private_mode,
+        },
         "callbacks": [ws_callback],
         "recursion_limit": 120,
     }
@@ -383,20 +388,15 @@ async def _execute_agent_turn(
 
 
 async def _postprocess_turn(
-    ltm: Any,
     session: SessionState,
     result: _TurnResult,
-    user_message: str,
-    private_mode: bool,
 ) -> None:
-    """后处理：消息计数、长期记忆持久化、Const 会话保存、Sub-agent 结果回调。"""
+    """后处理：消息计数、Const 会话保存、Sub-agent 结果回调。
+
+    LTM 持久化已移至图内 ``ltm_write`` 节点，不再在此处调用。
+    """
     if result.final_answer:
         session.increment_messages()
-
-    if not private_mode:
-        await ltm.send_history_from_session(
-            session, turn_id=result.turn_id, user_message=user_message, final_answer=result.final_answer,
-        )
 
     # Const 会话持久化
     if result.final_answer and session.is_const:
@@ -472,16 +472,14 @@ async def run_agent_turn(
         image_recognition=image_recognition,
         image_refs=image_refs,
         ltm=app_state.ltm,
+        private_mode=private_mode,
     )
 
     # 3. 执行轮次
     result: _TurnResult = await _execute_agent_turn(ctx, sender, session, llm_conf)
 
-    # 4. 后处理
+    # 4. 后处理（LTM 持久化已在图内 ltm_write 节点中完成）
     await _postprocess_turn(
-        ltm=app_state.ltm,
         session=session,
         result=result,
-        user_message=user_message,
-        private_mode=private_mode,
     )

--- a/api/events/memory.py
+++ b/api/events/memory.py
@@ -52,6 +52,6 @@ class MemorySender(WsTransport):
         """通知前端开始语义搜索记忆。"""
         await self._send("memory_search_start", {})
 
-    async def memory_search_done(self, count: int) -> None:
-        """通知前端记忆搜索完成。"""
-        await self._send("memory_search_done", {"count": count})
+    async def memory_search_done(self, total: int, fresh: int) -> None:
+        """通知前端记忆搜索完成。total=原始检索数, fresh=去重后净新增数。"""
+        await self._send("memory_search_done", {"total": total, "fresh": fresh})

--- a/api/events/memory.py
+++ b/api/events/memory.py
@@ -47,3 +47,11 @@ class MemorySender(WsTransport):
     async def memory_done(self, turn_id: str) -> None:
         """通知前端本轮记忆处理完成。"""
         await self._send("memory_done", {"turn_id": turn_id})
+
+    async def memory_search_start(self) -> None:
+        """通知前端开始语义搜索记忆。"""
+        await self._send("memory_search_start", {})
+
+    async def memory_search_done(self, count: int) -> None:
+        """通知前端记忆搜索完成。"""
+        await self._send("memory_search_done", {"count": count})

--- a/api/events/transport.py
+++ b/api/events/transport.py
@@ -20,6 +20,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# 模块级 WS 锁映射：所有共享同一 ws 连接的 Sender 实例共用一把锁，
+# 避免并发写入时 ws.send_json 交错，同时确保锁在 _send() 首次调用时
+# 才按需创建，绑定到调用时的事件循环。
+_ws_locks: dict[int, asyncio.Lock] = {}
+
 
 class WsTransport:
     """WebSocket 传输基类。
@@ -29,13 +34,14 @@ class WsTransport:
 
         async def answer(self, content: str) -> None:
             await self._send("answer", {"content": content})
+
+    线程安全性：本类通过模块级 ``_ws_locks`` 字典实现按 WebSocket 实例
+    粒度的锁，确保所有共享同一 ws 连接的 Sender 实例并发调用 _send() 时
+    不会交错写入。锁在 _send() 首次调用时按需创建，绑定调用时的事件循环。
     """
 
     def __init__(self, ws: WebSocket | None) -> None:
         self._ws = ws
-        # 延迟初始化锁，确保锁在 _send() 调用的事件循环中创建，
-        # 避免 LTM 后台 consumer 等场景下锁绑定到错误的事件循环。
-        self._write_lock: asyncio.Lock | None = None
 
     # ── 工厂方法 ─────────────────────────────────────────────
 
@@ -91,12 +97,15 @@ class WsTransport:
         if self._ws is None:
             return
 
-        # 延迟创建锁，确保绑定到 _send 调用时的事件循环
-        if self._write_lock is None:
-            self._write_lock = asyncio.Lock()
+        # 按 ws 对象身份获取共享锁，所有指向同一 ws 的 Sender 实例共用，
+        # 避免并发写入；锁在首次访问时按需创建，绑定当前事件循环。
+        ws_id = id(self._ws)
+        if ws_id not in _ws_locks:
+            _ws_locks[ws_id] = asyncio.Lock()
 
-        async with self._write_lock:
+        async with _ws_locks[ws_id]:
             try:
                 await self._ws.send_json({"type": event_type, "payload": payload})
             except WebSocketDisconnect:
                 self._ws = None
+                _ws_locks.pop(ws_id, None)

--- a/api/events/transport.py
+++ b/api/events/transport.py
@@ -20,10 +20,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# 模块级 WS 锁映射：所有共享同一 ws 连接的 Sender 实例共用一把锁，
-# 避免并发写入时 ws.send_json 交错，同时确保锁在 _send() 首次调用时
-# 才按需创建，绑定到调用时的事件循环。
-_ws_locks: dict[int, asyncio.Lock] = {}
+# 模块级 WS 锁映射：(id(ws), id(loop)) → asyncio.Lock
+# 之所以用二元组作 key，是因为 LangChain 内部有时会创建临时事件循环来调度
+# async callback（如 MemoryToolCallback），导致 callback 中的 _send() 与
+# 主循环共用同一把锁 → "bound to a different event loop" 错误。
+# 按 (ws, loop) 各自持锁，彻底隔离不同循环的锁竞争。
+_ws_locks: dict[tuple[int, int], asyncio.Lock] = {}
+
+
+def _cleanup_ws_locks(ws_id: int) -> None:
+    """断开时清理所有涉及给定 ws 的锁条目。"""
+    for key in list(_ws_locks.keys()):
+        if key[0] == ws_id:
+            _ws_locks.pop(key, None)
 
 
 class WsTransport:
@@ -97,15 +106,17 @@ class WsTransport:
         if self._ws is None:
             return
 
-        # 按 ws 对象身份获取共享锁，所有指向同一 ws 的 Sender 实例共用，
-        # 避免并发写入；锁在首次访问时按需创建，绑定当前事件循环。
+        # 按 (ws, loop) 获取锁，不同循环各自隔离，避免 LangChain 临时
+        # 事件循环与主循环共用锁导致的 "bound to a different event loop"。
         ws_id = id(self._ws)
-        if ws_id not in _ws_locks:
-            _ws_locks[ws_id] = asyncio.Lock()
+        loop_id = id(asyncio.get_running_loop())
+        key = (ws_id, loop_id)
+        if key not in _ws_locks:
+            _ws_locks[key] = asyncio.Lock()
 
-        async with _ws_locks[ws_id]:
+        async with _ws_locks[key]:
             try:
                 await self._ws.send_json({"type": event_type, "payload": payload})
             except WebSocketDisconnect:
                 self._ws = None
-                _ws_locks.pop(ws_id, None)
+                _cleanup_ws_locks(ws_id)

--- a/api/memory/__init__.py
+++ b/api/memory/__init__.py
@@ -2,6 +2,7 @@
 
 from api.memory.callback import MemoryToolCallback
 from api.memory.long_term import MEMORY_PATH, LongTermMemory, get_narrative
+from api.memory.retriever import RetrievalMode
 from api.memory.short_term import delete_thread, get_checkpointer
 from api.memory.user_init import ensure_all, ensure_env_file, ensure_soul_md, ensure_user_md
 
@@ -9,6 +10,7 @@ __all__ = [
     "MEMORY_PATH",
     "LongTermMemory",
     "MemoryToolCallback",
+    "RetrievalMode",
     "delete_thread",
     "ensure_all",
     "ensure_env_file",

--- a/api/memory/long_term.py
+++ b/api/memory/long_term.py
@@ -27,6 +27,10 @@ def _sanitize(text: str) -> str:
     return text.replace("\n", " ").replace("\r", " ")
 
 
+# 记忆注入标记 — retrieve_memory 节点注入的 HumanMessage 以此开头
+MEMORY_INJECTION_MARKER = "【相关记忆】"
+
+
 PERSONAS_DIR = Path(__file__).resolve().parent.parent.parent / "config" / "personas"
 MEMORY_PATH = PERSONAS_DIR / "memory.yaml"
 
@@ -439,7 +443,12 @@ class LongTermMemory:
 
     @staticmethod
     async def _extract_session_messages(session: SessionState) -> list[dict[str, str]]:
-        """从短期记忆提取全量会话消息并映射为记忆 Agent 格式。"""
+        """从短期记忆提取全量会话消息并映射为记忆 Agent 格式。
+
+        自动跳过以 :data:`MEMORY_INJECTION_MARKER` 开头的 HumanMessage
+        （即 retrieve_memory 节点注入的【相关记忆】），避免 LTM consumer
+        将记忆注入内容当作真实用户对话写入 memory.yaml。
+        """
         try:
             raw = await session.get_messages()
             if not raw:
@@ -450,6 +459,13 @@ class LongTermMemory:
         role_map = {"human": "user", "ai": "assistant", "tool": "tool"}
         result: list[dict[str, str]] = []
         for m in raw:
+            # 跳过注入的记忆 HumanMessage
+            if (
+                m.type == "human"
+                and isinstance(m.content, str)
+                and m.content.startswith(MEMORY_INJECTION_MARKER)
+            ):
+                continue
             role = role_map.get(m.type)
             if role is None:
                 continue

--- a/api/memory/long_term.py
+++ b/api/memory/long_term.py
@@ -17,6 +17,7 @@ from api.events import MemorySender
 from api.memory.callback import MemoryToolCallback
 from api.memory.manager import BaseMemoryManager
 from api.memory.manager import MAX_DESC_LENGTH
+from api.memory.retriever import MechanicalRetriever, RetrievalMode
 from api.providers.default_llm import get_default_llm
 from api.session.manager import SessionState, session_manager
 
@@ -313,6 +314,7 @@ class LongTermMemory:
         memory_manager: BaseMemoryManager,
     ) -> None:
         self._mm = memory_manager
+        self._retriever: MechanicalRetriever | None = None
         self._queue: asyncio.Queue | None = None
         self._consumer_task: asyncio.Task | None = None
 
@@ -328,15 +330,35 @@ class LongTermMemory:
             return ""
         return _format_narrative(items)
 
-    def get_related_memory_from(self, prompt: str) -> list[dict[str, str]]:
-        """根据查询要求从记忆库中找出语义相关的条目并返回其 id / description / theme。"""
+    def get_related_memory_from(
+        self, prompt: str, mode: RetrievalMode = RetrievalMode.LLM
+    ) -> list[dict[str, str]]:
+        """根据查询提示检索相关记忆条目。
+
+        通过 ``mode`` 参数选择检索策略：
+
+        - ``RetrievalMode.LLM`` → :meth:`_retrieve_llm`（LLM 语义检索）
+        - ``RetrievalMode.MECHANICAL`` → :meth:`_retrieve_mechanical`（BM25 机械检索）
+
+        两种路径的返回格式均为 ``[{id, description, theme}, ...]``。
+
+        Args:
+            prompt: 用户查询文本。
+            mode: 检索模式，默认 LLM 语义检索。
+        """
+        if mode == RetrievalMode.MECHANICAL:
+            return self._retrieve_mechanical(prompt)
+        return self._retrieve_llm(prompt)
+
+    def _retrieve_llm(self, prompt: str) -> list[dict[str, str]]:
+        """LLM 语义检索：将全量记忆注入 LLM，由 LLM 判断相关条目。"""
         if get_default_llm() is None:
             return []
         items = self._mm.show()
         if not items:
             return []
 
-        # 格式化为带列表序号（而非内部 hex ID）的编号列表，供 LLM 引用
+        # 格式化为带列表序号的编号列表，供 LLM 引用
         lines = []
         for i, item in enumerate(items):
             lines.append(f"[{i}] ({item['theme']}) {item['description']}")
@@ -358,6 +380,15 @@ class LongTermMemory:
         except (json.JSONDecodeError, TypeError, IndexError):
             pass
         return []
+
+    def _retrieve_mechanical(self, prompt: str) -> list[dict[str, str]]:
+        """BM25 机械检索：零 LLM 调用，毫秒级匹配。"""
+        if self._retriever is None:
+            self._retriever = MechanicalRetriever()
+            self._retriever.build_index(self._mm.show())
+        elif self._retriever.dirty:
+            self._retriever.build_index(self._mm.show())
+        return self._retriever.get_related_memory_from(prompt)
 
     def delete_memory(self, id: str) -> str:
         """删除指定 ID 的单条记忆，返回被删除条目的描述。"""

--- a/api/memory/long_term.py
+++ b/api/memory/long_term.py
@@ -9,6 +9,7 @@ import functools
 from pathlib import Path
 
 from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
 from langchain.agents import create_agent
@@ -369,10 +370,10 @@ class LongTermMemory:
         memory_text = "\n".join(lines)
         user_prompt = f"## 记忆库\n{memory_text}\n\n## 查询要求\n{prompt}"
 
-        response = get_default_llm().invoke([
-            SystemMessage(content=FIND_RELATED_MEMORY.strip()),
-            HumanMessage(content=user_prompt),
-        ])
+        response = get_default_llm().invoke(
+            [SystemMessage(content=FIND_RELATED_MEMORY.strip()), HumanMessage(content=user_prompt)],
+            config=RunnableConfig(callbacks=[]),
+        )
 
         try:
             indices = json.loads(response.content)

--- a/api/memory/long_term.py
+++ b/api/memory/long_term.py
@@ -328,8 +328,8 @@ class LongTermMemory:
             return ""
         return _format_narrative(items)
 
-    def get_related_memory_from(self, prompt: str) -> list[str]:
-        """根据查询要求从记忆库中找出语义相关的条目并返回其描述文本。"""
+    def get_related_memory_from(self, prompt: str) -> list[dict[str, str]]:
+        """根据查询要求从记忆库中找出语义相关的条目并返回其 id / description / theme。"""
         if get_default_llm() is None:
             return []
         items = self._mm.show()
@@ -351,7 +351,10 @@ class LongTermMemory:
         try:
             indices = json.loads(response.content)
             if isinstance(indices, list):
-                return [items[i]["description"] for i in indices if 0 <= i < len(items)]
+                return [
+                    {"id": items[i]["id"], "description": items[i]["description"], "theme": items[i]["theme"]}
+                    for i in indices if 0 <= i < len(items)
+                ]
         except (json.JSONDecodeError, TypeError, IndexError):
             pass
         return []

--- a/api/memory/retriever.py
+++ b/api/memory/retriever.py
@@ -1,0 +1,217 @@
+"""机械检索器 — 纯 BM25 机械匹配，替代 LLM 语义检索。
+
+湾流 V5.1：将记忆检索从「每次对话调用 LLM」降级为「纯 BM25 机械匹配」，
+消除每次对话中记忆读取环节的 LLM 延迟和成本。
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from enum import Enum
+from typing import Any
+
+
+# ── 枚举 ─────────────────────────────────────────────
+
+
+class RetrievalMode(Enum):
+    """记忆检索模式。
+
+    Attributes:
+        LLM:        LLM 语义检索（默认，当前生产方案）
+        MECHANICAL: BM25 机械检索（零 LLM 调用，毫秒级）
+    """
+    LLM = "llm"
+    MECHANICAL = "mech"
+
+
+# ── 停用字 ───────────────────────────────────────────
+
+_STOP_CHARS = frozenset(
+    "的 了 是 在 有 和 不 也 个 与 及 或 "
+    "把 被 让 对 从 到 向 于 由 以 这 那".split()
+)
+
+_RE_EN_TOKEN = re.compile(r"[a-zA-Z0-9_.+#/\\-]+")
+
+
+# ── 分词器 ───────────────────────────────────────────
+
+
+def _tokenize(text: str) -> list[str]:
+    """纯机械中文分词。
+
+    英文/数字 token 降大小写后保留原样；
+    中文通过单字 + Bigram + Trigram 覆盖语义单元，停用字仅影响单字层。
+    """
+    tokens: list[str] = []
+
+    # 英文/数字 token
+    for match in _RE_EN_TOKEN.finditer(text):
+        tokens.append(match.group().lower())
+
+    # 提取中文字符
+    chinese_chars = [c for c in text if "一" <= c <= "鿿"]
+
+    # 单字（过滤停用字）
+    for c in chinese_chars:
+        if c not in _STOP_CHARS:
+            tokens.append(c)
+
+    # Bigram
+    for i in range(len(chinese_chars) - 1):
+        tokens.append(chinese_chars[i] + chinese_chars[i + 1])
+
+    # Trigram
+    for i in range(len(chinese_chars) - 2):
+        tokens.append(chinese_chars[i] + chinese_chars[i + 1] + chinese_chars[i + 2])
+
+    return tokens
+
+
+# ── BM25 检索器 ──────────────────────────────────────
+
+
+class MechanicalRetriever:
+    """基于 BM25 的机械记忆检索器。
+
+    零外部依赖，纯正则分词 + BM25 评分 + 命中数加权。
+    索引构建约 35ms（236 条），单次检索约 2ms。
+
+    用法::
+
+        retriever = MechanicalRetriever()
+        retriever.build_index(mm.show())
+        results = retriever.search("塔罗牌重构", top_k=5)
+    """
+
+    def __init__(self, k1: float = 1.5, b: float = 0.75, alpha: float = 0.15) -> None:
+        self._k1 = k1
+        self._b = b
+        self._alpha = alpha
+
+        # 标记位：外部修改记忆后应置 True，下次检索前自动重建
+        self.dirty: bool = False
+
+        # 索引数据
+        self._items: list[dict[str, Any]] = []
+        self._doc_terms: list[list[str]] = []
+        self._doc_lengths: list[int] = []
+        self._avgdl: float = 0.0
+        self._df: dict[str, int] = {}
+        self._N: int = 0
+
+    def build_index(self, items: list[dict[str, Any]]) -> None:
+        """全量重建 BM25 倒排索引。
+
+        Args:
+            items: ``mm.show()`` 的输出，每条含 ``id`` / ``description`` / ``theme``。
+                   可选含 ``hit``（命中数），缺失时默认为 0。
+        """
+        self._items = list(items)
+        self._N = len(self._items)
+
+        # 分词
+        self._doc_terms = [
+            _tokenize(item.get("description", "")) for item in self._items
+        ]
+        self._doc_lengths = [len(terms) for terms in self._doc_terms]
+        self._avgdl = sum(self._doc_lengths) / max(self._N, 1)
+
+        # 文档频率（每个 term 出现在多少篇文档中，每篇仅计一次）
+        df: dict[str, int] = {}
+        for terms in self._doc_terms:
+            for term in set(terms):
+                df[term] = df.get(term, 0) + 1
+        self._df = df
+
+        self.dirty = False
+
+    def search(
+        self, query: str, top_k: int = 5, min_score: float = 0.0
+    ) -> list[dict[str, Any]]:
+        """BM25 搜索，返回 Top-K 结果。
+
+        Args:
+            query:   用户查询文本。
+            top_k:   截断条数，默认 5。
+            min_score: 最低分数阈值，低于此值的不返回。
+
+        Returns:
+            按 ``score`` 降序排列的结果列表：
+            ``{score, id, description, theme, hit}``
+        """
+        if self._N == 0:
+            return []
+
+        q_terms = _tokenize(query)
+        if not q_terms:
+            return []
+
+        unknown_terms = [t for t in q_terms if t not in self._df]
+        known_terms = [t for t in q_terms if t in self._df]
+        if not known_terms:
+            return []
+
+        # 对每个文档计算 BM25 分数
+        scores = [0.0] * self._N
+
+        for qt in set(known_terms):
+            idf = self._idf(qt)
+            qf = q_terms.count(qt)
+
+            for doc_idx in range(self._N):
+                tf = self._doc_terms[doc_idx].count(qt)
+                if tf == 0:
+                    continue
+                tf_boost = (
+                    tf
+                    * (self._k1 + 1)
+                    / (
+                        tf
+                        + self._k1
+                        * (1 - self._b + self._b * self._doc_lengths[doc_idx] / self._avgdl)
+                    )
+                )
+                scores[doc_idx] += idf * tf_boost * qf
+
+        # hit 对数加权：final_score = bm25_score × (1 + α · ln(hit + 1))
+        for i in range(self._N):
+            hit = int(self._items[i].get("hit", 0))
+            boost = 1.0 + self._alpha * math.log(hit + 1)
+            scores[i] *= boost
+
+        # Top-K 截断
+        top_indices = sorted(
+            range(self._N),
+            key=lambda i: scores[i],
+            reverse=True,
+        )
+        top_indices = [i for i in top_indices if scores[i] >= min_score][:top_k]
+
+        return [
+            {
+                "score": round(scores[i], 2),
+                "id": self._items[i]["id"],
+                "description": self._items[i]["description"],
+                "theme": self._items[i].get("theme", ""),
+                "hit": int(self._items[i].get("hit", 0)),
+            }
+            for i in top_indices
+        ]
+
+    def get_related_memory_from(
+        self, prompt: str, top_k: int = 5
+    ) -> list[dict[str, str]]:
+        """兼容接口，桥接 :meth:`search`，返回 ``{id, description, theme}`` 格式。"""
+        results = self.search(prompt, top_k=top_k)
+        return [
+            {"id": r["id"], "description": r["description"], "theme": r["theme"]}
+            for r in results
+        ]
+
+    def _idf(self, term: str) -> float:
+        """BM25 IDF：``ln((N - df + 0.5) / (df + 0.5) + 1)``"""
+        df = self._df.get(term, 0)
+        return math.log((self._N - df + 0.5) / (df + 0.5) + 1)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -82,6 +82,7 @@ async def _handle_chat(
         return agent_task
 
     auto_approve = payload.get("auto_approve", False)
+    skip_recall = payload.get("skip_recall", False)
     interaction.current_ws.set(ws)  # 供工具函数/Sender.from_context() 通过 WebSocket 推送交互
     interaction.current_session_id.set(session_id)
     interaction.set_session_auto_approve(session_id, auto_approve)
@@ -95,6 +96,7 @@ async def _handle_chat(
             model_name=payload.get("model_name"),
             image_recognition=payload.get("image_recognition", False),
             image_refs=payload.get("image_refs", []),
+            skip_recall=skip_recall,
         )
     )
     session.set_active_task(agent_task)

--- a/api/tools/manager.py
+++ b/api/tools/manager.py
@@ -35,6 +35,14 @@ class ToolManager:
         assert self._mcp_tools is not None, "load_all() 未调用"
         return self._mcp_tools
 
+    # 主 Agent 不再需要长期记忆管理工具（已由 retrieve_memory / ltm_write
+    # 图节点替代），此处从 get_all 排除，但保留工具文件本身及 LTM 后台
+    # consumer 中的 @tool CRUD 函数不受影响。
+    _MEMORY_TOOL_NAMES = frozenset({
+        "list_memories", "read_memories", "create_memory",
+        "update_memory", "delete_memory", "merge_memories",
+    })
+
     def get_all(self, multimodal: bool = False) -> list[BaseTool]:
         """返回合并后的完整工具列表（消费方主要用这个）。
 
@@ -45,9 +53,10 @@ class ToolManager:
         """
         tools = self.native_tools + self.mcp_tools
         if multimodal:
-            return [t for t in tools if t.name != "analyze_image"]
+            tools = [t for t in tools if t.name != "analyze_image"]
         else:
-            return [t for t in tools if t.name != "read_image"]
+            tools = [t for t in tools if t.name != "read_image"]
+        return [t for t in tools if t.name not in self._MEMORY_TOOL_NAMES]
 
     async def reload_mcp(self) -> list[BaseTool]:
         """热加载 MCP 工具，返回新的 MCP 工具列表。"""

--- a/web/src/assets/icons/sidebar/recall.svg
+++ b/web/src/assets/icons/sidebar/recall.svg
@@ -15,10 +15,10 @@
 			s3.793,1.702,3.793,3.794S28.235,45.722,26.143,45.722z"/>
 	</g>
 </g>
-<!-- 右下角三层向下箭头，表示点击切换私密模式 -->
+<!-- 右下角三层向上箭头，表示回忆模式：开启时检索记忆，关闭时跳过记忆提取 -->
 <g opacity="0.9" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
-	<path d="M56,36 L70,48 L82,36"/>
-	<path d="M56,48 L70,60 L82,48"/>
-	<path d="M56,60 L70,72 L82,60"/>
+	<path d="M56,48 L70,36 L82,48"/>
+	<path d="M56,60 L70,48 L82,60"/>
+	<path d="M56,72 L70,60 L82,72"/>
 </g>
 </svg>

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -110,6 +110,15 @@
             <Icon name="memory" :size="18" />
           </button>
           <button
+            class="btn-recall"
+            :class="{ active: skipRecall }"
+            :disabled="disabled"
+            :title="skipRecall ? '失忆模式：已跳过记忆检索' : '回忆模式：每轮自动检索相关记忆'"
+            @click="$emit('toggleRecall')"
+          >
+            <Icon name="recall" :size="18" />
+          </button>
+          <button
             class="btn-check"
             :class="{ active: autoApprove }"
             :disabled="disabled"
@@ -184,6 +193,7 @@ const props = defineProps<{
   isStreaming: boolean
   disabled: boolean
   privateMode: boolean
+  skipRecall: boolean
   autoApprove: boolean
   imageRecognition: boolean
   hasVision?: boolean
@@ -194,6 +204,7 @@ const emit = defineEmits<{
   stop: []
   modelChange: [providerId: string, modelName: string]
   togglePrivate: []
+  toggleRecall: []
   toggleAutoApprove: []
   toggleImageRecognition: []
 }>()
@@ -1354,9 +1365,72 @@ function onResizeEnd(e: PointerEvent) {
   cursor: default;
 }
 .btn-memory.active {
+  position: relative;
   background: color-mix(in srgb, #81ae92 12%, transparent);
   color: #81ae92;
   box-shadow: 0 0 0 1px color-mix(in srgb, #81ae92 30%, transparent);
+}
+.btn-memory.active::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to top right,
+    transparent calc(50% - 0.5px),
+    currentColor calc(50% - 0.5px),
+    currentColor calc(50% + 0.5px),
+    transparent calc(50% + 0.5px)
+  );
+  pointer-events: none;
+  opacity: 0.65;
+  border-radius: 8px;
+}
+
+/* ── 回忆/失忆模式切换按钮 ── */
+.btn-recall {
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  padding: 0;
+  font-family: inherit;
+  flex-shrink: 0;
+}
+.btn-recall:hover:not(:disabled) {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+.btn-recall:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.btn-recall.active {
+  position: relative;
+  background: color-mix(in srgb, #81ae92 12%, transparent);
+  color: #81ae92;
+  box-shadow: 0 0 0 1px color-mix(in srgb, #81ae92 30%, transparent);
+}
+.btn-recall.active::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to top right,
+    transparent calc(50% - 0.5px),
+    currentColor calc(50% - 0.5px),
+    currentColor calc(50% + 0.5px),
+    transparent calc(50% + 0.5px)
+  );
+  pointer-events: none;
+  opacity: 0.65;
+  border-radius: 8px;
 }
 
 /* ── 检查/自动执行按钮 ── */

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -11,8 +11,19 @@
         >
           <MessageBubble role="user" :content="turn.userMessage" :refs="turn.refs" :image-refs="turn.imageRefs" />
         </div>
-        <!-- 助手侧：events + finalAnswer + 记忆日志，hover 时才显示记忆日志 -->
+        <!-- 助手侧：记忆搜索指示器 + events + finalAnswer + 记忆日志，hover 时才显示记忆日志 -->
         <div class="assistant-side">
+          <!-- 语义记忆搜索指示器 -->
+          <div v-if="turn.memorySearch" class="memory-search-indicator">
+            <template v-if="turn.memorySearch.status === 'searching'">
+              <span class="memory-search-spinner"></span>
+              <span>正在搜索相关记忆…</span>
+            </template>
+            <template v-else>
+              <span class="memory-search-check">&#10003;</span>
+              <span>已检索到 {{ turn.memorySearch.count }} 条相关记忆</span>
+            </template>
+          </div>
           <template v-for="(ev, i) in turn.events" :key="i">
             <div
               v-if="ev.kind === 'thinking'"
@@ -639,5 +650,33 @@ function closeContextMenu() {
   font-variant-numeric: tabular-nums;
   opacity: 0.6;
   font-size: 10px;
+}
+
+/* ── 语义记忆搜索指示器 ── */
+.memory-search-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0 2px 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.memory-search-spinner {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: memory-spin 0.6s linear infinite;
+  flex-shrink: 0;
+}
+
+.memory-search-check {
+  font-size: 11px;
+  color: #22c55e;
+  flex-shrink: 0;
 }
 </style>

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -21,7 +21,7 @@
             </template>
             <template v-else>
               <span class="memory-search-check">&#10003;</span>
-              <span>已检索到 {{ turn.memorySearch.count }} 条相关记忆</span>
+              <span>已检索 {{ turn.memorySearch.total }} 条，新增 {{ turn.memorySearch.fresh }} 条</span>
             </template>
           </div>
           <template v-for="(ev, i) in turn.events" :key="i">

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -111,6 +111,10 @@
               <span class="quick-hint-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg></span>
               <span><kbd>Ctrl</kbd> + <kbd>K</kbd> 切换私密模式</span>
             </span>
+            <span class="quick-hint" @click="toggleRecall">
+              <span class="quick-hint-icon"><svg width="14" height="14" viewBox="0 0 82.118 82.118" fill="currentColor"><path d="M75.346,15.559h-47.9c-3.499,0-4.873,1.509-6.328,2.905c-0.294,0.283-0.613,0.685-0.982,1.01c-0.045,0.04-0.088,0.128-0.129,0.172L0.548,40.216c-0.721,0.761-0.731,1.962-0.024,2.737l19.459,21.298c0.07,0.076,0.146-0.04,0.227,0.024c2.194,1.756,3.463,2.284,7.237,2.284h47.899c4.35,0,6.772-2.659,6.772-7.184V24.2C82.118,19.491,79.491,15.559,75.346,15.559z M78.118,59.375c0,1.331,0.075,3.184-2.772,3.184h-47.9c-2.675,0-3.106-0.101-4.616-1.307L4.731,41.544L22.85,22.461c0.387-0.344,0.725-0.833,1.037-1.134c1.281-1.229,1.668-1.767,3.559-1.767h47.899c2.248,0,2.772,2.589,2.772,4.641v35.174H78.118z M26.143,34.135c-4.297,0-7.793,3.496-7.793,7.794c0,4.297,3.496,7.793,7.793,7.793s7.793-3.496,7.793-7.793C33.936,37.631,30.44,34.135,26.143,34.135z M26.143,45.722c-2.092,0-3.793-1.701-3.793-3.793s1.701-3.794,3.793-3.794s3.793,1.702,3.793,3.794S28.235,45.722,26.143,45.722z"/></svg></span>
+              <span><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd> 切换回忆/失忆</span>
+            </span>
             <span class="quick-hint"> <!-- will be wired to new-session -->
               <span class="quick-hint-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg></span>
               点击 <kbd>+</kbd> 新建会话
@@ -162,6 +166,7 @@ const emit = defineEmits<{
   (e: 'action', p: { action: string; data?: unknown }): void
   (e: 'cite', ref: ParsedRef): void
   (e: 'togglePrivate'): void
+  (e: 'toggleRecall'): void
 }>()
 
 function forwardAction(payload: { action: string; data?: unknown }) {
@@ -268,12 +273,21 @@ function typewriterTick() {
   }
 }
 
-// ── Private mode toggle (Ctrl+K) ──
+// ── Mode toggles (Ctrl+K / Ctrl+Shift+K) ──
 function togglePrivate() {
   emit('togglePrivate')
 }
 
+function toggleRecall() {
+  emit('toggleRecall')
+}
+
 function onPrivateKeydown(e: KeyboardEvent) {
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'K') {
+    e.preventDefault()
+    toggleRecall()
+    return
+  }
   if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
     e.preventDefault()
     togglePrivate()

--- a/web/src/components/Icon.vue
+++ b/web/src/components/Icon.vue
@@ -6,6 +6,7 @@
 import { computed } from 'vue'
 import chatRaw from '@/assets/icons/sidebar/chat.svg?raw'
 import memoryRaw from '@/assets/icons/sidebar/memory.svg?raw'
+import recallRaw from '@/assets/icons/sidebar/recall.svg?raw'
 import modelRaw from '@/assets/icons/sidebar/model.svg?raw'
 import pinRaw from '@/assets/icons/sidebar/pin.svg?raw'
 import citeSpeechRaw from '@/assets/icons/context-menu/cite-speech.svg?raw'
@@ -31,6 +32,7 @@ const props = withDefaults(defineProps<{
 const svgContents: Record<string, string> = {
   chat: chatRaw,
   memory: memoryRaw,
+  recall: recallRaw,
   model: modelRaw,
   pin: pinRaw,
   settings: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -46,11 +46,17 @@ export function useChat(sessionId: Ref<string>) {
   const contextUsage = computed(() => activeChannelRef.value.contextUsage)
   const taskTrackerData = computed(() => activeChannelRef.value.taskTrackerData)
   const privateMode = computed(() => activeChannelRef.value.privateMode)
+  const skipRecall = computed(() => activeChannelRef.value.skipRecall)
   const autoApprove = computed(() => activeChannelRef.value.autoApprove)
 
   function setPrivateMode(val: boolean) {
     const ch = activeChannelRef.value
     ch.privateMode = val
+  }
+
+  function setSkipRecall(val: boolean) {
+    const ch = activeChannelRef.value
+    ch.skipRecall = val
   }
 
   function setAutoApprove(val: boolean) {
@@ -88,6 +94,7 @@ export function useChat(sessionId: Ref<string>) {
     connected, isStreaming, turns, currentTurn, error, contextUsage, taskTrackerData,
     send, cancel, sendUserResponse, removeTurns,
     privateMode, setPrivateMode,
+    skipRecall, setSkipRecall,
     autoApprove, setAutoApprove,
   }
 }

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -201,6 +201,18 @@ export const useChatStore = defineStore('chat', () => {
       return
     }
 
+    // 语义记忆搜索事件：直接更新 currentTurn
+    if (event.type === 'memory_search_start') {
+      if (ch.currentTurn) ch.currentTurn.memorySearch = { status: 'searching' }
+      return
+    }
+    if (event.type === 'memory_search_done') {
+      if (ch.currentTurn) {
+        ch.currentTurn.memorySearch = { status: 'done', count: event.payload.count }
+      }
+      return
+    }
+
     const memoryHandler = memoryHandlers.get(event.type as MemoryEventType)
     if (typeof memoryHandler === 'function') {
       memoryHandler(ch, sid, event)

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -208,7 +208,7 @@ export const useChatStore = defineStore('chat', () => {
     }
     if (event.type === 'memory_search_done') {
       if (ch.currentTurn) {
-        ch.currentTurn.memorySearch = { status: 'done', count: event.payload.count }
+        ch.currentTurn.memorySearch = { status: 'done', total: event.payload.total, fresh: event.payload.fresh }
       }
       return
     }

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -64,6 +64,7 @@ export interface SessionChannel {
   _awaitingToolName: string | null
   parentSessionId: string | null
   privateMode: boolean
+  skipRecall: boolean
   autoApprove: boolean
 }
 
@@ -101,6 +102,7 @@ export const useChatStore = defineStore('chat', () => {
         _awaitingToolName: null,
         parentSessionId: null,
         privateMode: false,
+        skipRecall: false,
         autoApprove: false,
       })
     }
@@ -286,6 +288,7 @@ export const useChatStore = defineStore('chat', () => {
       payload: {
         message: flatMsg,
         private: ch.privateMode,
+        skip_recall: ch.skipRecall,
         auto_approve: ch.autoApprove,
         provider_id: providerId,
         model_name: modelName,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -172,6 +172,7 @@ export interface ChatMessage {
   payload: {
     message: string
     private?: boolean
+    skip_recall?: boolean
     auto_approve?: boolean
     provider_id?: string
     model_name?: string

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -138,7 +138,8 @@ export interface MemorySearchStartEvent {
 export interface MemorySearchDoneEvent {
   type: 'memory_search_done'
   payload: {
-    count: number
+    total: number
+    fresh: number
   }
 }
 
@@ -266,7 +267,7 @@ export interface ChatTurn {
   /** 后端生成的 turn_id，用于关联后台记忆 consumer 的事件 */
   turnId?: string
   /** 当前轮的语义记忆搜索结果 */
-  memorySearch?: { status: 'searching' } | { status: 'done'; count: number }
+  memorySearch?: { status: 'searching' } | { status: 'done'; total: number; fresh: number }
 }
 
 // === 会话与 API 类型 ===

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -128,6 +128,20 @@ export interface MemoryDoneEvent {
   }
 }
 
+/** memory_search_start — 前端语义记忆搜索开始 */
+export interface MemorySearchStartEvent {
+  type: 'memory_search_start'
+  payload: Record<string, never>
+}
+
+/** memory_search_done — 前端语义记忆搜索完成 */
+export interface MemorySearchDoneEvent {
+  type: 'memory_search_done'
+  payload: {
+    count: number
+  }
+}
+
 export type ServerEvent =
   | ThinkingStartEvent
   | TokenEvent
@@ -147,6 +161,8 @@ export type ServerEvent =
   | MemoryToolEndEvent
   | MemoryToolErrorEvent
   | MemoryDoneEvent
+  | MemorySearchStartEvent
+  | MemorySearchDoneEvent
 
 // === WebSocket 客户端 → 服务端消息 ===
 
@@ -249,6 +265,8 @@ export interface ChatTurn {
   finalAnswer: string | null
   /** 后端生成的 turn_id，用于关联后台记忆 consumer 的事件 */
   turnId?: string
+  /** 当前轮的语义记忆搜索结果 */
+  memorySearch?: { status: 'searching' } | { status: 'done'; count: number }
 }
 
 // === 会话与 API 类型 ===

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -13,7 +13,7 @@
     <template v-else>
     <header class="chat-header">
         <StatusBadge :connected="connected" :health="health" />
-        <div v-if="imageRecognition || privateMode || autoApprove" class="header-mode-tags">
+        <div v-if="imageRecognition || privateMode || skipRecall || autoApprove" class="header-mode-tags">
           <span v-if="imageRecognition" class="mode-tag">
             <svg class="mode-tag-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
             图像认知
@@ -21,6 +21,10 @@
           <span v-if="privateMode" class="mode-tag">
             <svg class="mode-tag-icon" viewBox="0 0 82.118 82.118" fill="currentColor"><path d="M75.346,15.559h-47.9c-3.499,0-4.873,1.509-6.328,2.905c-0.294,0.283-0.613,0.685-0.982,1.01c-0.045,0.04-0.088,0.128-0.129,0.172L0.548,40.216c-0.721,0.761-0.731,1.962-0.024,2.737l19.459,21.298c0.07,0.076,0.146-0.04,0.227,0.024c2.194,1.756,3.463,2.284,7.237,2.284h47.899c4.35,0,6.772-2.659,6.772-7.184V24.2C82.118,19.491,79.491,15.559,75.346,15.559z M78.118,59.375c0,1.331,0.075,3.184-2.772,3.184h-47.9c-2.675,0-3.106-0.101-4.616-1.307L4.731,41.544L22.85,22.461c0.387-0.344,0.725-0.833,1.037-1.134c1.281-1.229,1.668-1.767,3.559-1.767h47.899c2.248,0,2.772,2.589,2.772,4.641v35.174H78.118z M26.143,34.135c-4.297,0-7.793,3.496-7.793,7.794c0,4.297,3.496,7.793,7.793,7.793s7.793-3.496,7.793-7.793C33.936,37.631,30.44,34.135,26.143,34.135z M26.143,45.722c-2.092,0-3.793-1.701-3.793-3.793s1.701-3.794,3.793-3.794s3.793,1.702,3.793,3.794S28.235,45.722,26.143,45.722z"/></svg>
             私密
+          </span>
+          <span v-if="skipRecall" class="mode-tag">
+            <svg class="mode-tag-icon" viewBox="0 0 82.118 82.118" fill="currentColor"><path d="M75.346,15.559h-47.9c-3.499,0-4.873,1.509-6.328,2.905c-0.294,0.283-0.613,0.685-0.982,1.01c-0.045,0.04-0.088,0.128-0.129,0.172L0.548,40.216c-0.721,0.761-0.731,1.962-0.024,2.737l19.459,21.298c0.07,0.076,0.146-0.04,0.227,0.024c2.194,1.756,3.463,2.284,7.237,2.284h47.899c4.35,0,6.772-2.659,6.772-7.184V24.2C82.118,19.491,79.491,15.559,75.346,15.559z M78.118,59.375c0,1.331,0.075,3.184-2.772,3.184h-47.9c-2.675,0-3.106-0.101-4.616-1.307L4.731,41.544L22.85,22.461c0.387-0.344,0.725-0.833,1.037-1.134c1.281-1.229,1.668-1.767,3.559-1.767h47.899c2.248,0,2.772,2.589,2.772,4.641v35.174H78.118z M26.143,34.135c-4.297,0-7.793,3.496-7.793,7.794c0,4.297,3.496,7.793,7.793,7.793s7.793-3.496,7.793-7.793C33.936,37.631,30.44,34.135,26.143,34.135z M26.143,45.722c-2.092,0-3.793-1.701-3.793-3.793s1.701-3.794,3.793-3.794s3.793,1.702,3.793,3.794S28.235,45.722,26.143,45.722z"/></svg>
+            失忆
           </span>
           <span v-if="autoApprove" class="mode-tag">
             <svg class="mode-tag-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
@@ -38,6 +42,7 @@
       @action="handleToolAction"
       @cite="addCitation"
       @toggle-private="setPrivateMode(!privateMode)"
+      @toggle-recall="setSkipRecall(!skipRecall)"
     />
 
     <ChatInput
@@ -46,6 +51,7 @@
       :is-streaming="isStreaming"
       :disabled="!connected"
       :private-mode="privateMode"
+      :skip-recall="skipRecall"
       :auto-approve="autoApprove"
       :image-recognition="imageRecognition"
       :has-vision="selectedModelHasVision"
@@ -53,6 +59,7 @@
       @stop="cancel"
       @model-change="onModelChange"
       @toggle-private="setPrivateMode(!privateMode)"
+      @toggle-recall="setSkipRecall(!skipRecall)"
       @toggle-auto-approve="setAutoApprove(!autoApprove)"
       @toggle-image-recognition="imageRecognition = !imageRecognition"
     />
@@ -78,7 +85,7 @@ import type { ProviderConfig } from '@/types'
 import { computed, onMounted, ref } from 'vue'
 
 const { sessionId, sessions } = useSession()
-const { connected, isStreaming, turns, currentTurn, error, contextUsage, taskTrackerData, send, cancel, sendUserResponse, removeTurns, privateMode, setPrivateMode, autoApprove, setAutoApprove } =
+const { connected, isStreaming, turns, currentTurn, error, contextUsage, taskTrackerData, send, cancel, sendUserResponse, removeTurns, privateMode, setPrivateMode, skipRecall, setSkipRecall, autoApprove, setAutoApprove } =
   useChat(sessionId)
 
 const selectedModelName = ref('')


### PR DESCRIPTION
新增 `skipRecall`/`skip_recall` 开关，与 `privateMode` 平行：

- **回忆模式**（默认）：每轮对话自动检索长期记忆
- **失忆模式**：跳过 `retrieve_memory` 节点，不检索记忆

### 变更内容

| 文件 | 改动 |
|---|---|
| `web/src/assets/icons/sidebar/recall.svg` | 新建 — 记忆图标 + 三层向上箭头 |
| `web/src/components/Icon.vue` | 注册 `recall` 图标 |
| `web/src/types/index.ts` | `ChatMessage.payload` 新增 `skip_recall` |
| `web/src/stores/chatStore.ts` | `SessionChannel` 新增 `skipRecall` |
| `web/src/composables/useChat.ts` | 暴露 `skipRecall` / `setSkipRecall` |
| `web/src/components/ChatInput.vue` | 回忆/失忆按钮 + 激活态斜线标识 |
| `web/src/components/ChatWindow.vue` | 快速提示 + `Ctrl+Shift+K` 快捷键 |
| `web/src/views/ChatView.vue` | 串联 toggle + 顶栏失忆标签 |
| `agent/graph.py` | `RetrieveMemoryNode` 检查 `skip_recall` 跳过 |
| `api/agent/turn.py` | 透传 `skip_recall` 入 `config.configurable` |
| `api/routes/chat.py` | WS 消息提取 `skip_recall`