### PR TITLE
fix: 修复 Code scanning 告警（路径注入 + 原型污染）

### DIFF
--- a/agent/studio.py
+++ b/agent/studio.py
@@ -279,6 +279,19 @@ def _to_info(data: dict[str, Any], filename: str) -> StudioInfo:
     )
 
 
+def _safe_studio_path(filename: str) -> Path:
+    """把 <name 安全化>.yaml 拼接到 STUDIOS_DIR 下，并校验不越出该目录。
+
+    filename 理论上已被 _sanitize_filename 剔除路径分隔符等非法字符，
+    此处再以 resolve() 做防御：若解析后的父目录不是 STUDIOS_DIR，
+    说明存在越权路径（如 ``..`` 上跳），直接抛 ValueError。
+    """
+    path = (STUDIOS_DIR / filename).resolve()
+    if path.parent != STUDIOS_DIR.resolve():
+        raise ValueError(f"非法的工作坊文件名: {filename!r}")
+    return path
+
+
 def _write_studio_file(path: Path, data: dict[str, Any]) -> None:
     with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(data, f, allow_unicode=True, sort_keys=False)
@@ -296,7 +309,7 @@ def create_studio(data: dict[str, Any]) -> StudioInfo:
         raise ValueError(f"工作坊「{name}」已存在")
     filename = _sanitize_filename(name) + ".yaml"
     STUDIOS_DIR.mkdir(parents=True, exist_ok=True)
-    _write_studio_file(STUDIOS_DIR / filename, data)
+    _write_studio_file(_safe_studio_path(filename), data)
     return _to_info(data, filename)
 
 
@@ -313,7 +326,7 @@ def update_studio(name: str, data: dict[str, Any]) -> StudioInfo:
         raise ValueError(f"工作坊「{name}」不存在")
     new_name = str(data["name"]).strip()
     new_filename = _sanitize_filename(new_name) + ".yaml"
-    new_path = STUDIOS_DIR / new_filename
+    new_path = _safe_studio_path(new_filename)
     if new_name != name and find_studio_file(new_name) is not None:
         raise ValueError(f"工作坊「{new_name}」已存在")
     if old_path != new_path:

--- a/web/src/components/StudioForm.vue
+++ b/web/src/components/StudioForm.vue
@@ -154,18 +154,26 @@ function readPath(obj: any, key: string): any {
   return cur
 }
 
+/** 危险 key：若按此写入会触发原型污染，直接跳过本次写入 */
+function isUnsafeKey(k: string): boolean {
+  return k === '__proto__' || k === 'constructor' || k === 'prototype'
+}
+
 /** 按点路径写值；中间对象缺失时自动创建 */
 function writePath(obj: any, key: string, val: any) {
   const parts = key.split('.')
   let cur = obj
   for (let i = 0; i < parts.length - 1; i++) {
     const p = parts[i]
+    if (isUnsafeKey(p)) return
     if (cur[p] == null || typeof cur[p] !== 'object' || Array.isArray(cur[p])) {
       cur[p] = {}
     }
     cur = cur[p]
   }
-  cur[parts[parts.length - 1]] = val
+  const last = parts[parts.length - 1]
+  if (isUnsafeKey(last)) return
+  cur[last] = val
 }
 
 // ── 名称（schema 不含 name，单独处理） ──


### PR DESCRIPTION
修复两个 Code scanning 告警：

- **#39** Uncontrolled data used in path expression — `agent/studio.py` 新增 `_safe_studio_path`，resolve 后校验父目录仍在 STUDIOS_DIR 内
- **#38** Prototype-polluting function — `StudioForm.vue` 的 `writePath` 防护 `__proto__`/constructor/prototype

验证：test_studio 18 通过；vue-tsc StudioForm 无类型错误