### PR TITLE
fix(upgrade): 新增 yamale 安装迁移脚本补齐 v3.5.0 依赖

### DIFF
--- a/scripts/migrations/v350-install-yamale.py
+++ b/scripts/migrations/v350-install-yamale.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""配置迁移 — 确保 yamale 已安装（v3.5.0 工作坊 schema 校验依赖）。
+
+v3.5.0（工作坊体系 #277）引入 yamale 用于 studios/*.yaml 的 schema 校验，
+但旧版本升级用户可能缺失该依赖。本脚本幂等：
+- 已安装且版本 >= 5.0 → 直接通过
+- 未安装或版本过低 → 用当前解释器（upgrade.py 保证为 .venv）pip 安装
+
+依赖安装失败时以非零码退出，upgrade.py 会中止并提示。
+"""
+
+import importlib.metadata
+import importlib.util
+import subprocess
+import sys
+
+MIN_YAMALE_VERSION = (5, 0)
+
+
+def _yamale_ok() -> bool:
+    """检测 yamale 是否已安装且版本满足要求。"""
+    if importlib.util.find_spec("yamale") is None:
+        return False
+    try:
+        version = importlib.metadata.version("yamale")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    try:
+        parts = tuple(int(part) for part in version.split(".")[:2])
+    except ValueError:
+        # 非数字版本号（如 4.9.2rc1 这类 pre-release 后缀）无法确认满足
+        # requirements.txt 的 >= 5.0，保守视为未满足，触发一次 pip 安装
+        # （pip 会自行判断已装版本是否满足，多余执行无害且幂等）
+        return False
+    return parts >= MIN_YAMALE_VERSION
+
+
+def main() -> None:
+    if _yamale_ok():
+        print("[migration] yamale 已安装且版本满足要求，跳过")
+        return
+    print("[migration] 未检测到 yamale（>= 5.0），正在安装 ...")
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "yamale>=5.0"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"[migration] yamale 安装失败:\n{result.stderr}")
+        sys.exit(1)
+    print("[migration] ✔ yamale 安装完成")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 背景

issue #283 评论中作者指出：v3.5.0 缺少 yamale 的安装更新脚本。yamale 由 #277（工作坊体系）引入，用于 anthropic_skills/tool/studio-creator/scripts/validate_studio.py 校验 studios/*.yaml，但旧版本升级用户可能缺失该依赖，导致 studio 校验功能 import yamale 直接崩溃。

## 变更

新增幂等迁移脚本 scripts/migrations/v350-install-yamale.py，遵循 scripts/migrations/README.md 规范：

- 检测 yamale 是否已安装且版本 >= 5.0（importlib.util.find_spec + importlib.metadata 版本解析）
- 缺失/版本过低时用当前解释器（upgrade.py 保证为 .venv）执行 pip install yamale>=5.0
- 安装失败以非零码退出，upgrade.py 中止并提示；已安装则静默跳过（幂等）
- 不修改任何 git 跟踪文件，.applied 由 upgrade.py 自动维护

## 验证

- py_compile / LSP 诊断通过
- 临时 venv 实测：未安装 -> 成功安装（exit 0）；二次运行 -> 幂等跳过（exit 0）

Closes #283