### PR TITLE
feat: 记忆搜索可跳过

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -13,8 +13,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Literal
 
+from api.agent import interaction
 from api.memory import LongTermMemory
 
 from langchain_core.language_models import BaseChatModel, LanguageModelInput
@@ -106,13 +108,45 @@ class RetrieveMemoryNode:
         from api.events.memory import MemorySender  # noqa: PLC0415
         from api.memory import RetrievalMode  # noqa: PLC0415
 
-        # 通知前端开始搜索
+        turn_id = config["configurable"].get("turn_id", "")
+        session_id = config["configurable"]["thread_id"]
+
+        # ═══ 注册 skip 交互 Future ═══
+        interaction_id, skip_future = interaction.register()
+
+        # 通知前端开始搜索（携带 interaction_id 供跳过按钮回传）
         ws_sender = MemorySender.from_context()
         if ws_sender:
-            await ws_sender.memory_search_start()
+            await ws_sender.memory_search_start(
+                turn_id=turn_id,
+                interaction_id=interaction_id,
+            )
 
-        # 检索记忆
-        results = self._ltm.get_related_memory_from(query, mode=RetrievalMode.LLM)
+        # ═══ 异步检索 vs 跳过信号 竞速 ═══
+        retrieval_task = asyncio.create_task(
+            self._ltm.get_related_memory_from_async(query, mode=RetrievalMode.LLM)
+        )
+
+        done, pending = await asyncio.wait(
+            [retrieval_task, skip_future],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        if skip_future.done():
+            # ← 用户点击了跳过：放弃检索结果，不注入记忆
+            retrieval_task.cancel()
+            try:
+                await retrieval_task
+            except asyncio.CancelledError:
+                pass
+            interaction.cleanup(interaction_id)
+            if ws_sender:
+                await ws_sender.memory_search_skipped()
+            return {}
+
+        # → 检索正常完成
+        interaction.cleanup(interaction_id)
+        results = retrieval_task.result()
 
         if not results:
             if ws_sender:
@@ -120,7 +154,6 @@ class RetrieveMemoryNode:
             return {}
 
         # 按会话去重（以记忆 ID 为标识）
-        session_id = config["configurable"]["thread_id"]
         seen_ids = RetrieveMemoryNode._seen.setdefault(session_id, set())
         fresh: list[dict[str, str]] = []
         for r in results:

--- a/api/events/memory.py
+++ b/api/events/memory.py
@@ -48,9 +48,13 @@ class MemorySender(WsTransport):
         """通知前端本轮记忆处理完成。"""
         await self._send("memory_done", {"turn_id": turn_id})
 
-    async def memory_search_start(self) -> None:
+    async def memory_search_start(self, turn_id: str, interaction_id: str) -> None:
         """通知前端开始语义搜索记忆。"""
-        await self._send("memory_search_start", {})
+        await self._send("memory_search_start", {"turn_id": turn_id, "interaction_id": interaction_id})
+
+    async def memory_search_skipped(self) -> None:
+        """通知前端搜索已被跳过。"""
+        await self._send("memory_search_skipped", {})
 
     async def memory_search_done(self, total: int, fresh: int) -> None:
         """通知前端记忆搜索完成。total=原始检索数, fresh=去重后净新增数。"""

--- a/api/memory/llm_retriever.py
+++ b/api/memory/llm_retriever.py
@@ -139,3 +139,38 @@ class LLMRetriever:
         except (json.JSONDecodeError, TypeError, IndexError):
             pass
         return []
+
+    async def aretrieve(self, prompt: str) -> list[dict[str, str]]:
+        """异步检索相关记忆条目（支持 asyncio 取消）。
+
+        与 :meth:`retrieve` 逻辑相同，但使用 ``ainvoke`` 替代 ``invoke``，
+        可被 ``asyncio.Task.cancel()`` 中断。用于 RetrieveMemoryNode 的
+        竞速模式（检索 vs 用户跳过）。
+        """
+        if get_default_llm() is None:
+            return []
+        items = self._mm.show()
+        if not items:
+            return []
+
+        lines = []
+        for i, item in enumerate(items):
+            lines.append(f"[{i}] ({item['theme']}) {item['description']}")
+        memory_text = "\n".join(lines)
+        user_prompt = f"## 记忆库\n{memory_text}\n\n## 查询要求\n{prompt}"
+
+        response = await get_default_llm().ainvoke(
+            [SystemMessage(content=FIND_RELATED_MEMORY.strip()), HumanMessage(content=user_prompt)],
+            config=RunnableConfig(callbacks=[]),
+        )
+
+        try:
+            indices = json.loads(response.content)
+            if isinstance(indices, list):
+                return [
+                    {"id": items[i]["id"], "description": items[i]["description"], "theme": items[i]["theme"]}
+                    for i in indices if 0 <= i < len(items)
+                ]
+        except (json.JSONDecodeError, TypeError, IndexError):
+            pass
+        return []

--- a/api/memory/long_term.py
+++ b/api/memory/long_term.py
@@ -168,6 +168,23 @@ class LongTermMemory:
             self._mechanical_retriever.build_index(self._mm.show())
         return self._mechanical_retriever.get_related_memory_from(prompt)
 
+    async def get_related_memory_from_async(
+        self, prompt: str, mode: RetrievalMode = RetrievalMode.LLM
+    ) -> list[dict[str, str]]:
+        """异步检索相关记忆条目（可取消）。
+
+        与 :meth:`get_related_memory_from` 功能相同，但：
+        - LLM 模式使用 ``ainvoke``，支持 ``asyncio.Task.cancel()`` 中断
+        - 机械模式仍为同步（BM25 毫秒级，无需取消）
+        """
+        match mode:
+            case RetrievalMode.LLM:
+                return await self._llm_retriever.aretrieve(prompt)
+            case RetrievalMode.MECHANICAL:
+                return self._retrieve_mechanical(prompt)
+            case _:
+                raise ValueError("未定义的记忆提取模式")
+
     def delete_memory(self, id: str) -> str:
         """删除指定 ID 的单条记忆，返回被删除条目的描述。"""
         return self._mm.delete(id)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -12,7 +12,7 @@ from api.agent import interaction
 from api.agent.context_usage import estimate_context_usage_from_session
 from agent import build_system_prompt
 from api.agent.turn import run_agent_turn
-from api.events import ChatSender
+from api.events import ChatSender, MemorySender
 from api.providers import FALLBACK_CTX
 from api.providers.manager import get_manager
 from api.session.manager import SessionState, session_manager
@@ -152,6 +152,29 @@ async def _handle_update_auto_approve(
         session_id, msg["payload"]["auto_approve"]
     )
     return agent_task
+
+
+@ws_event_handler("skip_memory_search")
+async def _handle_skip_memory_search(
+    ws: WebSocket,
+    session_id: str,
+    session: SessionState,
+    agent_task: asyncio.Task | None,
+    msg: dict,
+
+) -> asyncio.Task | None:
+    """处理跳过记忆搜索：通过 interaction.resolve() 唤醒 retrieve_memory 节点的 Future。
+
+    不取消 agent_task——只跳过记忆检索，Agent 图继续执行。
+    """
+    interaction_id = msg.get("payload", {}).get("interaction_id", "")
+    if interaction_id:
+        interaction.resolve(interaction_id, "skipped")
+        # 立即通知前端已跳过（不等 node 中竞速结束后二次推送）
+        sender = MemorySender.from_ws(ws)
+        await sender.memory_search_skipped()
+    return agent_task
+
 
 @router.websocket("/ws/chat/{session_id}")
 async def websocket_chat(ws: WebSocket, session_id: str) -> None:

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -18,6 +18,10 @@
             <template v-if="turn.memorySearch.status === 'searching'">
               <span class="memory-search-spinner"></span>
               <span>正在搜索相关记忆…</span>
+              <button class="skip-btn" @click="onSkipMemorySearch">跳过</button>
+            </template>
+            <template v-else-if="turn.memorySearch.status === 'skipped'">
+              <span class="memory-search-skipped">— 已跳过搜索</span>
             </template>
             <template v-else>
               <span class="memory-search-check">&#10003;</span>
@@ -171,6 +175,10 @@ const emit = defineEmits<{
 
 function forwardAction(payload: { action: string; data?: unknown }) {
   emit('action', payload)
+}
+
+function onSkipMemorySearch() {
+  emit('action', { action: 'skip_memory_search' })
 }
 
 const windowRef = ref<HTMLElement | null>(null)
@@ -686,6 +694,33 @@ function closeContextMenu() {
   border-radius: 50%;
   animation: memory-spin 0.6s linear infinite;
   flex-shrink: 0;
+}
+
+.skip-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 7px;
+  height: 18px;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.skip-btn:hover {
+  color: var(--text);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.memory-search-skipped {
+  color: var(--text-tertiary);
+  font-style: italic;
 }
 
 .memory-search-check {

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -380,7 +380,18 @@ export const useChatStore = defineStore('chat', () => {
 
     // 语义记忆搜索事件：直接更新 currentTurn
     if (event.type === 'memory_search_start') {
-      if (ch.currentTurn) ch.currentTurn.memorySearch = { status: 'searching' }
+      if (ch.currentTurn) {
+        ch.currentTurn.memorySearch = {
+          status: 'searching',
+          skipInteractionId: event.payload.interaction_id,
+        }
+      }
+      return
+    }
+    if (event.type === 'memory_search_skipped') {
+      if (ch.currentTurn) {
+        ch.currentTurn.memorySearch = { status: 'skipped' }
+      }
       return
     }
     if (event.type === 'memory_search_done') {
@@ -484,6 +495,19 @@ export const useChatStore = defineStore('chat', () => {
     ch.ws.send(JSON.stringify({ type: 'cancel', payload: {} } as ClientMessage))
   }
 
+  function skipMemorySearch(sid: string) {
+    const ch = channels.get(sid)
+    if (!ch?.ws || ch.ws.readyState !== WebSocket.OPEN) return
+    const interactionId = ch.currentTurn?.memorySearch?.status === 'searching'
+      ? ch.currentTurn.memorySearch.skipInteractionId
+      : undefined
+    if (!interactionId) return
+    ch.ws.send(JSON.stringify({
+      type: 'skip_memory_search',
+      payload: { interaction_id: interactionId },
+    } as ClientMessage))
+  }
+
   function sendUserResponse(sid: string, interactionId: string, response: string | string[]) {
     const ch = channels.get(sid)
     if (!ch?.ws || ch.ws.readyState !== WebSocket.OPEN) return
@@ -536,6 +560,7 @@ export const useChatStore = defineStore('chat', () => {
     handleEventForChannel,
     send,
     cancel,
+    skipMemorySearch,
     sendUserResponse,
     removeTurns,
     updateAutoApprove,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -131,6 +131,15 @@ export interface MemoryDoneEvent {
 /** memory_search_start — 前端语义记忆搜索开始 */
 export interface MemorySearchStartEvent {
   type: 'memory_search_start'
+  payload: {
+    turn_id: string
+    interaction_id: string
+  }
+}
+
+/** memory_search_skipped — 前端语义记忆搜索已被跳过 */
+export interface MemorySearchSkippedEvent {
+  type: 'memory_search_skipped'
   payload: Record<string, never>
 }
 
@@ -163,6 +172,7 @@ export type ServerEvent =
   | MemoryToolErrorEvent
   | MemoryDoneEvent
   | MemorySearchStartEvent
+  | MemorySearchSkippedEvent
   | MemorySearchDoneEvent
 
 // === WebSocket 客户端 → 服务端消息 ===
@@ -210,7 +220,15 @@ export interface UpdateAutoApproveMessage {
   }
 }
 
-export type ClientMessage = ChatMessage | CancelMessage | PingMessage | UserResponseMessage | UpdateAutoApproveMessage
+/** skip_memory_search — 用户跳过当前轮的语义记忆搜索 */
+export interface SkipMemorySearchMessage {
+  type: 'skip_memory_search'
+  payload: {
+    interaction_id: string
+  }
+}
+
+export type ClientMessage = ChatMessage | CancelMessage | PingMessage | UserResponseMessage | UpdateAutoApproveMessage | SkipMemorySearchMessage
 
 // === 前端 UI 状态类型 ===
 
@@ -268,7 +286,7 @@ export interface ChatTurn {
   /** 后端生成的 turn_id，用于关联后台记忆 consumer 的事件 */
   turnId?: string
   /** 当前轮的语义记忆搜索结果 */
-  memorySearch?: { status: 'searching' } | { status: 'done'; total: number; fresh: number }
+  memorySearch?: { status: 'searching'; skipInteractionId?: string } | { status: 'skipped' } | { status: 'done'; total: number; fresh: number }
 }
 
 // === 会话与 API 类型 ===

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -166,6 +166,8 @@ function handleToolAction(payload: { action: string; data?: unknown }) {
   if (payload.action === 'user_response') {
     const d = payload.data as { interactionId: string; response: string | string[] }
     sendUserResponse(d.interactionId, d.response)
+  } else if (payload.action === 'skip_memory_search') {
+    chatStore.skipMemorySearch(sessionId.value)
   } else if (payload.action === 'undo') {
     handleUndo()
   }


### PR DESCRIPTION
**问题**：记忆搜索期间 LLM 检索阻塞 Agent 图执行，无中断途径。

**方案**：在 `RetrieveMemoryNode` 中用 `interaction.register()` 注册 Future，`asyncio.wait(FIRST_COMPLETED)` 竞速异步检索 vs 跳过信号。

- 前端 spinner 旁新增「跳过」按钮
- 点击后 WS `skip_memory_search` → `interaction.resolve()` 唤醒 Future
- 检索任务被 `task.cancel()` 终止，节点返回空结果
- Agent 图继续执行，不注入记忆

不取消 `agent_task`，不影响回答生成。