### PR TITLE
feat: 回复期间消息排队注入与选择工具自定义输入

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -184,7 +184,13 @@ class RetrieveMemoryNode:
 
 
 class CallAgentNode:
-    """调用 LLM，返回新的 AIMessage。"""
+    """调用 LLM，返回新的 AIMessage。
+
+    每次 LLM 调用前检查会话挂起队列（工具间隙注入）：若用户在 Agent
+    输出期间发送了消息，将其以 HumanMessage 形式并入本次调用的上下文。
+    注意必须随返回值一起返回注入的消息——LangGraph 的 add_messages
+    仅持久化节点返回值，否则注入的提问会从 checkpoint 中消失。
+    """
 
     def __init__(self, system_message: SystemMessage, model_with_tools: Runnable[LanguageModelInput, AIMessage]) -> None:
         self._system_message = system_message
@@ -193,9 +199,26 @@ class CallAgentNode:
     async def __call__(
         self, state: MessagesState, config: RunnableConfig
     ) -> dict[str, Any]:
-        messages = [self._system_message] + state["messages"]
+        # 延迟导入避免循环依赖
+        from api.events import TurnSender  # noqa: PLC0415
+        from api.session.manager import session_manager  # noqa: PLC0415
+
+        injected: list[HumanMessage] = []
+        sid = config["configurable"]["thread_id"]
+        session = session_manager.get(sid)
+        if session is not None and session.has_pending():
+            pending = session.drain_pending()
+            # 文本-only 注入：含图片的排队消息走轮末 new_turn 路径的多模态处理
+            injected = [HumanMessage(content=p.text) for p in pending]
+            sender = TurnSender.from_session(session)
+            if sender:
+                await sender.pending_consumed(
+                    [p.pending_id for p in pending], mode="mid_turn"
+                )
+
+        messages = [self._system_message] + state["messages"] + injected
         response = await self._model_with_tools.ainvoke(messages, config)
-        return {"messages": [response]}
+        return {"messages": [*injected, response]}
 
 
 class LtmWriteNode:

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -264,7 +264,8 @@ class InjectPendingNode:
         sender = TurnSender.from_session(session)
         if sender:
             await sender.pending_consumed(
-                [p.pending_id for p in pending], mode="mid_turn"
+                [{"pending_id": p.pending_id, "text": p.text} for p in pending],
+                mode="mid_turn",
             )
         return {"messages": injected}
 
@@ -362,7 +363,9 @@ class CheckPendingNode:
 
         if sender:
             await sender.pending_consumed(
-                [p.pending_id for p in pending], mode="new_turn", text=text
+                [{"pending_id": p.pending_id, "text": p.text} for p in pending],
+                mode="new_turn",
+                text=text,
             )
 
         return {"messages": injected, "continue_turn": True}

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -3,18 +3,32 @@
 
 图结构：（箭头为固定/条件边）
 
-                                    ↓←  [tools] ←↑
-        START ──→ [retrieve_memory] ──→ [agent] ──→  [ltm_write] ──→ END
+                                      ┌─→ [tools] → [inject_pending] ─┐
+                                      │                               ↓
+        START → [retrieve_memory] → [agent] ◄─────────────────────────┘
+          ↑                           │
+          |                           └─→ [ltm_write] → [check_pending]
+          |                                                   │
+          └───────────────────  队列非空 → 注入 + 跳回 START  │ 队列为空 → END
+
 
 `retrieve_memory` 节点在每轮用户输入时，根据最新的 HumanMessage 语义检索长期记忆，
 将结果以 HumanMessage（【相关记忆】…）的形式追加到 `messages` 列表中，紧随触发它的
 用户消息之后。旧轮次的记忆消息随历史保留，不会主动清除。
+
+`inject_pending` 节点连接 `tools` → `agent`，是**工具间隙注入**的独立实现：
+每次工具执行完后，将 Agent 输出期间用户发送的排队消息以 HumanMessage 并入图状态，
+使下一次 LLM 思考能看到最新输入。队列为空时为空操作。
+
+`check_pending` 节点连接 `ltm_write` → END，是**轮末查询点**：一轮结束后检查会话
+挂起队列，队列非空则将排队消息合并注入并以 ``continue_turn`` 跳回 retrieve_memory
+（等价于跳回 START），在**图内**完成下一轮编排；队列为空时走向 END。
 """
 
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Literal
+from typing import Annotated, Any, Literal, TypedDict
 
 from api.agent import interaction
 from api.memory import LongTermMemory
@@ -27,7 +41,7 @@ from langgraph._internal._runnable import RunnableCallable
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.constants import END, START
 from langgraph.graph import StateGraph
-from langgraph.graph.message import MessagesState
+from langgraph.graph.message import add_messages
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt import ToolNode
 
@@ -35,10 +49,24 @@ from langgraph.prebuilt import ToolNode
 # 彩蛋：Sonetto 就是这个 CompiledStateGraph ✨
 Sonetto = CompiledStateGraph
 
+
+# ── 图状态 ──────────────────────────────────────────
+
+
+class AgentState(TypedDict, total=False):
+    """图状态：对话消息 + 轮末续跑标记。
+
+    ``continue_turn`` 由轮末查询点（check_pending）写入：为 ``True`` 时
+    条件边跳回 retrieve_memory，形成图内多轮循环（内置下一轮编排）。
+    """
+    messages: Annotated[list[BaseMessage], add_messages]
+    continue_turn: bool
+
+
 # ── 条件路由 ──────────────────────────────────────────
 
 
-def route_after_agent(state: MessagesState) -> Literal["tools", "ltm_write"]:
+def route_after_agent(state: AgentState) -> Literal["tools", "ltm_write"]:
     """模型节点后的条件边路由器。
 
     带 tool_calls → tools 节点执行工具；
@@ -48,6 +76,17 @@ def route_after_agent(state: MessagesState) -> Literal["tools", "ltm_write"]:
     if isinstance(last, AIMessage) and last.tool_calls:
         return "tools"
     return "ltm_write"
+
+
+def route_after_check(state: AgentState) -> str:
+    """轮末查询点后的条件边路由器。
+
+    队列仍有待注入消息 → 跳回 retrieve_memory（等价于跳回 START）；
+    否则 → END 结束本轮图执行。
+    """
+    if state.get("continue_turn"):
+        return "retrieve_memory"
+    return END
 
 
 # ── 图节点类 ──────────────────────────────────────────
@@ -69,7 +108,7 @@ class RetrieveMemoryNode:
         self._ltm = ltm
 
     async def __call__(
-        self, state: MessagesState, config: RunnableConfig
+        self, state: AgentState, config: RunnableConfig
     ) -> dict[str, list[BaseMessage]]:
         if self._ltm is None:
             return {}
@@ -184,41 +223,50 @@ class RetrieveMemoryNode:
 
 
 class CallAgentNode:
-    """调用 LLM，返回新的 AIMessage。
-
-    每次 LLM 调用前检查会话挂起队列（工具间隙注入）：若用户在 Agent
-    输出期间发送了消息，将其以 HumanMessage 形式并入本次调用的上下文。
-    注意必须随返回值一起返回注入的消息——LangGraph 的 add_messages
-    仅持久化节点返回值，否则注入的提问会从 checkpoint 中消失。
-    """
+    """调用 LLM，返回新的 AIMessage。"""
 
     def __init__(self, system_message: SystemMessage, model_with_tools: Runnable[LanguageModelInput, AIMessage]) -> None:
         self._system_message = system_message
         self._model_with_tools = model_with_tools
 
     async def __call__(
-        self, state: MessagesState, config: RunnableConfig
+        self, state: AgentState, config: RunnableConfig
     ) -> dict[str, Any]:
+        messages = [self._system_message] + state["messages"]
+        response = await self._model_with_tools.ainvoke(messages, config)
+        return {"messages": [response]}
+
+
+class InjectPendingNode:
+    """工具间隙注入节点 — 连接 tools → agent 之间。
+
+    每次工具执行完成后，将 Agent 输出期间用户发送的排队消息以
+    HumanMessage 形式并入图状态，使下一次 LLM 思考能看到最新输入。
+    通过返回值持久化（LangGraph 的 add_messages 仅持久化节点返回值）。
+
+    文本-only 注入：含图片的排队消息走轮末 new_turn 路径的多模态处理。
+    """
+
+    async def __call__(
+        self, state: AgentState, config: RunnableConfig
+    ) -> dict[str, list[HumanMessage]]:
         # 延迟导入避免循环依赖
         from api.events import TurnSender  # noqa: PLC0415
         from api.session.manager import session_manager  # noqa: PLC0415
 
-        injected: list[HumanMessage] = []
         sid = config["configurable"]["thread_id"]
         session = session_manager.get(sid)
-        if session is not None and session.has_pending():
-            pending = session.drain_pending()
-            # 文本-only 注入：含图片的排队消息走轮末 new_turn 路径的多模态处理
-            injected = [HumanMessage(content=p.text) for p in pending]
-            sender = TurnSender.from_session(session)
-            if sender:
-                await sender.pending_consumed(
-                    [p.pending_id for p in pending], mode="mid_turn"
-                )
+        if session is None or not session.has_pending():
+            return {}
 
-        messages = [self._system_message] + state["messages"] + injected
-        response = await self._model_with_tools.ainvoke(messages, config)
-        return {"messages": [*injected, response]}
+        pending = session.drain_pending()
+        injected = [HumanMessage(content=p.text) for p in pending]
+        sender = TurnSender.from_session(session)
+        if sender:
+            await sender.pending_consumed(
+                [p.pending_id for p in pending], mode="mid_turn"
+            )
+        return {"messages": injected}
 
 
 class LtmWriteNode:
@@ -232,7 +280,7 @@ class LtmWriteNode:
         self._ltm = ltm
 
     async def __call__(
-        self, state: MessagesState, config: RunnableConfig
+        self, state: AgentState, config: RunnableConfig
     ) -> dict[str, Any]:
         if self._ltm is None:
             return {}
@@ -253,6 +301,73 @@ class LtmWriteNode:
         return {}
 
 
+class CheckPendingNode:
+    """轮末查询点 — 连接 ltm_write → END。
+
+    一轮结束后，在**节点内按确定顺序**推送本轮收尾事件，再检查会话挂起队列：
+    1. ``answer`` — 本轮最终回答（最后一条 AIMessage 内容）；
+    2. ``done``   — 收尾当前轮（含逐轮上下文用量）；
+    3. 队列非空 → 合并排队消息注入图状态，发 ``pending_consumed(new_turn)``，
+       ``continue_turn`` 置 True 让条件边跳回 retrieve_memory（等价于跳回 START）；
+       队列为空 → 走向 END。
+
+    逐轮消息计数（user+assistant 一对）也在此完成，取代外层编排层的计数。
+    文本-only 注入：含图片的排队消息暂以文本并入，多模态路径待后续增强。
+    """
+
+    async def __call__(
+        self, state: AgentState, config: RunnableConfig
+    ) -> dict[str, Any]:
+        # 延迟导入避免循环依赖（turn.py 顶层导入 build_agent）
+        from api.agent.context_usage import estimate_context_usage_from_session  # noqa: PLC0415
+        from api.agent.turn import merge_pending_batch  # noqa: PLC0415
+        from api.events import TurnSender  # noqa: PLC0415
+        from api.session.manager import session_manager  # noqa: PLC0415
+
+        sid = config["configurable"]["thread_id"]
+        session = session_manager.get(sid)
+        if session is None:
+            return {"continue_turn": False}
+
+        sender = TurnSender.from_session(session)
+
+        # ── 本轮 answer + 消息计数 ──
+        last_ai = next(
+            (m for m in reversed(state["messages"]) if isinstance(m, AIMessage)),
+            None,
+        )
+        if last_ai is not None:
+            if sender:
+                await sender.answer(str(last_ai.content))
+            if getattr(last_ai, "content", None):
+                session.increment_messages()  # user+assistant 一对
+
+        # ── 本轮 done（含上下文用量） ──
+        if sender:
+            usage = await estimate_context_usage_from_session(
+                session,
+                config["configurable"].get("system_prompt", ""),
+                max_tokens=config["configurable"].get("max_tokens", 256_000),
+                model_name=config["configurable"].get("model_name", ""),
+            )
+            await sender.done(config["configurable"].get("turn_id", ""), usage)
+
+        if not session.has_pending():
+            return {"continue_turn": False}
+
+        # ── 队列非空：合并注入 + 跳回 START ──
+        pending = session.drain_pending()
+        text, _, _ = merge_pending_batch(pending)
+        injected = [HumanMessage(content=text)]
+
+        if sender:
+            await sender.pending_consumed(
+                [p.pending_id for p in pending], mode="new_turn", text=text
+            )
+
+        return {"messages": injected, "continue_turn": True}
+
+
 # ── 图构建 ──────────────────────────────────────────────
 
 
@@ -269,8 +384,13 @@ def build_agent(
 
     ::
 
-                                    ↓←  [tools] ←↑
-        START ──→ [retrieve_memory] ──→ [agent] ──→  [ltm_write] ──→ END
+                                      ┌─→ [tools] → [inject_pending] ─┐
+                                      │                               ↓
+        START → [retrieve_memory] → [agent] ◄─────────────────────────┘
+          ↑                           │
+          |                           └─→ [ltm_write] → [check_pending]
+          |                                                   │
+          └───────────────────  队列非空 → 注入 + 跳回 START  │ 队列为空 → END
 
 
 
@@ -278,7 +398,10 @@ def build_agent(
       以 HumanMessage 追加到 messages
     - **agent** — 调用 LLM，可绑定工具
     - **tools** — 执行工具调用
+    - **inject_pending** — 工具间隙注入：tools 之后将排队消息并入图状态（空操作时为空）
     - **ltm_write** — 将本轮对话投递到 LTM 后台队列以更新 memory.yaml
+    - **check_pending** — 轮末查询点：队列非空时合并注入并跳回 retrieve_memory
+      （图内完成下一轮编排），为空时走向 END
 
     .. rubric:: config.configurable 支持的键
 
@@ -310,11 +433,13 @@ def build_agent(
         SystemMessage(content=system_prompt),
         model.bind_tools(tools),
     )
+    inject_pending_node = InjectPendingNode()
     ltm_write_node = LtmWriteNode(ltm)
+    check_pending_node = CheckPendingNode()
     tool_node = ToolNode(tools)
 
     # ── 组装图 ────────────────────────────────────────
-    builder = StateGraph(MessagesState)
+    builder = StateGraph(AgentState)
 
     builder.add_node(
         "retrieve_memory",
@@ -324,16 +449,26 @@ def build_agent(
         "agent",
         RunnableCallable(None, agent_node, name="agent", trace=False),
     )
+    builder.add_node(
+        "inject_pending",
+        RunnableCallable(None, inject_pending_node, name="inject_pending", trace=False),
+    )
     builder.add_node("tools", tool_node)
     builder.add_node(
         "ltm_write",
         RunnableCallable(None, ltm_write_node, name="ltm_write", trace=False),
     )
+    builder.add_node(
+        "check_pending",
+        RunnableCallable(None, check_pending_node, name="check_pending", trace=False),
+    )
 
     builder.add_edge(START, "retrieve_memory")
     builder.add_edge("retrieve_memory", "agent")
     builder.add_conditional_edges("agent", route_after_agent)
-    builder.add_edge("tools", "agent")
-    builder.add_edge("ltm_write", END)
+    builder.add_edge("tools", "inject_pending")
+    builder.add_edge("inject_pending", "agent")
+    builder.add_edge("ltm_write", "check_pending")
+    builder.add_conditional_edges("check_pending", route_after_check)
 
     return builder.compile(checkpointer=checkpointer)

--- a/agent/graph.py
+++ b/agent/graph.py
@@ -251,6 +251,7 @@ class InjectPendingNode:
         self, state: AgentState, config: RunnableConfig
     ) -> dict[str, list[HumanMessage]]:
         # 延迟导入避免循环依赖
+        from api.agent.turn import now_timestamp  # noqa: PLC0415
         from api.events import TurnSender  # noqa: PLC0415
         from api.session.manager import session_manager  # noqa: PLC0415
 
@@ -260,7 +261,8 @@ class InjectPendingNode:
             return {}
 
         pending = session.drain_pending()
-        injected = [HumanMessage(content=p.text) for p in pending]
+        # 时间戳随注入进入 LLM 上下文；pending_consumed 推送干净文本供前端展示
+        injected = [HumanMessage(content=p.text + now_timestamp()) for p in pending]
         sender = TurnSender.from_session(session)
         if sender:
             await sender.pending_consumed(
@@ -321,7 +323,7 @@ class CheckPendingNode:
     ) -> dict[str, Any]:
         # 延迟导入避免循环依赖（turn.py 顶层导入 build_agent）
         from api.agent.context_usage import estimate_context_usage_from_session  # noqa: PLC0415
-        from api.agent.turn import merge_pending_batch  # noqa: PLC0415
+        from api.agent.turn import merge_pending_batch, now_timestamp  # noqa: PLC0415
         from api.events import TurnSender  # noqa: PLC0415
         from api.session.manager import session_manager  # noqa: PLC0415
 
@@ -359,7 +361,8 @@ class CheckPendingNode:
         # ── 队列非空：合并注入 + 跳回 START ──
         pending = session.drain_pending()
         text, _, _ = merge_pending_batch(pending)
-        injected = [HumanMessage(content=text)]
+        # 时间戳随注入进入 LLM 上下文；pending_consumed 推送干净合并文本供前端展示
+        injected = [HumanMessage(content=text + now_timestamp())]
 
         if sender:
             await sender.pending_consumed(

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import re
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -18,7 +19,7 @@ from api.providers.manager import get_manager
 from api.providers.default_llm import get_default_llm
 from api.providers.manager import ProviderManager
 from api.session.const_store import save_const_session, serialize_messages
-from api.session.manager import SessionState
+from api.session.manager import PendingMessage, SessionState
 from api.memory.short_term import get_checkpointer
 from langchain_core.language_models.chat_models import BaseChatModel
 from tools.base import format_error
@@ -96,6 +97,34 @@ def _get_final_answer(event: dict[str, Any]) -> str:
         else str(raw_final_answer)
     )
     return final_answer
+
+
+# ── 排队消息合并 ──────────────────────────────────────────
+
+# 消息尾部时间标记（与前端 web/src/utils/references.ts TIME_SUFFIX_RE 一致）
+_TIME_SUFFIX_RE = re.compile(r"（\d{4}-\d{2}-\d{2} \w{3} \d{2}:\d{2}）$")
+
+
+def _strip_time_suffix(text: str) -> str:
+    """剥离消息尾部的时间标记（如「（2026-07-29 Wed 14:30）」。"""
+    return _TIME_SUFFIX_RE.sub("", text).rstrip()
+
+
+def merge_pending_batch(batch: list[PendingMessage]) -> tuple[str, bool, list[str] | None]:
+    """将一批排队消息合并为单个 Agent 输入（合并处理语义）。
+
+    返回 ``(text, image_recognition, image_refs)``：
+    - 文本以空行（\\n\\n）连接，逐条剥离时间后缀；
+    - 图片标记 OR 累积——任一消息启用图像认知则整体启用，路径全部合并。
+    """
+    text = "\n\n".join(_strip_time_suffix(p.text) for p in batch)
+    images = [
+        img
+        for p in batch
+        if p.image_recognition
+        for img in (p.image_refs or [])
+    ]
+    return text, bool(images), images or None
 
 
 async def _inject_cancel_tool_messages(session: SessionState, config: dict[str, Any], sender: TurnSender) -> None:
@@ -361,7 +390,8 @@ async def _execute_agent_turn(
         await sender.error("AGENT_ERROR", str(e))
 
     finally:
-        session.clear_active_task()
+        # 注意：clear_active_task 已移至 run_agent_turn 的 drain 循环外层 finally，
+        # 否则合并轮之间 has_active_task() 为 False，破坏侧栏/constify 的忙碌判定。
         context_usage = await estimate_context_usage_from_session(
             session, ctx.system_prompt,
             max_tokens=llm_conf.max_tokens, model_name=llm_conf.model_name,
@@ -424,14 +454,24 @@ async def run_agent_turn(
     model_name: str | None = None,
     image_recognition: bool = False,
     image_refs: list[str] | None = None,
+    queued_pending_ids: list[str] | None = None,
 ):
-    """编排一轮 Agent 对话。
+    """编排 Agent 对话（drain 循环）。
 
-    分 4 个阶段执行：
-      1. _resolve_llm        — 解析 LLM 与上下文窗口配置
+    首个轮次处理传入的 user_message；此后每轮结束后自动排空会话挂起队列
+    （Agent 输出期间用户发送的消息），合并为一个新轮次并继续执行，直到
+    队列为空。取消（CANCELLED）会终止循环，不再启动后续合并轮。
+
+    每个轮次分 4 个阶段执行：
+      1. _resolve_llm        — 解析 LLM 与上下文窗口配置（每轮重解析，排队消息可指定不同模型）
       2. _build_turn_context  — 构建 Agent 图、多模态输入与运行配置
       3. _execute_agent_turn  — 流式执行、异常/取消处理
       4. _postprocess_turn    — 消息计数、记忆持久化、Const 保存、Sub-agent 回调
+
+    Args:
+        queued_pending_ids: 随首个轮次一起被消费的排队消息 ID 列表（前端已创建
+            currentTurn 的普通发送为 ``[]`` 或 ``None``；后端自动启动的合并轮非空，
+            此时会先发 ``pending_consumed(new_turn)`` 让前端创建 currentTurn）。
     """
     # Sub-agent 跳过长期记忆的读（retrieve_memory）和写（ltm_write）
     if session.is_subagent:
@@ -442,38 +482,75 @@ async def run_agent_turn(
     app_state = ws.app.state
     sender = TurnSender.from_context()
 
-    # 1. 解析 LLM 配置
-    llm_conf: _LlmConfig = _resolve_llm(
-        provider_manager=get_manager(),
-        default_llm=get_default_llm(),
-        provider_id=provider_id,
-        model_name=model_name,
-    )
-    if llm_conf is None:
-        await sender.error(
-            "NO_LLM",
-            "No LLM provider configured. Add one in Model Settings first.",
-        )
-        return
+    current_task = asyncio.current_task()
+    first_iteration = True
+    try:
+        while True:
+            if first_iteration:
+                first_iteration = False
+                text = user_message
+                cur_private = private_mode
+                cur_skip = skip_recall
+                cur_provider = provider_id
+                cur_model = model_name
+                cur_img_recog = image_recognition
+                cur_img_refs = image_refs
+                pending_ids = queued_pending_ids or []
+            else:
+                batch = session.drain_pending()
+                if not batch:
+                    break
+                text, cur_img_recog, cur_img_refs = merge_pending_batch(batch)
+                last = batch[-1]
+                cur_private = last.private
+                cur_skip = last.skip_recall
+                cur_provider = last.provider_id
+                cur_model = last.model_name
+                pending_ids = [p.pending_id for p in batch]
+                interaction.set_session_auto_approve(session.session_id, last.auto_approve)
 
-    # 2. 构建执行上下文
-    ctx: _TurnContext = await _build_turn_context(
-        tools=app_state.tool_manager.get_all(multimodal=llm_conf.multimodal),
-        session=session,
-        llm_conf=llm_conf,
-        user_message=user_message,
-        image_recognition=image_recognition,
-        image_refs=image_refs,
-        ltm=app_state.ltm,
-        private_mode=private_mode,
-        skip_recall=skip_recall,
-    )
+            # 1. 解析 LLM 配置
+            llm_conf: _LlmConfig = _resolve_llm(
+                provider_manager=get_manager(),
+                default_llm=get_default_llm(),
+                provider_id=cur_provider,
+                model_name=cur_model,
+            )
+            if llm_conf is None:
+                await sender.error(
+                    "NO_LLM",
+                    "No LLM provider configured. Add one in Model Settings first.",
+                )
+                break
 
-    # 3. 执行轮次
-    result: _TurnResult = await _execute_agent_turn(ctx, sender, session, llm_conf)
+            # 通知前端合并轮启动：必须在流式事件前发送，让前端先创建 currentTurn
+            if pending_ids:
+                await sender.pending_consumed(
+                    pending_ids=pending_ids, mode="new_turn", text=text
+                )
 
-    # 4. 后处理（LTM 持久化已在图内 ltm_write 节点中完成）
-    await _postprocess_turn(
-        session=session,
-        result=result,
-    )
+            # 2. 构建执行上下文
+            ctx: _TurnContext = await _build_turn_context(
+                tools=app_state.tool_manager.get_all(multimodal=llm_conf.multimodal),
+                session=session,
+                llm_conf=llm_conf,
+                user_message=text,
+                image_recognition=cur_img_recog,
+                image_refs=cur_img_refs,
+                ltm=app_state.ltm,
+                private_mode=cur_private,
+                skip_recall=cur_skip,
+            )
+
+            # 3. 执行轮次
+            result: _TurnResult = await _execute_agent_turn(ctx, sender, session, llm_conf)
+            if result.error == "CANCELLED":
+                break
+
+            # 4. 后处理（LTM 持久化已在图内 ltm_write 节点中完成）
+            await _postprocess_turn(
+                session=session,
+                result=result,
+            )
+    finally:
+        session.clear_active_task(current_task)

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -219,7 +219,11 @@ async def _stream_turn(
     model_name: str | None = None,
     max_tokens: int = 256_000,
 ) -> str:
-    """流式执行 Agent 图，返回最终回答。"""
+    """流式执行 Agent 图，返回最终回答。
+
+    图的逐轮 answer/done/pending_consumed 事件由轮末查询点（check_pending）
+    在节点内按序推送（顺序确定）；此处仅消费流式事件、提取最终回答。
+    """
     final_answer = ""
     async for event in graph.astream_events(inputs, config=config, version="v2"):
         if event.get("event") == "on_chain_end" and event.get("name") == "agent":
@@ -338,6 +342,10 @@ async def _build_turn_context(
             "private_mode": private_mode,
             "skip_recall": skip_recall,
             "turn_id": turn_id,
+            # 供图内 check_pending 计算逐轮上下文用量（answer/done 事件）
+            "system_prompt": system_prompt,
+            "model_name": llm_conf.model_name,
+            "max_tokens": llm_conf.max_tokens,
         },
         "callbacks": [ws_callback],
         "recursion_limit": 120,
@@ -370,11 +378,11 @@ async def _execute_agent_turn(
         )
         await sender.context_usage(initial_usage)
 
+        # 逐轮 answer/done 已由图内 check_pending 节点按序推送
         final_answer = await _stream_turn(
             ctx.agent, ctx.inputs, ctx.config, sender, session,
             ctx.system_prompt, model_name=llm_conf.model_name, max_tokens=llm_conf.max_tokens,
         )
-        await sender.answer(final_answer)
 
     except asyncio.CancelledError:
         interaction.cancel_all()
@@ -390,8 +398,8 @@ async def _execute_agent_turn(
         await sender.error("AGENT_ERROR", str(e))
 
     finally:
-        # 注意：clear_active_task 已移至 run_agent_turn 的 drain 循环外层 finally，
-        # 否则合并轮之间 has_active_task() 为 False，破坏侧栏/constify 的忙碌判定。
+        # 兜底 done：若最后一轮未达 ltm_write（异常/取消中断）则补发收尾；
+        # 正常完成时前端 currentTurn 已为 null，重复 done 被前端静默忽略。
         context_usage = await estimate_context_usage_from_session(
             session, ctx.system_prompt,
             max_tokens=llm_conf.max_tokens, model_name=llm_conf.model_name,
@@ -408,13 +416,11 @@ async def _postprocess_turn(
     session: SessionState,
     result: _TurnResult,
 ) -> None:
-    """后处理：消息计数、Const 会话保存、Sub-agent 结果回调。
+    """后处理：Const 会话保存、Sub-agent 结果回调。
 
-    LTM 持久化已移至图内 ``ltm_write`` 节点，不再在此处调用。
+    LTM 持久化已移至图内 ``ltm_write`` 节点；
+    消息计数已移至图内 ``check_pending`` 节点（逐轮计数）。
     """
-    if result.final_answer:
-        session.increment_messages()
-
     # Const 会话持久化
     if result.final_answer and session.is_const:
         try:
@@ -456,22 +462,21 @@ async def run_agent_turn(
     image_refs: list[str] | None = None,
     queued_pending_ids: list[str] | None = None,
 ):
-    """编排 Agent 对话（drain 循环）。
+    """编排一次 Agent 图执行（单次调用）。
 
-    首个轮次处理传入的 user_message；此后每轮结束后自动排空会话挂起队列
-    （Agent 输出期间用户发送的消息），合并为一个新轮次并继续执行，直到
-    队列为空。取消（CANCELLED）会终止循环，不再启动后续合并轮。
+    排队消息的注入与下一轮编排全部在图内完成——工具间隙注入（inject_pending）
+    与轮末查询点（check_pending）负责队列消费，本函数不再循环驱动。
 
-    每个轮次分 4 个阶段执行：
-      1. _resolve_llm        — 解析 LLM 与上下文窗口配置（每轮重解析，排队消息可指定不同模型）
+    分 4 个阶段执行：
+      1. _resolve_llm        — 解析 LLM 与上下文窗口配置
       2. _build_turn_context  — 构建 Agent 图、多模态输入与运行配置
-      3. _execute_agent_turn  — 流式执行、异常/取消处理
-      4. _postprocess_turn    — 消息计数、记忆持久化、Const 保存、Sub-agent 回调
+      3. _execute_agent_turn  — 流式执行、逐轮 answer/done、异常/取消处理
+      4. _postprocess_turn    — Const 保存、Sub-agent 回调
 
     Args:
-        queued_pending_ids: 随首个轮次一起被消费的排队消息 ID 列表（前端已创建
-            currentTurn 的普通发送为 ``[]`` 或 ``None``；后端自动启动的合并轮非空，
-            此时会先发 ``pending_consumed(new_turn)`` 让前端创建 currentTurn）。
+        queued_pending_ids: 随首轮一起被消费的排队消息 ID 列表（_start_turn_from_ws
+            合并残留队列时非空），此时需先发 ``pending_consumed(new_turn)`` 让前端
+            创建 currentTurn。普通发送为 ``None``。
     """
     # Sub-agent 跳过长期记忆的读（retrieve_memory）和写（ltm_write）
     if session.is_subagent:
@@ -483,74 +488,47 @@ async def run_agent_turn(
     sender = TurnSender.from_context()
 
     current_task = asyncio.current_task()
-    first_iteration = True
     try:
-        while True:
-            if first_iteration:
-                first_iteration = False
-                text = user_message
-                cur_private = private_mode
-                cur_skip = skip_recall
-                cur_provider = provider_id
-                cur_model = model_name
-                cur_img_recog = image_recognition
-                cur_img_refs = image_refs
-                pending_ids = queued_pending_ids or []
-            else:
-                batch = session.drain_pending()
-                if not batch:
-                    break
-                text, cur_img_recog, cur_img_refs = merge_pending_batch(batch)
-                last = batch[-1]
-                cur_private = last.private
-                cur_skip = last.skip_recall
-                cur_provider = last.provider_id
-                cur_model = last.model_name
-                pending_ids = [p.pending_id for p in batch]
-                interaction.set_session_auto_approve(session.session_id, last.auto_approve)
-
-            # 1. 解析 LLM 配置
-            llm_conf: _LlmConfig = _resolve_llm(
-                provider_manager=get_manager(),
-                default_llm=get_default_llm(),
-                provider_id=cur_provider,
-                model_name=cur_model,
+        # 1. 解析 LLM 配置
+        llm_conf: _LlmConfig = _resolve_llm(
+            provider_manager=get_manager(),
+            default_llm=get_default_llm(),
+            provider_id=provider_id,
+            model_name=model_name,
+        )
+        if llm_conf is None:
+            await sender.error(
+                "NO_LLM",
+                "No LLM provider configured. Add one in Model Settings first.",
             )
-            if llm_conf is None:
-                await sender.error(
-                    "NO_LLM",
-                    "No LLM provider configured. Add one in Model Settings first.",
-                )
-                break
+            return
 
-            # 通知前端合并轮启动：必须在流式事件前发送，让前端先创建 currentTurn
-            if pending_ids:
-                await sender.pending_consumed(
-                    pending_ids=pending_ids, mode="new_turn", text=text
-                )
-
-            # 2. 构建执行上下文
-            ctx: _TurnContext = await _build_turn_context(
-                tools=app_state.tool_manager.get_all(multimodal=llm_conf.multimodal),
-                session=session,
-                llm_conf=llm_conf,
-                user_message=text,
-                image_recognition=cur_img_recog,
-                image_refs=cur_img_refs,
-                ltm=app_state.ltm,
-                private_mode=cur_private,
-                skip_recall=cur_skip,
+        # 首轮若合并了排队消息（_start_turn_from_ws 传入），通知前端创建 currentTurn
+        if queued_pending_ids:
+            await sender.pending_consumed(
+                pending_ids=queued_pending_ids, mode="new_turn", text=user_message
             )
 
-            # 3. 执行轮次
-            result: _TurnResult = await _execute_agent_turn(ctx, sender, session, llm_conf)
-            if result.error == "CANCELLED":
-                break
+        # 2. 构建执行上下文
+        ctx: _TurnContext = await _build_turn_context(
+            tools=app_state.tool_manager.get_all(multimodal=llm_conf.multimodal),
+            session=session,
+            llm_conf=llm_conf,
+            user_message=user_message,
+            image_recognition=image_recognition,
+            image_refs=image_refs,
+            ltm=app_state.ltm,
+            private_mode=private_mode,
+            skip_recall=skip_recall,
+        )
 
-            # 4. 后处理（LTM 持久化已在图内 ltm_write 节点中完成）
-            await _postprocess_turn(
-                session=session,
-                result=result,
-            )
+        # 3. 执行（图内完成全部轮次）
+        result: _TurnResult = await _execute_agent_turn(ctx, sender, session, llm_conf)
+
+        # 4. 后处理（消息计数已在图内 check_pending 节点完成）
+        await _postprocess_turn(
+            session=session,
+            result=result,
+        )
     finally:
         session.clear_active_task(current_task)

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import datetime
 import re
 import uuid
 from dataclasses import dataclass
@@ -110,11 +111,22 @@ def _strip_time_suffix(text: str) -> str:
     return _TIME_SUFFIX_RE.sub("", text).rstrip()
 
 
+def now_timestamp() -> str:
+    """当前服务器时间尾缀，如（2026-07-31 Fri 10:24）。
+
+    时间戳是必须进入 LLM 上下文的输入数据（Agent 需感知当前时间以回答
+    时间相关查询），由后端统一生成，前端不再拼接。
+    """
+    now = datetime.datetime.now()
+    wd = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][now.weekday()]
+    return f"（{now.year:04d}-{now.month:02d}-{now.day:02d} {wd} {now.hour:02d}:{now.minute:02d}）"
+
+
 def merge_pending_batch(batch: list[PendingMessage]) -> tuple[str, bool, list[str] | None]:
     """将一批排队消息合并为单个 Agent 输入（合并处理语义）。
 
     返回 ``(text, image_recognition, image_refs)``：
-    - 文本以空行（\\n\\n）连接，逐条剥离时间后缀；
+    - 文本以空行（\\n\\n）连接（消息文本已不含时间戳，时间戳由注入侧统一追加）；
     - 图片标记 OR 累积——任一消息启用图像认知则整体启用，路径全部合并。
     """
     text = "\n\n".join(_strip_time_suffix(p.text) for p in batch)
@@ -315,8 +327,11 @@ async def _build_turn_context(
     session.set_graph(agent)
 
     # 多模态输入
+    # 时间戳由后端统一追加并进入 LLM 上下文（Agent 需感知当前时间）
+    timestamped = user_message + now_timestamp()
+
     if image_recognition and image_refs:
-        content_parts: list[dict] = [{"type": "text", "text": user_message}]
+        content_parts: list[dict] = [{"type": "text", "text": timestamped}]
         for img_path in image_refs:
             if not img_path.strip():
                 continue
@@ -332,7 +347,7 @@ async def _build_turn_context(
                 continue
         inputs = {"messages": [HumanMessage(content=content_parts)]}
     else:
-        inputs = {"messages": [HumanMessage(content=user_message)]}
+        inputs = {"messages": [HumanMessage(content=timestamped)]}
 
     turn_id = uuid.uuid4().hex
 

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -460,7 +460,7 @@ async def run_agent_turn(
     model_name: str | None = None,
     image_recognition: bool = False,
     image_refs: list[str] | None = None,
-    queued_pending_ids: list[str] | None = None,
+    queued_pending: list[PendingMessage] | None = None,
 ):
     """编排一次 Agent 图执行（单次调用）。
 
@@ -474,7 +474,7 @@ async def run_agent_turn(
       4. _postprocess_turn    — Const 保存、Sub-agent 回调
 
     Args:
-        queued_pending_ids: 随首轮一起被消费的排队消息 ID 列表（_start_turn_from_ws
+        queued_pending: 随首轮一起被消费的排队消息列表（_start_turn_from_ws
             合并残留队列时非空），此时需先发 ``pending_consumed(new_turn)`` 让前端
             创建 currentTurn。普通发送为 ``None``。
     """
@@ -504,9 +504,11 @@ async def run_agent_turn(
             return
 
         # 首轮若合并了排队消息（_start_turn_from_ws 传入），通知前端创建 currentTurn
-        if queued_pending_ids:
+        if queued_pending:
             await sender.pending_consumed(
-                pending_ids=queued_pending_ids, mode="new_turn", text=user_message
+                [{"pending_id": p.pending_id, "text": p.text} for p in queued_pending],
+                mode="new_turn",
+                text=user_message,
             )
 
         # 2. 构建执行上下文

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -6,7 +6,7 @@ news:
     date: "2026-08-01"
     tags: ["交互", "消息", "排队"]
     version: ""
-    pr_number:
+    pr_number: 275
   - id: "memory-upstream-chain-refactor"
     title: "记忆上行链路重构"
     description: "记忆检索架构全面升级：LLM 语义检索与 BM25 机械检索拆分为对称双引擎，统一接口契约，检索更精准；生命周期方法按规范标准化；后台消费者独立为模块，依赖与导出清理。架构更稳健，维护更高效。"

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -1,4 +1,12 @@
 news:
+  - id: "pending-message-custom-input"
+    title: "排队消息与自定义输入"
+    description: "Sonetto 忙碌时仍可继续发送消息，消息自动排队并在合适时机注入对话，不再错过任何输入；单选/多选询问支持「告诉Sonetto别的意见」，可自由补充自定义想法。交互更顺畅，等待期间输入无缝衔接。"
+    type: "feat"
+    date: "2026-08-01"
+    tags: ["交互", "消息", "排队"]
+    version: ""
+    pr_number:
   - id: "memory-upstream-chain-refactor"
     title: "记忆上行链路重构"
     description: "记忆检索架构全面升级：LLM 语义检索与 BM25 机械检索拆分为对称双引擎，统一接口契约，检索更精准；生命周期方法按规范标准化；后台消费者独立为模块，依赖与导出清理。架构更稳健，维护更高效。"

--- a/api/events/turn.py
+++ b/api/events/turn.py
@@ -45,16 +45,18 @@ class TurnSender(WsTransport):
 
     async def pending_consumed(
         self,
-        pending_ids: list[str],
+        pending: list[dict],
         mode: str,
         text: str | None = None,
     ) -> None:
         """推送排队消息已被注入上下文。
 
-        mode='mid_turn'：注入到当前轮次（前端标记气泡「已注入」）；
-        mode='new_turn'：合并为新的一轮（前端创建 currentTurn，text 为用户消息）。
+        ``pending`` 为 ``[{"pending_id": str, "text": str}, ...]``，按消费顺序排列。
+
+        mode='mid_turn'：注入到当前轮次（前端在工具之间渲染为用户气泡）；
+        mode='new_turn'：合并为新的一轮（前端创建 currentTurn，text 为合并文本）。
         """
-        payload: dict = {"pending_ids": pending_ids, "mode": mode}
+        payload: dict = {"pending": pending, "mode": mode}
         if text is not None:
             payload["text"] = text
         await self._send("pending_consumed", payload)

--- a/api/events/turn.py
+++ b/api/events/turn.py
@@ -34,3 +34,35 @@ class TurnSender(WsTransport):
     async def done(self, turn_id: str, context_usage: dict) -> None:
         """推送轮次结束事件（含 turn_id 用于关联记忆）。"""
         await self._send("done", {"turn_id": turn_id, "context_usage": context_usage})
+
+    async def message_queued(self, pending_id: str, text: str, position: int) -> None:
+        """推送消息入队确认（Agent 输出期间发送的消息被挂起）。"""
+        await self._send("message_queued", {
+            "pending_id": pending_id,
+            "text": text,
+            "position": position,
+        })
+
+    async def pending_consumed(
+        self,
+        pending_ids: list[str],
+        mode: str,
+        text: str | None = None,
+    ) -> None:
+        """推送排队消息已被注入上下文。
+
+        mode='mid_turn'：注入到当前轮次（前端标记气泡「已注入」）；
+        mode='new_turn'：合并为新的一轮（前端创建 currentTurn，text 为用户消息）。
+        """
+        payload: dict = {"pending_ids": pending_ids, "mode": mode}
+        if text is not None:
+            payload["text"] = text
+        await self._send("pending_consumed", payload)
+
+    async def pending_sync(self, pending: list[dict]) -> None:
+        """推送当前挂起队列状态（WebSocket 重连时重建前端排队气泡）。"""
+        await self._send("pending_sync", {"pending": pending})
+
+    async def pending_cancelled(self, pending_ids: list[str]) -> None:
+        """推送排队消息被取消（用户点击停止，队列被丢弃）。"""
+        await self._send("pending_cancelled", {"pending_ids": pending_ids})

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -71,7 +71,7 @@ def _start_turn_from_ws(
             model_name=last.model_name,
             image_recognition=img_recog,
             image_refs=img_refs,
-            queued_pending_ids=[p.pending_id for p in queued],
+            queued_pending=queued,
         )
     )
     session.set_active_task(agent_task)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from collections.abc import Awaitable, Callable
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -11,11 +12,11 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from api.agent import interaction
 from api.agent.context_usage import estimate_context_usage_from_session
 from agent import build_system_prompt
-from api.agent.turn import run_agent_turn
-from api.events import ChatSender, MemorySender
+from api.agent.turn import merge_pending_batch, run_agent_turn
+from api.events import ChatSender, MemorySender, TurnSender
 from api.providers import FALLBACK_CTX
 from api.providers.manager import get_manager
-from api.session.manager import SessionState, session_manager
+from api.session.manager import PendingMessage, SessionState, session_manager
 from api.utils.logger import get_logger
 
 router = APIRouter()
@@ -34,6 +35,44 @@ def _resume_sub_agent(ws: WebSocket, session: SessionState) -> asyncio.Task | No
     interaction.current_ws.set(ws)
     agent_task = asyncio.create_task(
         run_agent_turn(session, task, private_mode=False)
+    )
+    session.set_active_task(agent_task)
+    return agent_task
+
+
+def _start_turn_from_ws(
+    ws: WebSocket,
+    session_id: str,
+    session: SessionState,
+    incoming: PendingMessage | None = None,
+) -> asyncio.Task | None:
+    """排空会话挂起队列（可选合并 incoming）并启动 Agent 轮次。
+
+    排队消息与 incoming 按 FIFO 合并为单个输入（合并处理语义）。
+    返回新建的 asyncio.Task；无可用消息时返回 None。
+
+    ``queued_pending_ids`` 仅包含原排队消息（不含 incoming）——incoming
+    是前端通过 send() 发来的，前端已创建 currentTurn，无需 pending_consumed。
+    """
+    queued = session.drain_pending()
+    batch = queued + ([incoming] if incoming else [])
+    if not batch:
+        return None
+    text, img_recog, img_refs = merge_pending_batch(batch)
+    last = batch[-1]
+    interaction.set_session_auto_approve(session_id, last.auto_approve)
+    agent_task = asyncio.create_task(
+        run_agent_turn(
+            session,
+            text,
+            private_mode=last.private,
+            skip_recall=last.skip_recall,
+            provider_id=last.provider_id,
+            model_name=last.model_name,
+            image_recognition=img_recog,
+            image_refs=img_refs,
+            queued_pending_ids=[p.pending_id for p in queued],
+        )
     )
     session.set_active_task(agent_task)
     return agent_task
@@ -74,35 +113,45 @@ async def _handle_chat(
     msg: dict,
 
 ) -> asyncio.Task | None:
-    """处理聊天消息：创建 Agent 轮次。"""
-    if agent_task is not None and not agent_task.done():
-        return agent_task  # 已有 Agent 运行中，忽略本次输入
-
+    """处理聊天消息：Agent 空闲时创建轮次，忙碌时挂起到队列等待注入。"""
     payload = msg["payload"]
     user_message = payload["message"].strip()
     if not user_message:
         return agent_task
 
-    auto_approve = payload.get("auto_approve", False)
-    skip_recall = payload.get("skip_recall", False)
+    incoming = PendingMessage(
+        pending_id=payload.get("client_msg_id") or uuid.uuid4().hex,
+        text=user_message,
+        private=payload.get("private", False),
+        skip_recall=payload.get("skip_recall", False),
+        auto_approve=payload.get("auto_approve", False),
+        provider_id=payload.get("provider_id"),
+        model_name=payload.get("model_name"),
+        image_recognition=payload.get("image_recognition", False),
+        image_refs=payload.get("image_refs") or [],
+    )
+
+    # 子 Agent 会话不参与排队（其流程由 _resume_sub_agent 驱动），保持原丢弃行为
+    if session.is_subagent:
+        return agent_task
+
     interaction.current_ws.set(ws)  # 供工具函数/Sender.from_context() 通过 WebSocket 推送交互
     interaction.current_session_id.set(session_id)
-    interaction.set_session_auto_approve(session_id, auto_approve)
 
-    agent_task = asyncio.create_task(
-        run_agent_turn(
-            session,
-            user_message,
-            private_mode=payload.get("private", False),
-            provider_id=payload.get("provider_id"),
-            model_name=payload.get("model_name"),
-            image_recognition=payload.get("image_recognition", False),
-            image_refs=payload.get("image_refs", []),
-            skip_recall=skip_recall,
+    # 已有 Agent 运行中：消息挂起到队列，等待注入
+    if agent_task is not None and not agent_task.done():
+        session.enqueue_pending(incoming)
+        sender = TurnSender.from_ws(ws)
+        await sender.message_queued(
+            incoming.pending_id, incoming.text, session.pending_count()
         )
-    )
-    session.set_active_task(agent_task)
-    return agent_task
+        # 重查：message_queued 等待期间旧任务可能已收尾退出，此时需补启动 drain
+        if agent_task.done():
+            return _start_turn_from_ws(ws, session_id, session)
+        return agent_task
+
+    # 空闲：合并残留队列 + 本条消息启动轮次
+    return _start_turn_from_ws(ws, session_id, session, incoming)
 
 
 @ws_event_handler("user_response")
@@ -132,10 +181,48 @@ async def _handle_cancel(
     msg: dict,
 
 ) -> asyncio.Task | None:
-    """处理取消请求。"""
+    """处理取消请求：停止当前轮并丢弃全部排队消息（停止 = 全部放弃）。"""
     if agent_task is not None and not agent_task.done():
         agent_task.cancel()
+    cleared = session.clear_pending()
+    if cleared:
+        sender = TurnSender.from_ws(ws)
+        await sender.pending_cancelled([p.pending_id for p in cleared])
     return None
+
+
+@ws_event_handler("remove_pending")
+async def _handle_remove_pending(
+    ws: WebSocket,
+    session_id: str,
+    session: SessionState,
+    agent_task: asyncio.Task | None,
+    msg: dict,
+
+) -> asyncio.Task | None:
+    """移除一条排队消息（不取消正在运行的 Agent）。"""
+    pending_id = msg.get("payload", {}).get("pending_id", "")
+    if pending_id and session.remove_pending(pending_id):
+        sender = TurnSender.from_ws(ws)
+        await sender.pending_cancelled([pending_id])
+    return agent_task
+
+
+@ws_event_handler("clear_pending")
+async def _handle_clear_pending(
+    ws: WebSocket,
+    session_id: str,
+    session: SessionState,
+    agent_task: asyncio.Task | None,
+    msg: dict,
+
+) -> asyncio.Task | None:
+    """清空全部排队消息（不取消正在运行的 Agent）。"""
+    cleared = session.clear_pending()
+    if cleared:
+        sender = TurnSender.from_ws(ws)
+        await sender.pending_cancelled([p.pending_id for p in cleared])
+    return agent_task
 
 
 @ws_event_handler("update_auto_approve")
@@ -203,6 +290,18 @@ async def websocket_chat(ws: WebSocket, session_id: str) -> None:
 
     # ── 断线重连时恢复 sub-agent ──────────────────────────
     agent_task = _resume_sub_agent(ws, session)
+
+    # ── 重连时同步挂起队列（Agent 输出期间发送的消息）──────
+    pending = session.peek_pending()
+    if pending:
+        turn_sender = TurnSender.from_ws(ws)
+        await turn_sender.pending_sync([
+            {"pending_id": p.pending_id, "text": p.text, "position": i + 1}
+            for i, p in enumerate(pending)
+        ])
+        # 队列有内容且无任务运行（如断连前被取消）时自动续跑
+        if not session.has_active_task():
+            agent_task = _start_turn_from_ws(ws, session_id, session)
 
     # ── 消息主循环（字典派发） ─────────────────────────────
     try:

--- a/api/session/manager.py
+++ b/api/session/manager.py
@@ -3,6 +3,7 @@
 import asyncio
 import time
 import uuid
+from collections import deque
 from dataclasses import dataclass, field
 
 from fastapi import WebSocket
@@ -54,9 +55,14 @@ class AgentRuntime:
         """设置当前 Agent 运行任务。"""
         self._active_task = task
 
-    def clear_active_task(self) -> None:
-        """清除 Agent 任务引用。"""
-        self._active_task = None
+    def clear_active_task(self, task: asyncio.Task | None = None) -> None:
+        """清除 Agent 任务引用。
+
+        传入 task 时仅当引用指向该任务才清除（owner 守卫），防止
+        取消后立刻重发导致旧任务的 finally 覆盖新任务引用。
+        """
+        if task is None or self._active_task is task:
+            self._active_task = None
 
     def cancel_active_task(self) -> None:
         """取消正在运行的 Agent 任务（如存在且未完成）。"""
@@ -133,6 +139,73 @@ class ConstSession:
         self.const_name = ""
 
 
+# ── 子数据类：排队消息 ──────────────────────────────────────────
+
+@dataclass
+class PendingMessage:
+    """一条被挂起的用户消息（Agent 输出期间发送，等待注入）。
+
+    Attributes:
+        pending_id:   唯一标识（前端 client_msg_id 或后端生成的 UUID）。
+        text:         消息文本（含时间戳/引用标记，与正常 chat payload 一致）。
+        private:      私密模式标记。
+        skip_recall:  失忆模式标记。
+        auto_approve: 自动批准模式。
+        provider_id:  指定 LLM 提供商（可选）。
+        model_name:   指定模型（可选）。
+        image_recognition: 是否图像认知模式。
+        image_refs:   图像文件绝对路径列表。
+        created_at:   入队时间。
+    """
+    pending_id: str
+    text: str
+    private: bool = False
+    skip_recall: bool = False
+    auto_approve: bool = False
+    provider_id: str | None = None
+    model_name: str | None = None
+    image_recognition: bool = False
+    image_refs: list[str] | None = None
+    created_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class PendingQueue:
+    """Agent 输出期间挂起的用户消息队列（FIFO）。"""
+    _items: deque[PendingMessage] = field(default_factory=deque, repr=False)
+
+    def enqueue(self, pm: PendingMessage) -> int:
+        """入队，返回 1-based 位置（供前端展示排队序号）。"""
+        self._items.append(pm)
+        return len(self._items)
+
+    def has_pending(self) -> bool:
+        """是否有待处理消息。"""
+        return bool(self._items)
+
+    def peek_all(self) -> list[PendingMessage]:
+        """非破坏性查看全部待处理消息（供重连同步）。"""
+        return list(self._items)
+
+    def drain_all(self) -> list[PendingMessage]:
+        """取走并清空全部待处理消息。"""
+        items = list(self._items)
+        self._items.clear()
+        return items
+
+    def remove(self, pending_id: str) -> bool:
+        """按 pending_id 移除一条消息，返回是否成功。"""
+        for i, pm in enumerate(self._items):
+            if pm.pending_id == pending_id:
+                del self._items[i]
+                return True
+        return False
+
+    def clear(self) -> list[PendingMessage]:
+        """清空队列并返回被移除的消息（语义与 drain_all 相同）。"""
+        return self.drain_all()
+
+
 # ── 会话状态（组合层）───────────────────────────────────────────
 
 class SessionState:
@@ -160,6 +233,7 @@ class SessionState:
             is_const=kwargs.pop("is_const", False),
             const_name=kwargs.pop("const_name", ""),
         )
+        self.pending_queue = PendingQueue()
         if kwargs:
             raise TypeError(
                 f"__init__() got unexpected keyword arguments: {kwargs}"
@@ -238,9 +312,9 @@ class SessionState:
         """设置当前 Agent 运行任务。"""
         self.runtime.set_active_task(task)
 
-    def clear_active_task(self) -> None:
-        """清除 Agent 任务引用。"""
-        self.runtime.clear_active_task()
+    def clear_active_task(self, task: asyncio.Task | None = None) -> None:
+        """清除 Agent 任务引用（带 owner 守卫，见 AgentRuntime.clear_active_task）。"""
+        self.runtime.clear_active_task(task)
 
     def cancel_active_task(self) -> None:
         """取消正在运行的 Agent 任务（如存在且未完成）。"""
@@ -281,6 +355,36 @@ class SessionState:
     def unconstify(self) -> None:
         """取消固定标记。"""
         self.const.unconstify()
+
+    # ── 排队消息转发 ────────────────────────────────────────
+
+    def enqueue_pending(self, pm: PendingMessage) -> int:
+        """入队一条挂起消息，返回 1-based 位置。"""
+        return self.pending_queue.enqueue(pm)
+
+    def has_pending(self) -> bool:
+        """是否有挂起消息待注入。"""
+        return self.pending_queue.has_pending()
+
+    def pending_count(self) -> int:
+        """挂起消息数量。"""
+        return len(self.pending_queue._items)
+
+    def peek_pending(self) -> list[PendingMessage]:
+        """非破坏性查看全部挂起消息。"""
+        return self.pending_queue.peek_all()
+
+    def drain_pending(self) -> list[PendingMessage]:
+        """取走并清空全部挂起消息。"""
+        return self.pending_queue.drain_all()
+
+    def remove_pending(self, pending_id: str) -> bool:
+        """按 pending_id 移除一条挂起消息，返回是否成功。"""
+        return self.pending_queue.remove(pending_id)
+
+    def clear_pending(self) -> list[PendingMessage]:
+        """清空挂起队列并返回被移除的消息。"""
+        return self.pending_queue.clear()
 
     def increment_messages(self, by: int = 2) -> None:
         """增加消息计数（默认 user+assistant 一对）。"""

--- a/tests/test_pending_queue.py
+++ b/tests/test_pending_queue.py
@@ -7,8 +7,9 @@
 - _handle_chat 忙碌路径入队 + ack + 重查补启动
 - _handle_cancel 清队列 + pending_cancelled
 - _start_turn_from_ws FIFO 合并
-- CallAgentNode 工具间隙注入（LangGraph 状态持久化）
-- run_agent_turn drain 循环（正常续跑 / CANCELLED 中断）
+- InjectPendingNode 独立节点注入（LangGraph 状态持久化 + 工具循环接线）
+- CheckPendingNode 图内多轮循环（队列非空注入并跳回 retrieve_memory）
+- run_agent_turn 单次图调用（不再 drain 队列）
 """
 
 import asyncio
@@ -17,12 +18,20 @@ from types import SimpleNamespace
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableLambda
+from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.constants import END, START
 from langgraph.graph import StateGraph
-from langgraph.graph.message import MessagesState
+from langgraph.prebuilt import ToolNode
 
-from agent.graph import CallAgentNode
+from agent.graph import (
+    AgentState,
+    CallAgentNode,
+    CheckPendingNode,
+    InjectPendingNode,
+    route_after_agent,
+    route_after_check,
+)
 from api.agent import interaction
 from api.agent.turn import (
     _TurnResult,
@@ -359,24 +368,18 @@ async def test_start_turn_from_ws_no_messages_returns_none(monkeypatch):
     assert _start_turn_from_ws(ws, "test-sid", s) is None
 
 
-# ── CallAgentNode 工具间隙注入 ────────────────────────────────
+# ── InjectPendingNode 工具间隙注入 ─────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_call_agent_node_mid_turn_injection():
-    captured: list = []
+async def test_inject_pending_node_drains_and_persists():
+    """独立节点单元测试：排空队列、持久化注入消息、发 mid_turn 事件。"""
+    node = InjectPendingNode()
 
-    def fake_model(messages: list) -> AIMessage:
-        captured.append(messages)
-        return AIMessage(content="response")
-
-    model_with_tools = RunnableLambda(fake_model)
-    node = CallAgentNode(SystemMessage(content="sys"), model_with_tools)
-
-    builder = StateGraph(MessagesState)
-    builder.add_node("agent", node)
-    builder.add_edge(START, "agent")
-    builder.add_edge("agent", END)
+    builder = StateGraph(AgentState)
+    builder.add_node("inject", node)
+    builder.add_edge(START, "inject")
+    builder.add_edge("inject", END)
     graph = builder.compile(checkpointer=MemorySaver())
 
     sid = "inject-sid"
@@ -390,22 +393,96 @@ async def test_call_agent_node_mid_turn_injection():
             {"messages": [HumanMessage(content="第一个问题")]}, config
         )
 
-        # (a) 排队文本进入模型输入
-        assert any(
-            isinstance(m, HumanMessage) and m.content == "排队问题"
-            for m in captured[0]
-        )
-        assert isinstance(captured[0][-1], HumanMessage)  # 注入在响应之前
-
-        # (b) 节点返回值持久化到 checkpoint（含注入消息）
+        # 注入消息持久化到 checkpoint
         state = await graph.aget_state(config)
         contents = [m.content for m in state.values["messages"]]
         assert "第一个问题" in contents
         assert "排队问题" in contents
-        assert contents[-1] == "response"
 
-        # (c) 队列已排空，且前端收到 mid_turn 注入事件
+        # 队列已排空，且前端收到 mid_turn 注入事件
         assert session.has_pending() is False
+        events = _ws_events(session.ws, "pending_consumed")
+        assert len(events) == 1
+        assert events[0]["payload"]["pending_ids"] == ["p1"]
+        assert events[0]["payload"]["mode"] == "mid_turn"
+    finally:
+        session_manager._sessions.pop(sid, None)
+
+
+@pytest.mark.asyncio
+async def test_inject_pending_node_tool_gap_graph():
+    """完整工具循环接线：agent → tools → inject_pending → agent。
+
+    首次 agent 调用（无工具）不注入；工具执行后的 inject_pending 才注入。
+    """
+    @tool
+    def fake_tool(x: str) -> str:
+        """A fake tool for tests."""
+        return f"tool-result:{x}"
+
+    captured: list = []
+
+    def fake_model(messages: list) -> AIMessage:
+        captured.append(messages)
+        has_prior_tool_call = any(
+            isinstance(m, AIMessage) and getattr(m, "tool_calls", None)
+            for m in messages
+        )
+        if not has_prior_tool_call:
+            return AIMessage(content="", tool_calls=[
+                {"name": "fake_tool", "args": {"x": "hi"}, "id": "call_1"}
+            ])
+        return AIMessage(content="final answer")
+
+    model_with_tools = RunnableLambda(fake_model)
+
+    async def ltm_write_noop(state: AgentState, config) -> dict:
+        return {}
+
+    builder = StateGraph(AgentState)
+    builder.add_node("agent", CallAgentNode(SystemMessage(content="sys"), model_with_tools))
+    builder.add_node("tools", ToolNode([fake_tool]))
+    builder.add_node("inject_pending", InjectPendingNode())
+    builder.add_node("ltm_write", ltm_write_noop)
+    builder.add_edge(START, "agent")
+    builder.add_conditional_edges("agent", route_after_agent)
+    builder.add_edge("tools", "inject_pending")
+    builder.add_edge("inject_pending", "agent")
+    builder.add_edge("ltm_write", END)
+    graph = builder.compile(checkpointer=MemorySaver())
+
+    sid = "inject-tool-sid"
+    session = _make_session(sid)
+    session.ws = FakeWs()
+    session.enqueue_pending(PendingMessage(pending_id="p1", text="排队问题"))
+    session_manager.put(sid, session)
+    try:
+        config = {"configurable": {"thread_id": sid}}
+        await graph.ainvoke(
+            {"messages": [HumanMessage(content="第一个问题")]}, config
+        )
+
+        # 两次 agent 调用：首次不注入，工具间隙后注入
+        assert len(captured) == 2
+        assert not any(
+            isinstance(m, HumanMessage) and m.content == "排队问题"
+            for m in captured[0]
+        )
+        assert any(
+            isinstance(m, HumanMessage) and m.content == "排队问题"
+            for m in captured[1]
+        )
+        # 工具结果也进入第二次思考
+        assert any(getattr(m, "content", None) == "tool-result:hi" for m in captured[1])
+
+        # 队列已排空 + checkpoint 含注入消息 + 最终回答
+        assert session.has_pending() is False
+        state = await graph.aget_state(config)
+        contents = [m.content for m in state.values["messages"]]
+        assert "排队问题" in contents
+        assert contents[-1] == "final answer"
+
+        # 前端收到 mid_turn 注入事件
         events = _ws_events(session.ws, "pending_consumed")
         assert len(events) == 1
         assert events[0]["payload"]["pending_ids"] == ["p1"]
@@ -418,19 +495,20 @@ async def test_call_agent_node_mid_turn_injection():
 
 
 @pytest.mark.asyncio
-async def test_run_agent_turn_drains_queue(monkeypatch):
+async def test_run_agent_turn_single_invocation(monkeypatch):
+    """run_agent_turn 为单次图调用：不再 drain 队列（留给图内 check_pending）。"""
     s = _make_session()
     s.enqueue_pending(PendingMessage(pending_id="q1", text="排队"))
     ws = FakeWs()
     interaction.current_ws.set(ws)
 
-    built_texts: list[str] = []
+    exec_calls: list[int] = []
 
     async def fake_build(tools, session, llm_conf, **kw):
-        built_texts.append(kw["user_message"])
         return SimpleNamespace(user_message=kw["user_message"])
 
     async def fake_execute(ctx, sender, session, llm_conf):
+        exec_calls.append(1)
         return _TurnResult(final_answer="ok", error=None)
 
     class FakeLlmConf:
@@ -445,21 +523,15 @@ async def test_run_agent_turn_drains_queue(monkeypatch):
 
     await run_agent_turn(s, "hi")
 
-    assert built_texts == ["hi", "排队"]  # 首轮 + 队列合并轮
-    assert s.pending_count() == 0
-    assert s.has_active_task() is False
-
-    # 合并轮启动前发送 pending_consumed(new_turn)
-    events = _ws_events(ws, "pending_consumed")
-    assert len(events) == 1
-    assert events[0]["payload"]["mode"] == "new_turn"
-    assert events[0]["payload"]["text"] == "排队"
-    assert events[0]["payload"]["pending_ids"] == ["q1"]
+    assert len(exec_calls) == 1  # 单次调用
+    assert s.has_pending() is True  # 队列留给图内 check_pending 消费
+    assert s.has_active_task() is False  # finally 清空 active task
+    assert _ws_events(ws, "pending_consumed") == []  # run_agent_turn 不再消费队列
 
 
 @pytest.mark.asyncio
-async def test_run_agent_turn_cancelled_breaks_loop(monkeypatch):
-    """CANCELLED 后不得继续启动合并轮。"""
+async def test_run_agent_turn_cancelled_preserves_queue(monkeypatch):
+    """取消后 run_agent_turn 不再消费队列（队列保留）。"""
     s = _make_session()
     s.enqueue_pending(PendingMessage(pending_id="q1", text="排队"))
     ws = FakeWs()
@@ -486,6 +558,92 @@ async def test_run_agent_turn_cancelled_breaks_loop(monkeypatch):
 
     await run_agent_turn(s, "hi")
 
-    assert len(exec_calls) == 1  # 只执行首轮，未消费队列
+    assert len(exec_calls) == 1
     assert s.has_pending() is True  # 队列保留
-    assert s.has_active_task() is False  # finally 清空 active task
+    assert s.has_active_task() is False
+
+
+# ── CheckPendingNode 图内多轮循环 ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_pending_node_loops_turns():
+    """轮末查询点：队列非空时合并注入并跳回 retrieve_memory，形成图内多轮。"""
+    captured: list = []
+
+    def fake_model(messages: list) -> AIMessage:
+        captured.append(messages)
+        return AIMessage(content=f"answer-{len(captured)}")
+
+    model_with_tools = RunnableLambda(fake_model)
+
+    async def retrieve_noop(state: AgentState, config) -> dict:
+        return {}
+
+    async def ltm_noop(state: AgentState, config) -> dict:
+        return {}
+
+    async def tools_noop(state: AgentState, config) -> dict:
+        return {}
+
+    builder = StateGraph(AgentState)
+    builder.add_node("retrieve_memory", retrieve_noop)
+    builder.add_node("agent", CallAgentNode(SystemMessage(content="sys"), model_with_tools))
+    builder.add_node("tools", tools_noop)  # route_after_agent 编译期要求该目标存在
+    builder.add_node("ltm_write", ltm_noop)
+    builder.add_node("check_pending", CheckPendingNode())
+    builder.add_edge(START, "retrieve_memory")
+    builder.add_edge("retrieve_memory", "agent")
+    builder.add_conditional_edges("agent", route_after_agent)
+    builder.add_edge("ltm_write", "check_pending")
+    builder.add_conditional_edges("check_pending", route_after_check)
+    graph = builder.compile(checkpointer=MemorySaver())
+
+    sid = "check-sid"
+    session = _make_session(sid)
+    session.ws = FakeWs()
+    session.enqueue_pending(PendingMessage(pending_id="p1", text="排队问题"))
+    session_manager.put(sid, session)
+    try:
+        config = {"configurable": {"thread_id": sid}}
+        await graph.ainvoke(
+            {"messages": [HumanMessage(content="第一个问题")]}, config
+        )
+
+        # 两次 agent 调用：第二次（跳回后）输入包含排队消息
+        assert len(captured) == 2
+        assert any(
+            isinstance(m, HumanMessage) and m.content == "排队问题"
+            for m in captured[1]
+        )
+
+        # 队列已排空 + checkpoint 含两条用户消息与两个回答
+        assert session.has_pending() is False
+        state = await graph.aget_state(config)
+        contents = [m.content for m in state.values["messages"]]
+        assert "第一个问题" in contents
+        assert "排队问题" in contents
+        assert "answer-1" in contents
+        assert "answer-2" in contents
+
+        # 逐轮消息计数由 check_pending 完成
+        assert session.message_count == 4  # 2 轮 × (user+assistant)
+
+        # 前端收到 pending_consumed(new_turn)
+        events = _ws_events(session.ws, "pending_consumed")
+        assert len(events) == 1
+        assert events[0]["payload"]["mode"] == "new_turn"
+        assert events[0]["payload"]["pending_ids"] == ["p1"]
+        assert events[0]["payload"]["text"] == "排队问题"
+
+        # 逐轮事件由 check_pending 节点按确定顺序推送：
+        # answer1 → done1 → pending_consumed(new_turn) → answer2 → done2
+        answers = _ws_events(session.ws, "answer")
+        assert [a["payload"]["content"] for a in answers] == ["answer-1", "answer-2"]
+        dones = _ws_events(session.ws, "done")
+        assert len(dones) == 2
+        assert [e["type"] for e in session.ws.sent] == [
+            "answer", "done", "pending_consumed", "answer", "done",
+        ]
+    finally:
+        session_manager._sessions.pop(sid, None)

--- a/tests/test_pending_queue.py
+++ b/tests/test_pending_queue.py
@@ -393,13 +393,14 @@ async def test_inject_pending_node_drains_and_persists():
             {"messages": [HumanMessage(content="第一个问题")]}, config
         )
 
-        # 注入消息持久化到 checkpoint
+        # 注入消息持久化到 checkpoint，且时间戳由后端追加进入 LLM 上下文
         state = await graph.aget_state(config)
-        contents = [m.content for m in state.values["messages"]]
-        assert "第一个问题" in contents
-        assert "排队问题" in contents
+        contents = [str(m.content) for m in state.values["messages"]]
+        assert any("第一个问题" in c for c in contents)
+        assert any("排队问题" in c for c in contents)
+        assert any("（20" in c for c in contents)  # 后端时间戳尾缀
 
-        # 队列已排空，且前端收到 mid_turn 注入事件（含文本供前端渲染气泡）
+        # 队列已排空，且前端收到 mid_turn 注入事件（干净文本供前端渲染气泡）
         assert session.has_pending() is False
         events = _ws_events(session.ws, "pending_consumed")
         assert len(events) == 1
@@ -469,17 +470,18 @@ async def test_inject_pending_node_tool_gap_graph():
             for m in captured[0]
         )
         assert any(
-            isinstance(m, HumanMessage) and m.content == "排队问题"
+            isinstance(m, HumanMessage) and "排队问题" in m.content
             for m in captured[1]
         )
         # 工具结果也进入第二次思考
         assert any(getattr(m, "content", None) == "tool-result:hi" for m in captured[1])
 
-        # 队列已排空 + checkpoint 含注入消息 + 最终回答
+        # 队列已排空 + checkpoint 含注入消息（带后端时间戳）+ 最终回答
         assert session.has_pending() is False
         state = await graph.aget_state(config)
-        contents = [m.content for m in state.values["messages"]]
-        assert "排队问题" in contents
+        contents = [str(m.content) for m in state.values["messages"]]
+        assert any("排队问题" in c for c in contents)
+        assert any("（20" in c for c in contents)  # 后端时间戳尾缀
         assert contents[-1] == "final answer"
 
         # 前端收到 mid_turn 注入事件
@@ -610,19 +612,20 @@ async def test_check_pending_node_loops_turns():
             {"messages": [HumanMessage(content="第一个问题")]}, config
         )
 
-        # 两次 agent 调用：第二次（跳回后）输入包含排队消息
+        # 两次 agent 调用：第二次（跳回后）输入包含排队消息（含后端时间戳）
         assert len(captured) == 2
         assert any(
-            isinstance(m, HumanMessage) and m.content == "排队问题"
+            isinstance(m, HumanMessage) and "排队问题" in m.content
             for m in captured[1]
         )
 
-        # 队列已排空 + checkpoint 含两条用户消息与两个回答
+        # 队列已排空 + checkpoint 含两条用户消息（带时间戳）与两个回答
         assert session.has_pending() is False
         state = await graph.aget_state(config)
-        contents = [m.content for m in state.values["messages"]]
-        assert "第一个问题" in contents
-        assert "排队问题" in contents
+        contents = [str(m.content) for m in state.values["messages"]]
+        assert any("第一个问题" in c for c in contents)
+        assert any("排队问题" in c for c in contents)
+        assert any("（20" in c for c in contents)  # 后端时间戳尾缀
         assert "answer-1" in contents
         assert "answer-2" in contents
 

--- a/tests/test_pending_queue.py
+++ b/tests/test_pending_queue.py
@@ -356,7 +356,7 @@ async def test_start_turn_from_ws_merges_fifo(monkeypatch):
     assert len(captured) == 1
     text, kw = captured[0]
     assert text == "排队一\n\n排队二\n\n新消息"  # 旧在前，新在后
-    assert kw["queued_pending_ids"] == ["q1", "q2"]  # 仅排队消息（不含 incoming）
+    assert [p.pending_id for p in kw["queued_pending"]] == ["q1", "q2"]  # 仅排队消息（不含 incoming）
     assert s.pending_count() == 0
 
 
@@ -399,11 +399,11 @@ async def test_inject_pending_node_drains_and_persists():
         assert "第一个问题" in contents
         assert "排队问题" in contents
 
-        # 队列已排空，且前端收到 mid_turn 注入事件
+        # 队列已排空，且前端收到 mid_turn 注入事件（含文本供前端渲染气泡）
         assert session.has_pending() is False
         events = _ws_events(session.ws, "pending_consumed")
         assert len(events) == 1
-        assert events[0]["payload"]["pending_ids"] == ["p1"]
+        assert events[0]["payload"]["pending"] == [{"pending_id": "p1", "text": "排队问题"}]
         assert events[0]["payload"]["mode"] == "mid_turn"
     finally:
         session_manager._sessions.pop(sid, None)
@@ -485,7 +485,7 @@ async def test_inject_pending_node_tool_gap_graph():
         # 前端收到 mid_turn 注入事件
         events = _ws_events(session.ws, "pending_consumed")
         assert len(events) == 1
-        assert events[0]["payload"]["pending_ids"] == ["p1"]
+        assert [p["pending_id"] for p in events[0]["payload"]["pending"]] == ["p1"]
         assert events[0]["payload"]["mode"] == "mid_turn"
     finally:
         session_manager._sessions.pop(sid, None)
@@ -633,7 +633,7 @@ async def test_check_pending_node_loops_turns():
         events = _ws_events(session.ws, "pending_consumed")
         assert len(events) == 1
         assert events[0]["payload"]["mode"] == "new_turn"
-        assert events[0]["payload"]["pending_ids"] == ["p1"]
+        assert events[0]["payload"]["pending"] == [{"pending_id": "p1", "text": "排队问题"}]
         assert events[0]["payload"]["text"] == "排队问题"
 
         # 逐轮事件由 check_pending 节点按确定顺序推送：

--- a/tests/test_pending_queue.py
+++ b/tests/test_pending_queue.py
@@ -1,0 +1,491 @@
+"""测试：流式输出期间消息排队并注入 Agent 上下文。
+
+覆盖：
+- SessionState 挂起队列（入队/FIFO/清空/断连存活）
+- clear_active_task owner 守卫
+- merge_pending_batch 合并逻辑
+- _handle_chat 忙碌路径入队 + ack + 重查补启动
+- _handle_cancel 清队列 + pending_cancelled
+- _start_turn_from_ws FIFO 合并
+- CallAgentNode 工具间隙注入（LangGraph 状态持久化）
+- run_agent_turn drain 循环（正常续跑 / CANCELLED 中断）
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.runnables import RunnableLambda
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.constants import END, START
+from langgraph.graph import StateGraph
+from langgraph.graph.message import MessagesState
+
+from agent.graph import CallAgentNode
+from api.agent import interaction
+from api.agent.turn import (
+    _TurnResult,
+    merge_pending_batch,
+    run_agent_turn,
+)
+from api.routes.chat import (
+    _handle_cancel,
+    _handle_chat,
+    _handle_clear_pending,
+    _handle_remove_pending,
+    _start_turn_from_ws,
+)
+from api.session.manager import PendingMessage, SessionState, session_manager
+
+
+# ── 测试替身 ──────────────────────────────────────────────────
+
+
+class FakeToolManager:
+    """最小工具管理器，get_all 返回空列表。"""
+
+    def get_all(self, multimodal: bool = False) -> list:
+        return []
+
+
+class FakeAppState:
+    """最小 app.state，提供 run_agent_turn 所需的 tool_manager / ltm。"""
+
+    tool_manager = FakeToolManager()
+    ltm = None
+
+
+class FakeApp:
+    state = FakeAppState()
+
+
+class FakeWs:
+    """最小 WebSocket 替身，捕获 send_json 事件。"""
+
+    def __init__(self) -> None:
+        self.app = FakeApp()
+        self.sent: list[dict] = []
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+
+class CompletingWs(FakeWs):
+    """send_json 时完成给定的 Future（用于测试 ack 后重查补启动）。"""
+
+    def __init__(self, future: asyncio.Future) -> None:
+        super().__init__()
+        self._future = future
+
+    async def send_json(self, data: dict) -> None:
+        await asyncio.sleep(0)
+        if not self._future.done():
+            self._future.set_result(None)
+        self.sent.append(data)
+
+
+def _ws_events(ws: FakeWs, event_type: str) -> list[dict]:
+    return [e for e in ws.sent if e.get("type") == event_type]
+
+
+def _make_session(sid: str = "test-sid") -> SessionState:
+    return SessionState(session_id=sid)
+
+
+# ── SessionState 队列 ─────────────────────────────────────────
+
+
+def test_pending_queue_basic():
+    s = _make_session()
+    assert s.pending_count() == 0
+    assert s.has_pending() is False
+
+    pos1 = s.enqueue_pending(PendingMessage(pending_id="a", text="A"))
+    pos2 = s.enqueue_pending(PendingMessage(pending_id="b", text="B"))
+    assert pos1 == 1
+    assert pos2 == 2
+    assert s.pending_count() == 2
+    assert s.has_pending() is True
+
+    drained = s.drain_pending()
+    assert [p.pending_id for p in drained] == ["a", "b"]  # FIFO
+    assert s.has_pending() is False
+    assert s.drain_pending() == []  # drain 幂等
+
+
+def test_pending_queue_clear_and_peek():
+    s = _make_session()
+    s.enqueue_pending(PendingMessage(pending_id="c", text="C"))
+    # peek 非破坏
+    assert [p.pending_id for p in s.peek_pending()] == ["c"]
+    assert s.pending_count() == 1
+    cleared = s.clear_pending()
+    assert [p.pending_id for p in cleared] == ["c"]
+    assert s.pending_count() == 0
+
+
+def test_pending_queue_survives_disconnect():
+    """队列与 ws 解耦，断连/重连后仍在（服务端挂置语义）。"""
+    s = _make_session()
+    s.enqueue_pending(PendingMessage(pending_id="a", text="A"))
+    s.ws = None  # 模拟断连
+    assert s.has_pending() is True
+    assert [p.pending_id for p in s.peek_pending()] == ["a"]
+
+
+# ── clear_active_task owner 守卫 ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clear_active_task_owner_guard():
+    s = _make_session()
+    t1 = asyncio.Future()
+    t2 = asyncio.Future()
+    s.set_active_task(t1)
+    # task=None 时无条件清除（兼容旧调用点）
+    s.clear_active_task()
+    assert s.has_active_task() is False
+
+    s.set_active_task(t2)
+    s.clear_active_task(t1)  # 非 owner，不应清除
+    assert s.has_active_task() is True
+    s.clear_active_task(t2)  # owner，清除
+    assert s.has_active_task() is False
+
+
+# ── merge_pending_batch ───────────────────────────────────────
+
+
+def test_merge_pending_batch():
+    batch = [
+        PendingMessage(pending_id="1", text="你好（2026-07-30 Wed 14:30）"),
+        PendingMessage(pending_id="2", text="第二条"),
+        PendingMessage(
+            pending_id="3",
+            text="带图",
+            image_recognition=True,
+            image_refs=["/a.jpg", "/b.jpg"],
+        ),
+    ]
+    text, img_recog, img_refs = merge_pending_batch(batch)
+    assert text == "你好\n\n第二条\n\n带图"  # 空行分隔 + 时间后缀剥离
+    assert img_recog is True
+    assert img_refs == ["/a.jpg", "/b.jpg"]
+
+
+def test_merge_pending_batch_images_or():
+    batch = [
+        PendingMessage(pending_id="1", text="纯文本"),
+        PendingMessage(pending_id="2", text="有图", image_recognition=True, image_refs=["/x.png"]),
+    ]
+    text, img_recog, img_refs = merge_pending_batch(batch)
+    assert text == "纯文本\n\n有图"
+    assert img_recog is True  # OR 累积
+    assert img_refs == ["/x.png"]
+
+
+# ── _handle_chat 忙碌路径 ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_busy_enqueues():
+    s = _make_session()
+    ws = FakeWs()
+    agent_task: asyncio.Future = asyncio.Future()  # 永不完成 → 忙碌路径
+    msg = {"type": "chat", "payload": {"message": "hello", "client_msg_id": "cid-1"}}
+
+    ret = await _handle_chat(ws, "test-sid", s, agent_task, msg)
+    assert ret is agent_task  # 返回原任务
+    assert s.pending_count() == 1
+    pending = s.peek_pending()[0]
+    assert pending.pending_id == "cid-1"
+    assert pending.text == "hello"
+
+    acks = _ws_events(ws, "message_queued")
+    assert len(acks) == 1
+    assert acks[0]["payload"]["pending_id"] == "cid-1"
+    assert acks[0]["payload"]["position"] == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_busy_recheck_starts_drain(monkeypatch):
+    """ack 等待期间旧任务收尾 → 重查后补启动 drain。"""
+    agent_task: asyncio.Future = asyncio.Future()
+    s = _make_session()
+    ws = CompletingWs(agent_task)
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "api.routes.chat._start_turn_from_ws",
+        lambda w, sid, sess: (calls.append(sid), "NEW_TASK")[1],
+    )
+    msg = {"type": "chat", "payload": {"message": "hello"}}
+
+    ret = await _handle_chat(ws, "test-sid", s, agent_task, msg)
+    assert calls == ["test-sid"]  # 重查触发了补启动
+    assert ret == "NEW_TASK"
+    assert s.pending_count() == 1  # 队列仍保留，由 drain 消费
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_subagent_no_queue():
+    s = _make_session()
+    s.sub_agent.is_subagent = True
+    ws = FakeWs()
+    agent_task: asyncio.Future = asyncio.Future()
+    msg = {"type": "chat", "payload": {"message": "hello", "client_msg_id": "cid-1"}}
+
+    ret = await _handle_chat(ws, "test-sid", s, agent_task, msg)
+    assert ret is agent_task
+    assert s.pending_count() == 0  # 子 Agent 会话不排队
+
+
+# ── _handle_cancel ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_cancel_clears_queue():
+    s = _make_session()
+    s.enqueue_pending(PendingMessage(pending_id="p1", text="A"))
+    s.enqueue_pending(PendingMessage(pending_id="p2", text="B"))
+    ws = FakeWs()
+
+    ret = await _handle_cancel(ws, "test-sid", s, None, {})
+    assert ret is None
+    assert s.pending_count() == 0
+
+    events = _ws_events(ws, "pending_cancelled")
+    assert len(events) == 1
+    assert events[0]["payload"]["pending_ids"] == ["p1", "p2"]
+
+
+@pytest.mark.asyncio
+async def test_handle_cancel_empty_queue_no_event():
+    s = _make_session()
+    ws = FakeWs()
+    await _handle_cancel(ws, "test-sid", s, None, {})
+    assert _ws_events(ws, "pending_cancelled") == []
+
+
+# ── _handle_remove_pending / _handle_clear_pending ───────────
+
+
+@pytest.mark.asyncio
+async def test_handle_remove_pending():
+    s = _make_session()
+    s.enqueue_pending(PendingMessage(pending_id="p1", text="A"))
+    s.enqueue_pending(PendingMessage(pending_id="p2", text="B"))
+    ws = FakeWs()
+
+    ret = await _handle_remove_pending(ws, "test-sid", s, None, {
+        "type": "remove_pending", "payload": {"pending_id": "p1"}
+    })
+    assert ret is None
+    assert [p.pending_id for p in s.peek_pending()] == ["p2"]
+
+    events = _ws_events(ws, "pending_cancelled")
+    assert len(events) == 1
+    assert events[0]["payload"]["pending_ids"] == ["p1"]
+
+
+@pytest.mark.asyncio
+async def test_handle_remove_pending_unknown_id_no_event():
+    s = _make_session()
+    s.enqueue_pending(PendingMessage(pending_id="p1", text="A"))
+    ws = FakeWs()
+
+    await _handle_remove_pending(ws, "test-sid", s, None, {
+        "type": "remove_pending", "payload": {"pending_id": "nope"}
+    })
+    assert s.pending_count() == 1
+    assert _ws_events(ws, "pending_cancelled") == []
+
+
+@pytest.mark.asyncio
+async def test_handle_clear_pending():
+    s = _make_session()
+    s.enqueue_pending(PendingMessage(pending_id="p1", text="A"))
+    s.enqueue_pending(PendingMessage(pending_id="p2", text="B"))
+    ws = FakeWs()
+
+    ret = await _handle_clear_pending(ws, "test-sid", s, None, {
+        "type": "clear_pending", "payload": {}
+    })
+    assert ret is None
+    assert s.pending_count() == 0
+
+    events = _ws_events(ws, "pending_cancelled")
+    assert len(events) == 1
+    assert events[0]["payload"]["pending_ids"] == ["p1", "p2"]
+
+
+# ── _start_turn_from_ws FIFO 合并 ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_turn_from_ws_merges_fifo(monkeypatch):
+    s = _make_session()
+    s.enqueue_pending(PendingMessage(pending_id="q1", text="排队一"))
+    s.enqueue_pending(PendingMessage(pending_id="q2", text="排队二"))
+
+    captured: list[tuple[str, dict]] = []
+
+    async def fake_run(session, text, **kw):
+        captured.append((text, kw))
+        return None
+
+    monkeypatch.setattr("api.routes.chat.run_agent_turn", fake_run)
+    ws = FakeWs()
+    interaction.current_ws.set(ws)
+
+    task = _start_turn_from_ws(
+        ws, "test-sid", s, PendingMessage(pending_id="c1", text="新消息")
+    )
+    assert task is not None
+    await asyncio.wait_for(task, timeout=1)
+    assert len(captured) == 1
+    text, kw = captured[0]
+    assert text == "排队一\n\n排队二\n\n新消息"  # 旧在前，新在后
+    assert kw["queued_pending_ids"] == ["q1", "q2"]  # 仅排队消息（不含 incoming）
+    assert s.pending_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_start_turn_from_ws_no_messages_returns_none(monkeypatch):
+    s = _make_session()
+    monkeypatch.setattr("api.routes.chat.run_agent_turn", lambda *a, **k: None)
+    ws = FakeWs()
+    assert _start_turn_from_ws(ws, "test-sid", s) is None
+
+
+# ── CallAgentNode 工具间隙注入 ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_call_agent_node_mid_turn_injection():
+    captured: list = []
+
+    def fake_model(messages: list) -> AIMessage:
+        captured.append(messages)
+        return AIMessage(content="response")
+
+    model_with_tools = RunnableLambda(fake_model)
+    node = CallAgentNode(SystemMessage(content="sys"), model_with_tools)
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("agent", node)
+    builder.add_edge(START, "agent")
+    builder.add_edge("agent", END)
+    graph = builder.compile(checkpointer=MemorySaver())
+
+    sid = "inject-sid"
+    session = _make_session(sid)
+    session.ws = FakeWs()
+    session.enqueue_pending(PendingMessage(pending_id="p1", text="排队问题"))
+    session_manager.put(sid, session)
+    try:
+        config = {"configurable": {"thread_id": sid}}
+        await graph.ainvoke(
+            {"messages": [HumanMessage(content="第一个问题")]}, config
+        )
+
+        # (a) 排队文本进入模型输入
+        assert any(
+            isinstance(m, HumanMessage) and m.content == "排队问题"
+            for m in captured[0]
+        )
+        assert isinstance(captured[0][-1], HumanMessage)  # 注入在响应之前
+
+        # (b) 节点返回值持久化到 checkpoint（含注入消息）
+        state = await graph.aget_state(config)
+        contents = [m.content for m in state.values["messages"]]
+        assert "第一个问题" in contents
+        assert "排队问题" in contents
+        assert contents[-1] == "response"
+
+        # (c) 队列已排空，且前端收到 mid_turn 注入事件
+        assert session.has_pending() is False
+        events = _ws_events(session.ws, "pending_consumed")
+        assert len(events) == 1
+        assert events[0]["payload"]["pending_ids"] == ["p1"]
+        assert events[0]["payload"]["mode"] == "mid_turn"
+    finally:
+        session_manager._sessions.pop(sid, None)
+
+
+# ── run_agent_turn drain 循环 ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_agent_turn_drains_queue(monkeypatch):
+    s = _make_session()
+    s.enqueue_pending(PendingMessage(pending_id="q1", text="排队"))
+    ws = FakeWs()
+    interaction.current_ws.set(ws)
+
+    built_texts: list[str] = []
+
+    async def fake_build(tools, session, llm_conf, **kw):
+        built_texts.append(kw["user_message"])
+        return SimpleNamespace(user_message=kw["user_message"])
+
+    async def fake_execute(ctx, sender, session, llm_conf):
+        return _TurnResult(final_answer="ok", error=None)
+
+    class FakeLlmConf:
+        llm = None
+        model_name = "test"
+        max_tokens = 100
+        multimodal = False
+
+    monkeypatch.setattr("api.agent.turn._resolve_llm", lambda **kw: FakeLlmConf())
+    monkeypatch.setattr("api.agent.turn._build_turn_context", fake_build)
+    monkeypatch.setattr("api.agent.turn._execute_agent_turn", fake_execute)
+
+    await run_agent_turn(s, "hi")
+
+    assert built_texts == ["hi", "排队"]  # 首轮 + 队列合并轮
+    assert s.pending_count() == 0
+    assert s.has_active_task() is False
+
+    # 合并轮启动前发送 pending_consumed(new_turn)
+    events = _ws_events(ws, "pending_consumed")
+    assert len(events) == 1
+    assert events[0]["payload"]["mode"] == "new_turn"
+    assert events[0]["payload"]["text"] == "排队"
+    assert events[0]["payload"]["pending_ids"] == ["q1"]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_turn_cancelled_breaks_loop(monkeypatch):
+    """CANCELLED 后不得继续启动合并轮。"""
+    s = _make_session()
+    s.enqueue_pending(PendingMessage(pending_id="q1", text="排队"))
+    ws = FakeWs()
+    interaction.current_ws.set(ws)
+
+    exec_calls: list[int] = []
+
+    async def fake_build(tools, session, llm_conf, **kw):
+        return SimpleNamespace(user_message=kw["user_message"])
+
+    async def fake_execute(ctx, sender, session, llm_conf):
+        exec_calls.append(1)
+        return _TurnResult(final_answer="", error="CANCELLED")
+
+    class FakeLlmConf:
+        llm = None
+        model_name = "test"
+        max_tokens = 100
+        multimodal = False
+
+    monkeypatch.setattr("api.agent.turn._resolve_llm", lambda **kw: FakeLlmConf())
+    monkeypatch.setattr("api.agent.turn._build_turn_context", fake_build)
+    monkeypatch.setattr("api.agent.turn._execute_agent_turn", fake_execute)
+
+    await run_agent_turn(s, "hi")
+
+    assert len(exec_calls) == 1  # 只执行首轮，未消费队列
+    assert s.has_pending() is True  # 队列保留
+    assert s.has_active_task() is False  # finally 清空 active task

--- a/tools/interaction/tool_multi_choice.py
+++ b/tools/interaction/tool_multi_choice.py
@@ -8,6 +8,9 @@ from api.agent import interaction
 from api.events import ToolSender
 from tools.base import ToolBase, format_error, format_success
 
+# 前端自定义文本输入的前缀标记，用于区分「选中的选项」和「用户手写输入」
+_CUSTOM_PREFIX = "__custom__::"
+
 
 class AskUserMultiChoiceInput(BaseModel):
     get_doc: bool = Field(default=False, description="设为 true 以获取使用说明")
@@ -54,9 +57,28 @@ class AskUserMultiChoiceTool(ToolBase):
 
         try:
             answer = await future
-            return format_success(
-                {"question": question, "answer": answer, "options": options}
-            )
+            data: dict = {
+                "question": question,
+                "answer": answer,
+                "options": options,
+            }
+            # 检测用户是否通过「告诉Sonetto别的意见」提交了自定义文本
+            if isinstance(answer, list):
+                cleaned: list[str] = []
+                has_custom = False
+                for item in answer:
+                    if isinstance(item, str) and item.startswith(_CUSTOM_PREFIX):
+                        cleaned.append(item[len(_CUSTOM_PREFIX):])
+                        has_custom = True
+                    else:
+                        cleaned.append(item)
+                data["answer"] = cleaned
+                if has_custom:
+                    data["is_custom_text"] = True
+            elif isinstance(answer, str) and answer.startswith(_CUSTOM_PREFIX):
+                data["answer"] = answer[len(_CUSTOM_PREFIX):]
+                data["is_custom_text"] = True
+            return format_success(data)
         except asyncio.CancelledError:
             return format_error("用户取消了回复")
         finally:

--- a/tools/interaction/tool_single_choice.py
+++ b/tools/interaction/tool_single_choice.py
@@ -8,6 +8,9 @@ from api.agent import interaction
 from api.events import ToolSender
 from tools.base import ToolBase, format_error, format_success
 
+# 前端自定义文本输入的前缀标记，用于区分「选中的选项」和「用户手写输入」
+_CUSTOM_PREFIX = "__custom__::"
+
 
 class AskUserSingleChoiceInput(BaseModel):
     get_doc: bool = Field(default=False, description="设为 true 以获取使用说明")
@@ -54,9 +57,34 @@ class AskUserSingleChoiceTool(ToolBase):
 
         try:
             answer = await future
-            return format_success(
-                {"question": question, "answer": answer, "options": options}
-            )
+            data: dict = {
+                "question": question,
+                "answer": answer,
+                "options": options,
+            }
+            # 检测用户是否通过「告诉Sonetto别的意见」提交了自定义文本
+            if isinstance(answer, list):
+                cleaned: list[str] = []
+                has_custom = False
+                has_option = False
+                for item in answer:
+                    if isinstance(item, str) and item.startswith(_CUSTOM_PREFIX):
+                        cleaned.append(item[len(_CUSTOM_PREFIX):])
+                        has_custom = True
+                    else:
+                        cleaned.append(item)
+                        if item in options:
+                            has_option = True
+                data["answer"] = cleaned
+                data["selected_option"] = has_option
+                if has_custom:
+                    data["is_custom_text"] = True
+            elif isinstance(answer, str) and answer.startswith(_CUSTOM_PREFIX):
+                data["answer"] = answer[len(_CUSTOM_PREFIX):]
+                data["is_custom_text"] = True
+            else:
+                data["selected_option"] = answer in options if isinstance(answer, str) else False
+            return format_success(data)
         except asyncio.CancelledError:
             return format_error("用户取消了回复")
         finally:

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -19,6 +19,34 @@
       :class="{ 'is-resizing': isResizing }"
       :style="containerStyle"
     >
+      <!-- 排队消息区域：Agent 输出期间发送的消息在此排队等待注入 -->
+      <div v-if="pendingMessages.length > 0" class="queue-tray">
+        <div class="queue-tray-header">
+          <span class="queue-pulse"></span>
+          <span>排队消息</span>
+          <span class="queue-tray-count">{{ pendingMessages.length }}</span>
+          <button class="queue-tray-clear" @click="emit('clearPending')">清空</button>
+        </div>
+        <div class="queue-tray-list">
+          <div
+            v-for="p in pendingMessages"
+            :key="p.id"
+            class="queue-item"
+            :class="p.status"
+          >
+            <span class="queue-item-text">{{ displayPendingText(p.text) }}</span>
+            <span class="queue-item-badge" :class="p.status">
+              {{ p.status === 'injected' ? '已注入' : '排队中' }}
+            </span>
+            <button
+              v-if="p.status === 'queued'"
+              class="queue-item-remove"
+              title="移除"
+              @click="emit('removePending', p.id)"
+            >✕</button>
+          </div>
+        </div>
+      </div>
       <div
         class="resize-handle"
         @pointerdown="startResize"
@@ -150,18 +178,30 @@
           </div>
           <span class="input-separator"></span>
           <div class="input-actions">
-            <button
-              v-if="!isStreaming"
-              class="btn-send"
-              :disabled="!text.trim() || disabled || noProvider"
-              :title="noProvider ? '请先在模型设置中添加 LLM 提供商' : ''"
-              @click="handleSend"
-            >
-              <Icon name="send" :size="16" />
-            </button>
-            <button v-else class="btn-stop" @click="$emit('stop')">
-              <Icon name="stop" :size="12" />
-            </button>
+            <template v-if="!isStreaming">
+              <button
+                class="btn-send"
+                :disabled="!text.trim() || disabled || noProvider"
+                :title="noProvider ? '请先在模型设置中添加 LLM 提供商' : ''"
+                @click="handleSend"
+              >
+                <Icon name="send" :size="16" />
+              </button>
+            </template>
+            <template v-else>
+              <!-- 流式期间发送按钮仍可用：消息进入排队队列，等待注入 -->
+              <button
+                class="btn-send"
+                :disabled="!text.trim() || disabled || noProvider"
+                :title="pendingMessages.length > 0 ? `已排队 ${pendingMessages.length} 条消息，将在 Agent 空闲后合并注入` : '发送（Agent 输出期间将排队）'"
+                @click="handleSend"
+              >
+                <Icon name="send" :size="16" />
+              </button>
+              <button class="btn-stop" @click="$emit('stop')">
+                <Icon name="stop" :size="12" />
+              </button>
+            </template>
           </div>
         </div>
       </div>
@@ -184,7 +224,7 @@
 import { api } from '@/api'
 import AutocompletePanel from '@/components/AutocompletePanel.vue'
 import Icon from '@/components/Icon.vue'
-import type { ProviderConfig, SkillInfo, ToolInfo } from '@/types'
+import type { PendingMessage, ProviderConfig, SkillInfo, ToolInfo } from '@/types'
 import type { ParsedRef } from '@/utils/references'
 import { REF_CHIP_CONFIG, filterImageRefs } from '@/utils/references'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
@@ -197,11 +237,15 @@ const props = defineProps<{
   autoApprove: boolean
   imageRecognition: boolean
   hasVision?: boolean
+  /** Agent 输出期间排队等待注入的消息 */
+  pendingMessages: PendingMessage[]
 }>()
 
 const emit = defineEmits<{
   send: [text: string, refs: ParsedRef[], providerId?: string, modelName?: string, imageRecognition?: boolean, imagePaths?: string[]]
   stop: []
+  removePending: [pendingId: string]
+  clearPending: []
   modelChange: [providerId: string, modelName: string]
   togglePrivate: []
   toggleRecall: []
@@ -218,6 +262,14 @@ const showMenu = ref(false)
 const showLinkInput = ref(false)
 const linkUrl = ref('')
 const linkInputRef = ref<HTMLInputElement | null>(null)
+
+// 排队消息尾部的时间标记（与 chatStore/buildTimestamp 一致），展示时剥离
+const PENDING_TIME_SUFFIX_RE = /（\d{4}-\d{2}-\d{2} \w{3} \d{2}:\d{2}）$/
+
+function displayPendingText(text: string): string {
+  const stripped = text.replace(PENDING_TIME_SUFFIX_RE, '').trim()
+  return stripped || text
+}
 
 // ── 供父组件注入新引用（如 ChatWindow 发出的 cite） ──
 
@@ -1607,5 +1659,127 @@ function onResizeEnd(e: PointerEvent) {
 }
 .btn-stop:hover {
   background: #dc2626;
+}
+/* ── 排队消息区域（输入框内顶部延伸区） ── */
+.queue-tray {
+  border-bottom: 1px solid var(--border);
+  padding-top: 8px;
+  animation: queue-tray-in .18s ease;
+}
+@keyframes queue-tray-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.queue-tray-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 14px 6px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  user-select: none;
+}
+.queue-pulse {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+.queue-tray-count {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.queue-tray-clear {
+  margin-left: auto;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  line-height: 1.5;
+  cursor: pointer;
+  transition: all .15s;
+}
+.queue-tray-clear:hover {
+  color: #ef4444;
+  border-color: #ef4444;
+}
+.queue-tray-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 10px 8px;
+  max-height: 152px;   /* 约 3 条，再多内部滚动 */
+  overflow-y: auto;
+}
+.queue-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-secondary);
+  font-size: 13px;
+  color: var(--text-secondary);
+  animation: queue-item-in .22s ease;
+  transition: opacity .3s, border-color .3s, background .3s;
+}
+@keyframes queue-item-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.queue-item-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.queue-item-badge {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 1.5;
+  border: 1px solid;
+  white-space: nowrap;
+}
+.queue-item-badge.queued {
+  color: var(--text-secondary);
+  border-color: var(--border);
+  background: transparent;
+}
+.queue-item-badge.injected {
+  color: #22c55e;
+  border-color: color-mix(in srgb, #22c55e 30%, transparent);
+  background: color-mix(in srgb, #22c55e 8%, transparent);
+}
+.queue-item.injected {
+  opacity: .6;
+  border-color: color-mix(in srgb, #22c55e 25%, transparent);
+  background: color-mix(in srgb, #22c55e 5%, var(--bg-secondary));
+}
+.queue-item-remove {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all .15s;
+}
+.queue-item-remove:hover {
+  background: #fef2f2;
+  color: #ef4444;
 }
 </style>

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -226,7 +226,7 @@ import AutocompletePanel from '@/components/AutocompletePanel.vue'
 import Icon from '@/components/Icon.vue'
 import type { PendingMessage, ProviderConfig, SkillInfo, ToolInfo } from '@/types'
 import type { ParsedRef } from '@/utils/references'
-import { REF_CHIP_CONFIG, filterImageRefs } from '@/utils/references'
+import { REF_CHIP_CONFIG, filterImageRefs, parseReferences } from '@/utils/references'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
 const props = defineProps<{
@@ -263,12 +263,10 @@ const showLinkInput = ref(false)
 const linkUrl = ref('')
 const linkInputRef = ref<HTMLInputElement | null>(null)
 
-// 排队消息尾部的时间标记（与 chatStore/buildTimestamp 一致），展示时剥离
-const PENDING_TIME_SUFFIX_RE = /（\d{4}-\d{2}-\d{2} \w{3} \d{2}:\d{2}）$/
-
+// 排队消息文本已不含时间戳（后端统一追加进 LLM 上下文）；展示时剥离引用块
 function displayPendingText(text: string): string {
-  const stripped = text.replace(PENDING_TIME_SUFFIX_RE, '').trim()
-  return stripped || text
+  const { cleanText } = parseReferences(text)
+  return cleanText || text
 }
 
 // ── 供父组件注入新引用（如 ChatWindow 发出的 cite） ──

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -50,6 +50,10 @@
             >
               <ToolBubbleRouter :tool-call="ev" @action="forwardAction" />
             </div>
+            <!-- 工具间隙注入的用户消息：渲染为工具之间的用户气泡 -->
+            <div v-else-if="ev.kind === 'user_message'" class="cite-source">
+              <MessageBubble role="user" :content="ev.content" />
+            </div>
           </template>
           <!-- finalAnswer：仅在已完成（非流式）轮次中展示 -->
           <div

--- a/web/src/components/ChatWindow.vue
+++ b/web/src/components/ChatWindow.vue
@@ -52,7 +52,7 @@
             </div>
             <!-- 工具间隙注入的用户消息：渲染为工具之间的用户气泡 -->
             <div v-else-if="ev.kind === 'user_message'" class="cite-source">
-              <MessageBubble role="user" :content="ev.content" />
+              <MessageBubble role="user" :content="ev.content" :refs="ev.refs" />
             </div>
           </template>
           <!-- finalAnswer：仅在已完成（非流式）轮次中展示 -->

--- a/web/src/components/tools/AskUserBubble.vue
+++ b/web/src/components/tools/AskUserBubble.vue
@@ -42,12 +42,32 @@
           />
           <span class="choice-label">{{ opt }}</span>
         </label>
+
+        <!-- 单项选择：告诉Sonetto别的意见 -->
+        <div class="other-choice-area">
+          <button
+            v-if="!showSingleOther"
+            class="btn-other-toggle"
+            @click="showSingleOther = true"
+          >
+            告诉Sonetto别的意见 ✎
+          </button>
+          <div v-else class="other-input-group">
+            <textarea
+              v-model="singleOtherText"
+              class="other-textarea"
+              placeholder="在此输入你的想法..."
+              rows="2"
+            ></textarea>
+          </div>
+        </div>
+
         <button
           class="btn-submit"
-          :disabled="!singleSelected"
+          :disabled="!singleSelected && !singleOtherText.trim()"
           @click="submitSingle"
         >
-          确认选择
+          确认选择{{ singleOtherText.trim() ? '（含自定义意见）' : '' }}
         </button>
       </div>
 
@@ -67,12 +87,32 @@
           />
           <span class="choice-label">{{ opt }}</span>
         </label>
+
+        <!-- 多项选择：告诉Sonetto别的意见 -->
+        <div class="other-choice-area">
+          <button
+            v-if="!showMultiOther"
+            class="btn-other-toggle"
+            @click="showMultiOther = true"
+          >
+            告诉Sonetto别的意见 ✎
+          </button>
+          <div v-else class="other-input-group">
+            <textarea
+              v-model="multiOtherText"
+              class="other-textarea"
+              placeholder="在此输入你的想法..."
+              rows="2"
+            ></textarea>
+          </div>
+        </div>
+
         <button
           class="btn-submit"
-          :disabled="multiSelected.length === 0"
+          :disabled="multiSelected.length === 0 && !multiOtherText.trim()"
           @click="submitMulti"
         >
-          确认选择（{{ multiSelected.length }}）
+          确认选择（{{ multiOtherText.trim() ? multiSelected.length + 1 : multiSelected.length }}）
         </button>
       </div>
     </div>
@@ -117,10 +157,21 @@ const emit = defineEmits<{
   (e: 'action', p: { action: string; data?: unknown }): void
 }>()
 
+/** 自定义文本前缀，用于在 response 中区分选中的选项和用户手写输入 */
+const CUSTOM_TEXT_PREFIX = '__custom__::'
+
 const submitted = ref(false)
 const qaText = ref('')
 const singleSelected = ref('')
 const multiSelected = ref<string[]>([])
+
+/** 单项选择「告诉Sonetto别的意见」状态 */
+const showSingleOther = ref(false)
+const singleOtherText = ref('')
+
+/** 多项选择「告诉Sonetto别的意见」状态 */
+const showMultiOther = ref(false)
+const multiOtherText = ref('')
 
 const interactionData = computed(() => {
   const result = props.toolCall.interaction
@@ -132,13 +183,6 @@ const interactionData = computed(() => {
         interactionId: '',
         submitted: false,
       }
-  console.log('[AskUserBubble] interactionData computed:', {
-    status: props.toolCall.status,
-    submitted: submitted.value,
-    hasInteraction: !!props.toolCall.interaction,
-    interactionId: result.interactionId,
-    mode: result.mode,
-  })
   return result
 })
 
@@ -154,12 +198,17 @@ const doneData = computed(() => {
   return null
 })
 
-/** 格式化用户的回答（多选时用顿号连接） */
+/** 格式化用户的回答（多选时用顿号连接，自定义文本移除前缀标记） */
 const doneAnswer = computed(() => {
   if (!doneData.value) return ''
   const answer = doneData.value.answer
   if (Array.isArray(answer)) {
-    return answer.join('、')
+    return answer
+      .map(a => a.startsWith(CUSTOM_TEXT_PREFIX) ? a.slice(CUSTOM_TEXT_PREFIX.length) : a)
+      .join('、')
+  }
+  if (typeof answer === 'string' && answer.startsWith(CUSTOM_TEXT_PREFIX)) {
+    return answer.slice(CUSTOM_TEXT_PREFIX.length)
   }
   return answer || ''
 })
@@ -178,25 +227,42 @@ function submitQA() {
 }
 
 function submitSingle() {
-  if (!singleSelected.value) return
+  const response: string[] = []
+  if (singleSelected.value) {
+    response.push(singleSelected.value)
+  }
+  const other = singleOtherText.value.trim()
+  if (other) {
+    response.push(CUSTOM_TEXT_PREFIX + other)
+  }
+  if (response.length === 0) return
   submitted.value = true
   emit('action', {
     action: 'user_response',
     data: {
       interactionId: interactionData.value.interactionId,
-      response: singleSelected.value,
+      // 单选且无自定义文本时保持字符串，向后兼容
+      response: response.length === 1 && !other ? response[0] : response,
     },
   })
 }
 
 function submitMulti() {
-  if (multiSelected.value.length === 0) return
+  const response: string[] = []
+  // 已选中的选项
+  response.push(...multiSelected.value)
+  // 自定义文本
+  const other = multiOtherText.value.trim()
+  if (other) {
+    response.push(CUSTOM_TEXT_PREFIX + other)
+  }
+  if (response.length === 0) return
   submitted.value = true
   emit('action', {
     action: 'user_response',
     data: {
       interactionId: interactionData.value.interactionId,
-      response: multiSelected.value,
+      response,
     },
   })
 }
@@ -276,6 +342,54 @@ function submitMulti() {
   color: var(--text-primary);
 }
 
+/* ── 告诉Sonetto别的意见 ── */
+.other-choice-area {
+  margin-top: 2px;
+}
+.btn-other-toggle {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.15s;
+  text-align: left;
+}
+.btn-other-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 4%, transparent);
+}
+.other-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.other-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.other-textarea:focus {
+  border-color: var(--accent);
+}
+.other-textarea::placeholder {
+  color: var(--text-secondary);
+}
 /* 提交按钮 */
 .btn-submit {
   align-self: flex-end;

--- a/web/src/components/tools/_shared/displayNames.ts
+++ b/web/src/components/tools/_shared/displayNames.ts
@@ -43,7 +43,7 @@ const DISPLAY_NAMES: Record<string, string> = {
   ask_user: '询问用户',
   ask_user_for_info: '询问用户',
   ask_user_qa: '询问用户',
-  ask_user_single_choice: '请选择',
+  ask_user_single_choice: '选择意见',
   ask_user_multi_choice: '多选',
   task_tracker: '任务追踪',
 

--- a/web/src/composables/useChat.handlers.ts
+++ b/web/src/composables/useChat.handlers.ts
@@ -99,8 +99,7 @@ function handleDone(ch: SessionChannel, sid: string, turn: ChatTurn, event: Serv
   const de = event as DoneEvent
   ch.isAwaitingUser = false
   ch._awaitingToolName = null
-  // 轮次结束，清除已注入当前轮的排队气泡（「已注入」标识完成使命）
-  ch.pendingMessages = ch.pendingMessages.filter(p => p.status !== 'injected')
+  // 注：工具间隙注入的消息已由 pending_consumed(mid_turn) 移入聊天流渲染
   if (de.payload.context_usage) {
     ch.contextUsage = de.payload.context_usage
   }

--- a/web/src/composables/useChat.handlers.ts
+++ b/web/src/composables/useChat.handlers.ts
@@ -99,6 +99,8 @@ function handleDone(ch: SessionChannel, sid: string, turn: ChatTurn, event: Serv
   const de = event as DoneEvent
   ch.isAwaitingUser = false
   ch._awaitingToolName = null
+  // 轮次结束，清除已注入当前轮的排队气泡（「已注入」标识完成使命）
+  ch.pendingMessages = ch.pendingMessages.filter(p => p.status !== 'injected')
   if (de.payload.context_usage) {
     ch.contextUsage = de.payload.context_usage
   }
@@ -111,8 +113,10 @@ function handleDone(ch: SessionChannel, sid: string, turn: ChatTurn, event: Serv
   // ── 防重复守卫：若 turn 已存在于 turns 中则跳过 ──
   if (ch.turns.some(t => t.id === turn.id)) {
     console.warn(`[useChat:done] 防重复守卫触发: 会话 ${sid}, turn.id=${turn.id} 已在 turns 中, 跳过 push`)
-    ch.currentTurn = null
-    ch.isStreaming = false
+    if (ch.currentTurn?.id === turn.id) {
+      ch.currentTurn = null
+      ch.isStreaming = false
+    }
     return
   }
 
@@ -127,21 +131,29 @@ function handleDone(ch: SessionChannel, sid: string, turn: ChatTurn, event: Serv
         // 延迟后再检查一次：turns 中可能已被其他逻辑写入
         if (ch.turns.some(t => t.id === turnToFinalize.id)) {
           console.warn(`[useChat:done] becameAnswer 防重复守卫触发: 会话 ${sid}, turn.id=${turnToFinalize.id}`)
-          ch.currentTurn = null
-          ch.isStreaming = false
+          if (ch.currentTurn?.id === turnToFinalize.id) {
+            ch.currentTurn = null
+            ch.isStreaming = false
+          }
           return
         }
         ch.turns.push(turnToFinalize)
-        ch.currentTurn = null
-        ch.isStreaming = false
+        // ⚠ id 守卫：420ms 延迟窗口内可能已由 pending_consumed(new_turn)
+        // 创建了下一合并轮，不得清空它
+        if (ch.currentTurn?.id === turnToFinalize.id) {
+          ch.currentTurn = null
+          ch.isStreaming = false
+        }
         if (!ch.privateMode) { useChatStore().persistTurns(sid) }
       }, 420)
     })
   } else {
     console.log(`[useChat:done] 直接分支执行 persist (会话 ${sid}), turns.length=${ch.turns.length}`)
     ch.turns.push(turn)
-    ch.currentTurn = null
-    ch.isStreaming = false
+    if (ch.currentTurn?.id === turn.id) {
+      ch.currentTurn = null
+      ch.isStreaming = false
+    }
     if (!ch.privateMode) { useChatStore().persistTurns(sid) }
   }
   // 轮次结束，刷新会话列表以更新 message_count
@@ -158,6 +170,10 @@ function handleError(ch: SessionChannel, _sid: string, _turn: ChatTurn, event: S
   ch._awaitingToolName = null
   ch.error = (event as ErrorEvent).payload.message
   ch.isStreaming = false
+  // 用户点击停止（CANCELLED）→ 排队消息一并丢弃，与后端 pending_cancelled 语义一致
+  if ((event as ErrorEvent).payload.code === 'CANCELLED') {
+    ch.pendingMessages = []
+  }
 }
 
 /** ask_user：设置交互等待状态，在 running 工具上挂载 interaction。 */

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -28,8 +28,8 @@ export const allSessionStatuses = computed(() => useChatStore().allSessionStatus
  * useChat composable — 委托到 Pinia store。
  *
  * 保持现有 API 接口不变：
- *   connected, isStreaming, turns, currentTurn, error,
- *   contextUsage, taskTrackerData, send, cancel, sendUserResponse, removeTurns,
+ *   connected, isStreaming, turns, currentTurn, pendingMessages, pendingCount,
+ *   error, contextUsage, taskTrackerData, send, cancel, sendUserResponse, removeTurns,
  *   privateMode, setPrivateMode, autoApprove, setAutoApprove
  */
 export function useChat(sessionId: Ref<string>) {
@@ -42,6 +42,8 @@ export function useChat(sessionId: Ref<string>) {
   const isStreaming = computed(() => activeChannelRef.value.isStreaming)
   const turns = computed(() => activeChannelRef.value.turns)
   const currentTurn = computed(() => activeChannelRef.value.currentTurn)
+  const pendingMessages = computed(() => activeChannelRef.value.pendingMessages)
+  const pendingCount = computed(() => activeChannelRef.value.pendingMessages.length)
   const error = computed(() => activeChannelRef.value.error)
   const contextUsage = computed(() => activeChannelRef.value.contextUsage)
   const taskTrackerData = computed(() => activeChannelRef.value.taskTrackerData)
@@ -105,7 +107,8 @@ export function useChat(sessionId: Ref<string>) {
   }
 
   return {
-    connected, isStreaming, turns, currentTurn, error, contextUsage, taskTrackerData,
+    connected, isStreaming, turns, currentTurn, pendingMessages, pendingCount,
+    error, contextUsage, taskTrackerData,
     send, cancel, sendUserResponse, removeTurns,
     privateMode, setPrivateMode,
     skipRecall, setSkipRecall,

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -6,7 +6,7 @@ import type {
   ClientMessage, TokenEvent, PendingMessage,
   MessageQueuedEvent, PendingConsumedEvent, PendingSyncEvent, PendingCancelledEvent,
 } from '@/types'
-import { buildFlatMessage, buildTimestamp, parseReferences } from '@/utils/references'
+import { buildFlatMessage, parseReferences } from '@/utils/references'
 import type { ParsedRef } from '@/utils/references'
 import { getToken } from '@/api'
 import { sessionsApi } from '@/api/sessions'
@@ -430,12 +430,14 @@ export const useChatStore = defineStore('chat', () => {
       const pe = event as PendingConsumedEvent
       const consumed = new Set(pe.payload.pending.map(p => p.pending_id))
       if (pe.payload.mode === 'mid_turn') {
-        // 注入当前轮：从排队区移除，作为用户气泡插入工具之间的聊天流
+        // 注入当前轮：从排队区移除，作为用户气泡插入工具之间的聊天流。
+        // 文本含引用块，解析出干净文本与引用 chip（与普通用户气泡一致）。
         ch.pendingMessages = ch.pendingMessages.filter(p => !consumed.has(p.id))
         const turn = ch.currentTurn
         if (turn) {
           for (const item of pe.payload.pending) {
-            turn.events.push({ kind: 'user_message', content: item.text })
+            const { cleanText, refs } = parseReferences(item.text)
+            turn.events.push({ kind: 'user_message', content: cleanText, refs })
           }
         }
       } else if (pe.payload.mode === 'new_turn') {
@@ -513,8 +515,7 @@ export const useChatStore = defineStore('chat', () => {
     const ch = channels.get(sid)
     if (!ch?.ws || ch.ws.readyState !== WebSocket.OPEN) return
 
-    const timestamp = buildTimestamp()
-    const flatMsg = buildFlatMessage(text, timestamp, refs)
+    const flatMsg = buildFlatMessage(text, refs)
     // 客户端消息 ID：作为 client_msg_id 发送，后端复用作 pending_id，
     // 使 message_queued ack 与乐观气泡 id 精确对应。
     const clientMsgId = crypto.randomUUID()

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -428,15 +428,18 @@ export const useChatStore = defineStore('chat', () => {
 
     if (event.type === 'pending_consumed') {
       const pe = event as PendingConsumedEvent
+      const consumed = new Set(pe.payload.pending.map(p => p.pending_id))
       if (pe.payload.mode === 'mid_turn') {
-        // 注入当前轮：标记对应气泡「已注入」
-        const consumed = new Set(pe.payload.pending_ids)
-        for (const p of ch.pendingMessages) {
-          if (consumed.has(p.id)) p.status = 'injected'
+        // 注入当前轮：从排队区移除，作为用户气泡插入工具之间的聊天流
+        ch.pendingMessages = ch.pendingMessages.filter(p => !consumed.has(p.id))
+        const turn = ch.currentTurn
+        if (turn) {
+          for (const item of pe.payload.pending) {
+            turn.events.push({ kind: 'user_message', content: item.text })
+          }
         }
       } else if (pe.payload.mode === 'new_turn') {
         // 后端自动启动的合并轮：移除已消费气泡，创建 currentTurn（不调用 send）
-        const consumed = new Set(pe.payload.pending_ids)
         ch.pendingMessages = ch.pendingMessages.filter(p => !consumed.has(p.id))
         ch.error = null
         ch.currentTurn = {

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -3,7 +3,8 @@ import { defineStore } from 'pinia'
 import type {
   ServerEvent, ChatTurn, ToolCall, ThinkingBlock,
   TurnEvent, ContextUsage, AskUserEvent, MemoryToolEvent,
-  ClientMessage, TokenEvent,
+  ClientMessage, TokenEvent, PendingMessage,
+  MessageQueuedEvent, PendingConsumedEvent, PendingSyncEvent, PendingCancelledEvent,
 } from '@/types'
 import { buildFlatMessage, buildTimestamp, parseReferences } from '@/utils/references'
 import type { ParsedRef } from '@/utils/references'
@@ -63,6 +64,8 @@ export interface SessionChannel {
   isAwaitingUser: boolean
   turns: ChatTurn[]
   currentTurn: ChatTurn | null
+  /** Agent 输出期间发送、等待注入的排队消息气泡 */
+  pendingMessages: PendingMessage[]
   error: string | null
   contextUsage: ContextUsage | null
   taskTrackerData: Record<string, unknown> | null
@@ -125,6 +128,7 @@ export const useChatStore = defineStore('chat', () => {
         isAwaitingUser: false,
         turns: deduped ?? [],
         currentTurn: null,
+        pendingMessages: [],
         error: null,
         contextUsage: null,
         taskTrackerData: null,
@@ -407,6 +411,60 @@ export const useChatStore = defineStore('chat', () => {
       return
     }
 
+    // 排队消息事件：在 turn 守卫之前处理（可能 currentTurn 尚为 null）
+    if (event.type === 'message_queued') {
+      const me = event as MessageQueuedEvent
+      // 竞态兜底：空闲路径可能已为该消息创建了 currentTurn，但后端实际入队了
+      // → 该消息并非作为轮次处理，转为排队气泡
+      if (ch.currentTurn && ch.currentTurn.id === me.payload.pending_id && ch.currentTurn.events.length === 0) {
+        ch.currentTurn = null
+        ch.isStreaming = false
+      }
+      if (!ch.pendingMessages.some(p => p.id === me.payload.pending_id)) {
+        ch.pendingMessages.push({ id: me.payload.pending_id, text: me.payload.text, status: 'queued' })
+      }
+      return
+    }
+
+    if (event.type === 'pending_consumed') {
+      const pe = event as PendingConsumedEvent
+      if (pe.payload.mode === 'mid_turn') {
+        // 注入当前轮：标记对应气泡「已注入」
+        const consumed = new Set(pe.payload.pending_ids)
+        for (const p of ch.pendingMessages) {
+          if (consumed.has(p.id)) p.status = 'injected'
+        }
+      } else if (pe.payload.mode === 'new_turn') {
+        // 后端自动启动的合并轮：移除已消费气泡，创建 currentTurn（不调用 send）
+        const consumed = new Set(pe.payload.pending_ids)
+        ch.pendingMessages = ch.pendingMessages.filter(p => !consumed.has(p.id))
+        ch.error = null
+        ch.currentTurn = {
+          id: crypto.randomUUID(),
+          userMessage: pe.payload.text || '(已合并消息)',
+          refs: [],
+          events: [],
+          memoryEvents: [],
+          finalAnswer: null,
+        }
+        ch.isStreaming = true
+      }
+      return
+    }
+
+    if (event.type === 'pending_sync') {
+      const se = event as PendingSyncEvent
+      ch.pendingMessages = se.payload.pending.map(p => ({ id: p.pending_id, text: p.text, status: 'queued' }))
+      return
+    }
+
+    if (event.type === 'pending_cancelled') {
+      const ce = event as PendingCancelledEvent
+      const ids = new Set(ce.payload.pending_ids)
+      ch.pendingMessages = ch.pendingMessages.filter(p => !ids.has(p.id))
+      return
+    }
+
     const turn = ch.currentTurn
     if (!turn) return
 
@@ -451,28 +509,12 @@ export const useChatStore = defineStore('chat', () => {
   ) {
     const ch = channels.get(sid)
     if (!ch?.ws || ch.ws.readyState !== WebSocket.OPEN) return
-    // 覆盖 currentTurn 前检查是否有未完成的轮次
-    if (ch.currentTurn) {
-      console.warn('[chatStore] send: 覆盖 currentTurn, sid=%s, 旧 turn.id=%s, 旧 finalAnswer=%s',
-        sid, ch.currentTurn.id, ch.currentTurn.finalAnswer?.slice(0, 50) ?? 'null')
-    }
-    ch.isStreaming = true
-    ch.error = null
 
     const timestamp = buildTimestamp()
     const flatMsg = buildFlatMessage(text, timestamp, refs)
-
-    ch.currentTurn = {
-      id: crypto.randomUUID(),
-      userMessage: text,
-      refs,
-      imageRefs: imageRecognition && imagePaths?.length
-        ? imagePaths.map(p => ({ type: 'file' as const, path: p, label: p.split(/[/\\]/).pop() || p }))
-        : undefined,
-      events: [],
-      memoryEvents: [],
-      finalAnswer: null,
-    }
+    // 客户端消息 ID：作为 client_msg_id 发送，后端复用作 pending_id，
+    // 使 message_queued ack 与乐观气泡 id 精确对应。
+    const clientMsgId = crypto.randomUUID()
 
     const payload: ClientMessage = {
       type: 'chat',
@@ -483,8 +525,31 @@ export const useChatStore = defineStore('chat', () => {
         auto_approve: ch.autoApprove,
         provider_id: providerId,
         model_name: modelName,
+        client_msg_id: clientMsgId,
         ...(imageRecognition && imagePaths?.length ? { image_recognition: true, image_refs: imagePaths } : {}),
       },
+    }
+
+    // Agent 输出期间（或已有排队消息）：挂起到队列，等待注入，不触碰 currentTurn
+    if (ch.isStreaming || ch.pendingMessages.length > 0) {
+      ch.pendingMessages.push({ id: clientMsgId, text, status: 'queued' })
+      ch.ws.send(JSON.stringify(payload))
+      return
+    }
+
+    // 空闲：正常创建轮次
+    ch.isStreaming = true
+    ch.error = null
+    ch.currentTurn = {
+      id: clientMsgId,
+      userMessage: text,
+      refs,
+      imageRefs: imageRecognition && imagePaths?.length
+        ? imagePaths.map(p => ({ type: 'file' as const, path: p, label: p.split(/[/\\]/).pop() || p }))
+        : undefined,
+      events: [],
+      memoryEvents: [],
+      finalAnswer: null,
     }
     ch.ws.send(JSON.stringify(payload))
   }
@@ -493,6 +558,26 @@ export const useChatStore = defineStore('chat', () => {
     const ch = channels.get(sid)
     if (!ch?.ws || ch.ws.readyState !== WebSocket.OPEN) return
     ch.ws.send(JSON.stringify({ type: 'cancel', payload: {} } as ClientMessage))
+  }
+
+  /** 从排队队列移除一条消息（乐观移除 + 后端同步）。 */
+  function removePendingMessage(sid: string, pendingId: string) {
+    const ch = channels.get(sid)
+    if (!ch) return
+    ch.pendingMessages = ch.pendingMessages.filter(p => p.id !== pendingId)
+    if (ch.ws?.readyState === WebSocket.OPEN) {
+      ch.ws.send(JSON.stringify({ type: 'remove_pending', payload: { pending_id: pendingId } } as ClientMessage))
+    }
+  }
+
+  /** 清空全部排队消息（乐观清空 + 后端同步，不取消正在运行的 Agent）。 */
+  function clearPendingMessages(sid: string) {
+    const ch = channels.get(sid)
+    if (!ch) return
+    ch.pendingMessages = []
+    if (ch.ws?.readyState === WebSocket.OPEN) {
+      ch.ws.send(JSON.stringify({ type: 'clear_pending', payload: {} } as ClientMessage))
+    }
   }
 
   function skipMemorySearch(sid: string) {
@@ -564,6 +649,8 @@ export const useChatStore = defineStore('chat', () => {
     sendUserResponse,
     removeTurns,
     updateAutoApprove,
+    removePendingMessage,
+    clearPendingMessages,
     restoreTurnsFromBackend,
   }
 })

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -335,6 +335,8 @@ export interface MemoryToolEvent {
 export interface UserMessageEvent {
   kind: 'user_message'
   content: string
+  /** 消息内引用的解析结果（引用 chip） */
+  refs?: ParsedRef[]
 }
 
 export type TurnEvent = ThinkingBlock | ToolCall | MemoryToolEvent | UserMessageEvent

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -166,8 +166,9 @@ export interface MessageQueuedEvent {
 export interface PendingConsumedEvent {
   type: 'pending_consumed'
   payload: {
-    pending_ids: string[]
-    /** mid_turn：注入当前轮；new_turn：合并为新的一轮 */
+    /** 被消费的排队消息（按消费顺序），含文本供前端渲染 */
+    pending: Array<{ pending_id: string; text: string }>
+    /** mid_turn：注入当前轮（工具之间渲染为用户气泡）；new_turn：合并为新的一轮 */
     mode: 'mid_turn' | 'new_turn'
     /** new_turn 模式下合并后的用户消息文本 */
     text?: string
@@ -330,7 +331,13 @@ export interface MemoryToolEvent {
   status: 'running' | 'done' | 'error'
 }
 
-export type TurnEvent = ThinkingBlock | ToolCall | MemoryToolEvent
+/** 工具间隙注入的用户消息（渲染为工具之间的用户气泡） */
+export interface UserMessageEvent {
+  kind: 'user_message'
+  content: string
+}
+
+export type TurnEvent = ThinkingBlock | ToolCall | MemoryToolEvent | UserMessageEvent
 
 export interface ChatTurn {
   id: string

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -152,6 +152,44 @@ export interface MemorySearchDoneEvent {
   }
 }
 
+/** message_queued — Agent 输出期间发送的消息已挂起到服务端队列 */
+export interface MessageQueuedEvent {
+  type: 'message_queued'
+  payload: {
+    pending_id: string
+    text: string
+    position: number
+  }
+}
+
+/** pending_consumed — 排队消息已被注入 Agent 上下文 */
+export interface PendingConsumedEvent {
+  type: 'pending_consumed'
+  payload: {
+    pending_ids: string[]
+    /** mid_turn：注入当前轮；new_turn：合并为新的一轮 */
+    mode: 'mid_turn' | 'new_turn'
+    /** new_turn 模式下合并后的用户消息文本 */
+    text?: string
+  }
+}
+
+/** pending_sync — WebSocket 重连时同步服务端挂起队列 */
+export interface PendingSyncEvent {
+  type: 'pending_sync'
+  payload: {
+    pending: Array<{ pending_id: string; text: string; position: number }>
+  }
+}
+
+/** pending_cancelled — 用户点击停止，排队消息被丢弃 */
+export interface PendingCancelledEvent {
+  type: 'pending_cancelled'
+  payload: {
+    pending_ids: string[]
+  }
+}
+
 export type ServerEvent =
   | ThinkingStartEvent
   | TokenEvent
@@ -174,6 +212,10 @@ export type ServerEvent =
   | MemorySearchStartEvent
   | MemorySearchSkippedEvent
   | MemorySearchDoneEvent
+  | MessageQueuedEvent
+  | PendingConsumedEvent
+  | PendingSyncEvent
+  | PendingCancelledEvent
 
 // === WebSocket 客户端 → 服务端消息 ===
 
@@ -190,6 +232,8 @@ export interface ChatMessage {
     image_recognition?: boolean
     /** 图像认知模式下的图片文件绝对路径列表 */
     image_refs?: string[]
+    /** 客户端生成的消息 ID，后端用作 pending_id 以关联入队确认 */
+    client_msg_id?: string
   }
 }
 
@@ -228,7 +272,21 @@ export interface SkipMemorySearchMessage {
   }
 }
 
-export type ClientMessage = ChatMessage | CancelMessage | PingMessage | UserResponseMessage | UpdateAutoApproveMessage | SkipMemorySearchMessage
+/** remove_pending — 从排队队列移除一条消息（不取消正在运行的 Agent） */
+export interface RemovePendingMessage {
+  type: 'remove_pending'
+  payload: {
+    pending_id: string
+  }
+}
+
+/** clear_pending — 清空全部排队消息（不取消正在运行的 Agent） */
+export interface ClearPendingMessage {
+  type: 'clear_pending'
+  payload: Record<string, never>
+}
+
+export type ClientMessage = ChatMessage | CancelMessage | PingMessage | UserResponseMessage | UpdateAutoApproveMessage | SkipMemorySearchMessage | RemovePendingMessage | ClearPendingMessage
 
 // === 前端 UI 状态类型 ===
 
@@ -287,6 +345,15 @@ export interface ChatTurn {
   turnId?: string
   /** 当前轮的语义记忆搜索结果 */
   memorySearch?: { status: 'searching'; skipInteractionId?: string } | { status: 'skipped' } | { status: 'done'; total: number; fresh: number }
+}
+
+/** 前端展示的排队消息气泡 */
+export interface PendingMessage {
+  /** pending_id（message_queued ack 后替换为服务端 ID） */
+  id: string
+  text: string
+  /** queued：等待注入；injected：已注入当前轮 */
+  status: 'queued' | 'injected'
 }
 
 // === 会话与 API 类型 ===

--- a/web/src/utils/references.ts
+++ b/web/src/utils/references.ts
@@ -159,22 +159,13 @@ export function buildRefsBlock(refs: ParsedRef[]): string {
   return `\n\n${REFS_START}${JSON.stringify(refs)}${REFS_END}`
 }
 
-/** 构造前端自动追加的 ISO 时间尾缀，如（2026-06-10 Wed 14:30） */
-export function buildTimestamp(): string {
-  const now = new Date()
-  const y = now.getFullYear()
-  const mo = String(now.getMonth() + 1).padStart(2, '0')
-  const d = String(now.getDate()).padStart(2, '0')
-  const hh = String(now.getHours()).padStart(2, '0')
-  const mm = String(now.getMinutes()).padStart(2, '0')
-  const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
-  const wd = weekdays[now.getDay()]
-  return `（${y}-${mo}-${d} ${wd} ${hh}:${mm}）`
-}
-
-/** 构建 WebSocket 发送用的平面字符串（结构化 → 序列化） */
-export function buildFlatMessage(text: string, timestamp: string, refs: ParsedRef[]): string {
-  const base = text + timestamp
-  if (refs.length === 0) return base
-  return base + buildRefsBlock(refs)
+/**
+ * 构建 WebSocket 发送用的平面字符串（结构化 → 序列化）。
+ *
+ * 时间戳不再由前端拼接——它是必须进入 LLM 上下文的输入数据，由后端在
+ * 构造 LLM 输入时统一追加服务器时间。前端只发送文本与引用块。
+ */
+export function buildFlatMessage(text: string, refs: ParsedRef[]): string {
+  if (refs.length === 0) return text
+  return text + buildRefsBlock(refs)
 }

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -55,6 +55,9 @@
       :auto-approve="autoApprove"
       :image-recognition="imageRecognition"
       :has-vision="selectedModelHasVision"
+      :pending-messages="pendingMessages"
+      @remove-pending="onRemovePending"
+      @clear-pending="onClearPending"
       @send="onSend"
       @stop="cancel"
       @model-change="onModelChange"
@@ -104,7 +107,7 @@ import type { ProviderConfig } from '@/types'
 import { computed, onMounted, ref } from 'vue'
 
 const { sessionId, sessions } = useSession()
-const { connected, isStreaming, turns, currentTurn, error, contextUsage, taskTrackerData, send, cancel, sendUserResponse, removeTurns, privateMode, setPrivateMode, skipRecall, setSkipRecall, autoApprove, setAutoApprove } =
+const { connected, isStreaming, turns, currentTurn, pendingMessages, error, contextUsage, taskTrackerData, send, cancel, sendUserResponse, removeTurns, privateMode, setPrivateMode, skipRecall, setSkipRecall, autoApprove, setAutoApprove } =
   useChat(sessionId)
 const chatStore = useChatStore()
 
@@ -160,6 +163,14 @@ function addCitation(ref: ParsedRef) {
 
 function onSend(text: string, refs: ParsedRef[], providerId?: string, modelName?: string, imageRecognition?: boolean, imagePaths?: string[]) {
   send(text, refs, providerId, modelName, imageRecognition, imagePaths)
+}
+
+function onRemovePending(pendingId: string) {
+  chatStore.removePendingMessage(sessionId.value, pendingId)
+}
+
+function onClearPending() {
+  chatStore.clearPendingMessages(sessionId.value)
 }
 
 function handleToolAction(payload: { action: string; data?: unknown }) {


### PR DESCRIPTION
## Summary

- **挂起消息队列**：Agent 忙碌（含等待 ask_user 交互回复）期间，用户仍可在输入框继续发消息，消息进入排队队列；工具间隙（`inject_pending` 节点）与轮末（`check_pending` 节点）将排队消息注入图状态，图内自动开启下一轮，不再丢失任何输入。
- **单选/多选自定义输入**：AskUserBubble 单/多选模式新增「告诉Sonetto别的意见」独立输入框，用户可补充自定义文本；后端以 `__custom__::` 前缀区分选项与手写输入，输出 `is_custom_text`/`selected_option` 标记供 LLM 识别。
- **事件链路**：新增 `message_queued` / `pending_sync` / `pending_consumed` / `pending_cancelled` 前端事件，排队区域 UI 与状态管理（chatStore / useChat）同步更新。
- **时间戳统一**：消息时间戳改由后端统一追加，注入时进入 LLM 上下文。

## Test plan

- [x] 后端：`pytest tests/test_pending_queue.py` — 21 passed
- [ ] 手动：Agent 忙碌时连续发送多条消息，验证排队区展示、工具间隙注入与轮末合并续跑
- [ ] 手动：单选/多选时点击「告诉Sonetto别的意见」输入自定义文本，验证 `is_custom_text` 标记与 done 气泡展示

🤖 Generated with [Claude Code](https://claude.com/claude-code)