### PR TITLE
feat(provider): Anthropic 适配器与 Provider 能力封装重构

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -32,6 +32,7 @@ from typing import Annotated, Any, Literal, TypedDict
 
 from api.agent import interaction
 from api.memory import LongTermMemory
+from api.session.const_store import flatten_content
 
 from langchain_core.language_models import BaseChatModel, LanguageModelInput
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
@@ -341,7 +342,7 @@ class CheckPendingNode:
         )
         if last_ai is not None:
             if sender:
-                await sender.answer(str(last_ai.content))
+                await sender.answer(flatten_content(last_ai.content))
             if getattr(last_ai, "content", None):
                 session.increment_messages()  # user+assistant 一对
 

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -18,7 +18,7 @@ from api.events import CallbackSender, TurnSender
 from api.callbacks.websocket_callback import WebSocketCallback
 from api.providers import FALLBACK_CTX
 from api.providers.manager import get_manager, ProviderManager
-from api.session.const_store import save_const_session, serialize_messages
+from api.session.const_store import flatten_content, save_const_session, serialize_messages
 from api.session.manager import PendingMessage, SessionState
 from api.memory.short_term import get_checkpointer
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -93,12 +93,10 @@ def _get_final_answer(event: dict[str, Any]) -> str:
     if not messages:
         return ""
     raw_final_answer = messages[-1]  # 最后一条message为Final Answer
-    final_answer = (
-        raw_final_answer.content
-        if hasattr(raw_final_answer, "content")
-        else str(raw_final_answer)
-    )
-    return final_answer
+    if hasattr(raw_final_answer, "content"):
+        # Anthropic 的 content 是 blocks list，需展平为纯文本
+        return flatten_content(raw_final_answer.content)
+    return str(raw_final_answer)
 
 
 # ── 排队消息合并 ──────────────────────────────────────────
@@ -259,7 +257,11 @@ async def _stream_turn(
             messages = await session.get_messages()
             if messages:
                 last = messages[-1]
-                candidate = last.content if hasattr(last, "content") else str(last)
+                candidate = (
+                    flatten_content(last.content)
+                    if hasattr(last, "content")
+                    else str(last)
+                )
                 if candidate:
                     final_answer = candidate
         except Exception:

--- a/api/callbacks/websocket_callback.py
+++ b/api/callbacks/websocket_callback.py
@@ -9,7 +9,53 @@ from langchain_core.messages import ToolMessage
 from langchain_core.outputs import LLMResult
 
 from api.events import CallbackSender
+from api.utils.logger import get_logger
 from .tool_extractors import _dispatch
+
+_log = get_logger("websocket_callback")
+
+
+def _extract_block_token(token: Any) -> tuple[str, str]:
+    """从块式 token 中提取 (text, thinking) 纯文本。
+
+    部分 Anthropic 适配模型（如 Kimi K3）把流式 content blocks 原样透传为
+    ``on_llm_new_token`` 的 token：可能是 JSON 字符串（``[{"type":"thinking",...}]``）
+    或 Python list。这里统一解析并拆出 text 块与 thinking 块的正文。
+
+    Returns:
+        ``(text, thinking)``。两者都为空表示 token 不是块式结构（普通文本 token），
+        调用方应走原有逻辑。
+    """
+    blocks: list | None = None
+    if isinstance(token, list):
+        blocks = token
+    elif isinstance(token, str) and token.lstrip().startswith("["):
+        try:
+            parsed = json.loads(token)
+        except (json.JSONDecodeError, TypeError):
+            return "", ""
+        if isinstance(parsed, list):
+            blocks = parsed
+        elif isinstance(parsed, str):
+            # JSON 字符串字面量（如 `"hello"`）当作普通文本
+            return parsed, ""
+        else:
+            return "", ""
+
+    if blocks is None:
+        return "", ""
+
+    text_parts: list[str] = []
+    thinking_parts: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "text" and isinstance(block.get("text"), str):
+            text_parts.append(block["text"])
+        elif btype == "thinking" and isinstance(block.get("thinking"), str):
+            thinking_parts.append(block["thinking"])
+    return "".join(text_parts), "".join(thinking_parts)
 
 
 def _extract_content(output: Any) -> str:
@@ -72,8 +118,21 @@ class WebSocketCallback(BaseCallbackHandler):
         await self._sender.thinking_start(time.time())
 
     async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
-        # 思考模型流式期间 content 为空（思考文字在 reasoning_content，LangChain 默认丢弃），
-        # 以空 token chunk 计数作为思考进度推给前端；不保存、不展示思考明文。
+        # 归一化块式 token：部分 Anthropic 适配模型（如 Kimi K3）把 content blocks
+        # （thinking/text）原样透传为 token（JSON 字符串或 list）。这里解析并提取：
+        #   - text 块    → 正常 token 事件（流式正文）
+        #   - thinking 块 → thinking_token 计数（进度，不展示思考明文，与既有策略一致）
+        # 普通字符串 token 原样转发。
+        text, thinking = _extract_block_token(token)
+        if thinking:
+            self._thinking_count += 1
+            await self._sender.thinking_token(self._thinking_count)
+        if text:
+            await self._sender.token(text)
+            return
+        if thinking:
+            return
+        # 非块式 token：维持原有逻辑（空 chunk 计思考进度，非空发正文）
         if not token:
             self._thinking_count += 1
             await self._sender.thinking_token(self._thinking_count)

--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -77,6 +77,21 @@ class Provider(ABC):
         """验证提供商 API 连接是否正常。"""
         ...
 
+    @abstractmethod
+    async def list_models(self) -> list[str]:
+        """拉取该提供商可用模型的 ID 列表（配置向导与模型重新发现用）。"""
+        ...
+
+    # ── 能力（子类按需覆盖）──────────────────────────────
+
+    def apply_thinking(self, kwargs: dict, enabled: bool) -> dict:
+        """按需注入思考模式参数，返回注入后的 kwargs。
+
+        支持思考模式的提供商覆盖此方法；默认实现不注入任何参数
+        （如 Anthropic 原生 API v1 暂不启用其思考模式，ChatAnthropic 默认不思考）。
+        """
+        return kwargs
+
 
 def build_provider(config: ProviderConfig) -> Provider:
     """按 provider_type 分发构建 Provider 实例。

--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -14,7 +14,7 @@ class ProviderConfig:
     """单个 LLM 提供商的配置，对应 providers.yaml 中的一项。"""
 
     id: str
-    provider_type: str  # 如 "openai"、"openrouter"、"deepseek" 等 OpenAI 兼容 API
+    provider_type: str  # 如 "openai"、"openrouter"、"deepseek" 等 OpenAI 兼容 API，或 "anthropic"
     label: str
     api_key: str
     base_url: str
@@ -76,3 +76,17 @@ class Provider(ABC):
     async def check_health(self) -> HealthStatus:
         """验证提供商 API 连接是否正常。"""
         ...
+
+
+def build_provider(config: ProviderConfig) -> Provider:
+    """按 provider_type 分发构建 Provider 实例。
+
+    anthropic → AnthropicProvider；其余（openai/openrouter 等 OpenAI 兼容）→ OpenAIProvider。
+    """
+    if config.provider_type == "anthropic":
+        from api.providers.anthropic_provider import AnthropicProvider
+
+        return AnthropicProvider(config)
+    from api.providers.openai_provider import OpenAIProvider
+
+    return OpenAIProvider(config)

--- a/api/providers/anthropic_provider.py
+++ b/api/providers/anthropic_provider.py
@@ -1,0 +1,49 @@
+"""Anthropic 官方 API（含兼容代理）的 Provider 实现。"""
+
+from typing import Any
+
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from api.providers import HealthStatus, Provider
+
+# Anthropic SDK 默认端点（路径如 /v1/messages、/v1/models 由 SDK 追加）。
+# 不能省略 base_url 依赖 SDK 默认值——ChatAnthropic 与 AsyncAnthropic 都会读取
+# ANTHROPIC_BASE_URL 环境变量（本机即被设为 DeepSeek 的 Anthropic 兼容代理），
+# 必须显式传官方端点才能保证"留空 = 官方 API"。
+DEFAULT_BASE_URL = "https://api.anthropic.com"
+
+
+class AnthropicProvider(Provider):
+    """适配 Anthropic 官方 API 的提供商（原生 Messages API，非 OpenAI 兼容协议）。"""
+
+    def create_llm(self, model: str, **kwargs: Any) -> BaseChatModel:
+        from langchain_anthropic import ChatAnthropic
+
+        return ChatAnthropic(
+            model=model,
+            api_key=self.config.api_key,
+            base_url=self.config.base_url or DEFAULT_BASE_URL,
+            **kwargs,
+        )
+
+    async def check_health(self) -> HealthStatus:
+        import time
+
+        from anthropic import AsyncAnthropic
+
+        start = time.monotonic()
+        try:
+            client = AsyncAnthropic(
+                api_key=self.config.api_key,
+                base_url=self.config.base_url or DEFAULT_BASE_URL,
+            )
+            await client.models.list()
+            elapsed = (time.monotonic() - start) * 1000
+            return HealthStatus(status="ok", latency_ms=round(elapsed, 1))
+        except Exception as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            return HealthStatus(
+                status="error",
+                latency_ms=round(elapsed, 1),
+                detail=str(exc),
+            )

--- a/api/providers/anthropic_provider.py
+++ b/api/providers/anthropic_provider.py
@@ -14,7 +14,11 @@ DEFAULT_BASE_URL = "https://api.anthropic.com"
 
 
 class AnthropicProvider(Provider):
-    """适配 Anthropic 官方 API 的提供商（原生 Messages API，非 OpenAI 兼容协议）。"""
+    """适配 Anthropic 官方 API 的提供商（原生 Messages API，非 OpenAI 兼容协议）。
+
+    ``apply_thinking`` 沿用基类默认（不注入任何参数）：v1 暂不启用其思考模式，
+    ChatAnthropic 默认不思考。
+    """
 
     def create_llm(self, model: str, **kwargs: Any) -> BaseChatModel:
         from langchain_anthropic import ChatAnthropic
@@ -29,14 +33,9 @@ class AnthropicProvider(Provider):
     async def check_health(self) -> HealthStatus:
         import time
 
-        from anthropic import AsyncAnthropic
-
         start = time.monotonic()
         try:
-            client = AsyncAnthropic(
-                api_key=self.config.api_key,
-                base_url=self.config.base_url or DEFAULT_BASE_URL,
-            )
+            client = self._async_client()
             await client.models.list()
             elapsed = (time.monotonic() - start) * 1000
             return HealthStatus(status="ok", latency_ms=round(elapsed, 1))
@@ -47,3 +46,16 @@ class AnthropicProvider(Provider):
                 latency_ms=round(elapsed, 1),
                 detail=str(exc),
             )
+
+    async def list_models(self) -> list[str]:
+        client = self._async_client()
+        models = await client.models.list()
+        return sorted(m.id for m in models.data)
+
+    def _async_client(self) -> Any:
+        from anthropic import AsyncAnthropic
+
+        return AsyncAnthropic(
+            api_key=self.config.api_key,
+            base_url=self.config.base_url or DEFAULT_BASE_URL,
+        )

--- a/api/providers/manager.py
+++ b/api/providers/manager.py
@@ -123,12 +123,11 @@ class ProviderManager:
         """获取默认 provider 的 LLM（惰性缓存）。无可用 provider 时返回 None。
 
         Args:
-            thinking_enabled: 是否对默认 LLM 注入 ``extra_body`` 开启思考模式。
-                默认 ``False``（关闭），规避 DeepSeek 思考模式下工具调用必须完整
-                回传 reasoning_content（思维链）否则 400 的问题；主对话轮次等需要
-                思考模式的场景传 ``True`` 保持开启。仅对 OpenAI 兼容提供商注入——
-                其他厂商（如 Anthropic）不走 ``extra_body``，且 v1 暂不启用其
-                思考模式（ChatAnthropic 默认不思考）。
+            thinking_enabled: 是否对默认 LLM 开启思考模式。通过 ``Provider.apply_thinking``
+                注入厂商对应的思考参数：OpenAI 兼容提供商走 ``extra_body.thinking``，
+                不支持的提供商（如 Anthropic v1）不注入任何参数。默认 ``False``（关闭），
+                规避 DeepSeek 思考模式下工具调用必须完整回传 reasoning_content（思维链）
+                否则 400 的问题；主对话轮次等需要思考模式的场景传 ``True`` 保持开启。
             temperature: LLM 采样温度，默认 0.7。
             streaming: 是否流式，默认 True。
 
@@ -142,11 +141,7 @@ class ProviderManager:
         key = (thinking_enabled, temperature, streaming)
         if key in self._default_llm_cache:
             return self._default_llm_cache[key]
-        if provider.config.provider_type != "anthropic":
-            thinking = {"type": "enabled" if thinking_enabled else "disabled"}
-            extra = dict(kwargs.get("extra_body") or {})
-            extra["thinking"] = thinking
-            kwargs["extra_body"] = extra
+        kwargs = provider.apply_thinking(kwargs, thinking_enabled)
         llm = provider.create_llm(
             provider.default_model,
             temperature=temperature,

--- a/api/providers/manager.py
+++ b/api/providers/manager.py
@@ -126,8 +126,9 @@ class ProviderManager:
             thinking_enabled: 是否对默认 LLM 注入 ``extra_body`` 开启思考模式。
                 默认 ``False``（关闭），规避 DeepSeek 思考模式下工具调用必须完整
                 回传 reasoning_content（思维链）否则 400 的问题；主对话轮次等需要
-                思考模式的场景传 ``True`` 保持开启。无论厂商一律注入——OpenAI
-                兼容服务端对未知的顶层 extra_body 字段通常忽略。
+                思考模式的场景传 ``True`` 保持开启。仅对 OpenAI 兼容提供商注入——
+                其他厂商（如 Anthropic）不走 ``extra_body``，且 v1 暂不启用其
+                思考模式（ChatAnthropic 默认不思考）。
             temperature: LLM 采样温度，默认 0.7。
             streaming: 是否流式，默认 True。
 
@@ -141,10 +142,11 @@ class ProviderManager:
         key = (thinking_enabled, temperature, streaming)
         if key in self._default_llm_cache:
             return self._default_llm_cache[key]
-        thinking = {"type": "enabled" if thinking_enabled else "disabled"}
-        extra = dict(kwargs.get("extra_body") or {})
-        extra["thinking"] = thinking
-        kwargs["extra_body"] = extra
+        if provider.config.provider_type != "anthropic":
+            thinking = {"type": "enabled" if thinking_enabled else "disabled"}
+            extra = dict(kwargs.get("extra_body") or {})
+            extra["thinking"] = thinking
+            kwargs["extra_body"] = extra
         llm = provider.create_llm(
             provider.default_model,
             temperature=temperature,
@@ -189,9 +191,9 @@ class ProviderManager:
 
     @staticmethod
     def _build_provider(config: ProviderConfig) -> Provider:
-        from api.providers.openai_provider import OpenAIProvider
+        from api.providers import build_provider
 
-        return OpenAIProvider(config)
+        return build_provider(config)
 
 
 # ── 模块级单例 ──────────────────────────────────────────────

--- a/api/providers/openai_provider.py
+++ b/api/providers/openai_provider.py
@@ -1,5 +1,7 @@
 """OpenAI 兼容 API 的通用 Provider 实现。"""
 
+from typing import Any
+
 from langchain_core.language_models.chat_models import BaseChatModel
 
 from api.providers import HealthStatus, Provider
@@ -8,7 +10,7 @@ from api.providers import HealthStatus, Provider
 class OpenAIProvider(Provider):
     """适配所有 OpenAI 兼容 API 的提供商（DeepSeek / Qwen / Kimi 等）。"""
 
-    def create_llm(self, model: str, **kwargs) -> BaseChatModel:
+    def create_llm(self, model: str, **kwargs: Any) -> BaseChatModel:
         from langchain_openai import ChatOpenAI
 
         return ChatOpenAI(
@@ -18,17 +20,20 @@ class OpenAIProvider(Provider):
             **kwargs,
         )
 
+    def apply_thinking(self, kwargs: dict, enabled: bool) -> dict:
+        """OpenAI 兼容提供商通过 ``extra_body.thinking`` 开启/关闭思考模式。"""
+        thinking = {"type": "enabled" if enabled else "disabled"}
+        extra = dict(kwargs.get("extra_body") or {})
+        extra["thinking"] = thinking
+        kwargs["extra_body"] = extra
+        return kwargs
+
     async def check_health(self) -> HealthStatus:
         import time
 
-        from openai import AsyncOpenAI
-
         start = time.monotonic()
         try:
-            client = AsyncOpenAI(
-                api_key=self.config.api_key,
-                base_url=self.config.base_url,
-            )
+            client = self._async_client()
             await client.models.list()
             elapsed = (time.monotonic() - start) * 1000
             return HealthStatus(status="ok", latency_ms=round(elapsed, 1))
@@ -39,3 +44,16 @@ class OpenAIProvider(Provider):
                 latency_ms=round(elapsed, 1),
                 detail=str(exc),
             )
+
+    async def list_models(self) -> list[str]:
+        client = self._async_client()
+        models = await client.models.list()
+        return sorted(m.id for m in models.data)
+
+    def _async_client(self) -> Any:
+        from openai import AsyncOpenAI
+
+        return AsyncOpenAI(
+            api_key=self.config.api_key,
+            base_url=self.config.base_url,
+        )

--- a/api/providers/vision.py
+++ b/api/providers/vision.py
@@ -61,9 +61,9 @@ async def detect_vision_capabilities(config: ProviderConfig) -> dict[str, bool]:
     if not config.models:
         return {}
 
-    from api.providers.openai_provider import OpenAIProvider
+    from api.providers import build_provider
 
-    provider = OpenAIProvider(config)
+    provider = build_provider(config)
 
     tasks = [
         test_model_vision(provider, model, IMAGE_PATH) for model in config.models

--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -1,12 +1,13 @@
 """REST API — 提供商 CRUD 与连接测试。"""
 
+from typing import Any
+
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from api.providers import ProviderConfig
+from api.providers import Provider, ProviderConfig, build_provider
 from api.providers.enrich import enrich_provider_config
 from api.providers.manager import ProviderManager, get_manager
-from api.providers.openai_provider import OpenAIProvider
 
 router = APIRouter()
 
@@ -41,6 +42,22 @@ class TestConnectionBody(BaseModel):
 
 
 # ── HELPERS ─────────────────────────────────────────────
+
+
+def _build_models_client(provider_type: str, api_key: str, base_url: str) -> Any:
+    """按 provider_type 构建可调 ``models.list()`` 的异步客户端。
+
+    anthropic → ``anthropic.AsyncAnthropic``；其余 → ``openai.AsyncOpenAI``。
+    """
+    if provider_type == "anthropic":
+        from anthropic import AsyncAnthropic
+
+        from api.providers.anthropic_provider import DEFAULT_BASE_URL
+
+        return AsyncAnthropic(api_key=api_key, base_url=base_url or DEFAULT_BASE_URL)
+    from openai import AsyncOpenAI
+
+    return AsyncOpenAI(api_key=api_key, base_url=base_url)
 
 
 def _require_manager() -> ProviderManager:
@@ -158,9 +175,9 @@ async def delete_provider(provider_id: str, request: Request) -> dict:
 # ── 连接测试与模型发现 ─────────────────────────────────
 
 
-def _build_temp_provider(body: TestConnectionBody) -> OpenAIProvider:
+def _build_temp_provider(body: TestConnectionBody) -> Provider:
     """根据请求体凭据临时创建 provider 用于测试。"""
-    return OpenAIProvider(
+    return build_provider(
         ProviderConfig(
             id="_test_",
             provider_type=body.provider_type,
@@ -202,14 +219,15 @@ async def test_existing_provider(provider_id: str, request: Request) -> dict:
 @router.post("/providers/discover-models")
 async def discover_models(body: TestConnectionBody) -> dict:
     """根据凭据拉取模型列表（前端向导步骤 3）。"""
-    from openai import AsyncOpenAI
+    from api.providers.model_context_windows import lookup_context_window
 
     try:
-        client = AsyncOpenAI(api_key=body.api_key, base_url=body.base_url)
+        client = _build_models_client(
+            body.provider_type, body.api_key, body.base_url
+        )
         models = await client.models.list()
         model_names = sorted(m.id for m in models.data)
 
-        from api.providers.model_context_windows import lookup_context_window
         model_context_windows: dict[str, int] = {}
         for m in models.data:
             ctx = lookup_context_window(m.id)
@@ -227,7 +245,6 @@ async def discover_models_for_existing(provider_id: str, request: Request) -> di
 
     重新拉取后，如果原来的 default_model 已不存在，自动置 None 并返回警告。
     """
-    from openai import AsyncOpenAI
     from api.providers.model_context_windows import lookup_context_window
 
     mgr = _require_manager()
@@ -236,7 +253,9 @@ async def discover_models_for_existing(provider_id: str, request: Request) -> di
         raise HTTPException(status_code=404, detail="Provider not found")
 
     try:
-        client = AsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
+        client = _build_models_client(
+            config.provider_type, config.api_key, config.base_url
+        )
         models = await client.models.list()
         model_names = sorted(m.id for m in models.data)
 

--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -1,7 +1,5 @@
 """REST API — 提供商 CRUD 与连接测试。"""
 
-from typing import Any
-
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
@@ -42,22 +40,6 @@ class TestConnectionBody(BaseModel):
 
 
 # ── HELPERS ─────────────────────────────────────────────
-
-
-def _build_models_client(provider_type: str, api_key: str, base_url: str) -> Any:
-    """按 provider_type 构建可调 ``models.list()`` 的异步客户端。
-
-    anthropic → ``anthropic.AsyncAnthropic``；其余 → ``openai.AsyncOpenAI``。
-    """
-    if provider_type == "anthropic":
-        from anthropic import AsyncAnthropic
-
-        from api.providers.anthropic_provider import DEFAULT_BASE_URL
-
-        return AsyncAnthropic(api_key=api_key, base_url=base_url or DEFAULT_BASE_URL)
-    from openai import AsyncOpenAI
-
-    return AsyncOpenAI(api_key=api_key, base_url=base_url)
 
 
 def _require_manager() -> ProviderManager:
@@ -222,17 +204,14 @@ async def discover_models(body: TestConnectionBody) -> dict:
     from api.providers.model_context_windows import lookup_context_window
 
     try:
-        client = _build_models_client(
-            body.provider_type, body.api_key, body.base_url
-        )
-        models = await client.models.list()
-        model_names = sorted(m.id for m in models.data)
+        provider = _build_temp_provider(body)
+        model_names = await provider.list_models()
 
         model_context_windows: dict[str, int] = {}
-        for m in models.data:
-            ctx = lookup_context_window(m.id)
+        for name in model_names:
+            ctx = lookup_context_window(name)
             if ctx:
-                model_context_windows[m.id] = ctx
+                model_context_windows[name] = ctx
 
         return {"models": model_names, "model_context_windows": model_context_windows}
     except Exception as exc:
@@ -253,18 +232,15 @@ async def discover_models_for_existing(provider_id: str, request: Request) -> di
         raise HTTPException(status_code=404, detail="Provider not found")
 
     try:
-        client = _build_models_client(
-            config.provider_type, config.api_key, config.base_url
-        )
-        models = await client.models.list()
-        model_names = sorted(m.id for m in models.data)
+        provider = build_provider(config)
+        model_names = await provider.list_models()
 
         # 从 OpenRouter 查找模型上下文窗口
         model_context_windows: dict[str, int] = {}
-        for m in models.data:
-            ctx = lookup_context_window(m.id)
+        for name in model_names:
+            ctx = lookup_context_window(name)
             if ctx:
-                model_context_windows[m.id] = ctx
+                model_context_windows[name] = ctx
 
         # 检查 default_model 是否还在新列表中（仅提示，不做保存）
         warning = None

--- a/api/routes/sessions.py
+++ b/api/routes/sessions.py
@@ -69,7 +69,7 @@ async def get_messages(session_id: str, request: Request) -> dict:
         msgs = []
     return {
         "session_id": session_id,
-        "messages": [{"role": m.type, "content": m.content} for m in msgs],
+        "messages": [{"role": m.type, "content": flatten_content(m.content)} for m in msgs],
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "langchain>=0.3.0",
     "langchain-openai>=0.3.0",
+    "langchain-anthropic>=1.4.3,<1.4.4",
     "langchain-mcp-adapters>=0.2.0",
     "langgraph>=0.2.0",
     "pydantic-settings>=2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 langchain>=0.3.0
 langchain-openai>=0.3.0
+langchain-anthropic>=1.4.3,<1.4.4
 langchain-mcp-adapters>=0.2.0
 langgraph>=0.2.0
 pydantic-settings>=2.0.0

--- a/tests/test_api/test_callback_token_normalize.py
+++ b/tests/test_api/test_callback_token_normalize.py
@@ -1,0 +1,94 @@
+"""WebSocketCallback token 归一化测试 — 块式 token（Kimi K3 等 Anthropic 适配模型）。
+
+部分模型把 content blocks（thinking/text）原样透传为 ``on_llm_new_token`` 的 token，
+本测试锁定：text 块 → token 事件、thinking 块 → thinking_token 计数、普通字符串原样转发。
+"""
+
+# 先经 app 正常入口初始化导入顺序，避免 api.events 循环导入
+import api.agent.turn  # noqa: F401
+
+from api.callbacks.websocket_callback import WebSocketCallback, _extract_block_token
+
+KIMI_THINKING = '[{"thinking":"用","type":"thinking","index":0}]'
+KIMI_TEXT = '[{"text":"晚上好！","type":"text","index":1}]'
+KIMI_TEXT_LIST = [{"text": "你好", "type": "text", "index": 1}]
+
+
+class TestExtractBlockToken:
+    def test_thinking_block_extracts_thinking(self) -> None:
+        assert _extract_block_token(KIMI_THINKING) == ("", "用")
+
+    def test_text_block_extracts_text(self) -> None:
+        assert _extract_block_token(KIMI_TEXT) == ("晚上好！", "")
+
+    def test_mixed_blocks_extract_both(self) -> None:
+        tok = '[{"thinking":"用","type":"thinking","index":0},{"text":"你好","type":"text","index":1}]'
+        assert _extract_block_token(tok) == ("你好", "用")
+
+    def test_list_input_extracts_text(self) -> None:
+        assert _extract_block_token(KIMI_TEXT_LIST) == ("你好", "")
+
+    def test_plain_string_returns_empty(self) -> None:
+        # 普通文本 token 非块式 → 返回空，走原有逻辑
+        assert _extract_block_token("普通文本") == ("", "")
+        assert _extract_block_token("") == ("", "")
+
+    def test_invalid_json_returns_empty(self) -> None:
+        assert _extract_block_token("not json [") == ("", "")
+
+
+class TestOnLlmNewToken:
+    class _FakeSender:
+        def __init__(self) -> None:
+            self.tokens: list[str] = []
+            self.thinking_counts: list[int] = []
+
+        async def token(self, token: str) -> None:
+            self.tokens.append(token)
+
+        async def thinking_token(self, count: int) -> None:
+            self.thinking_counts.append(count)
+
+    async def _run(self, token: str) -> tuple[list[str], list[int]]:
+        cb = WebSocketCallback(self._FakeSender())
+        sender = cb._sender
+        await cb.on_llm_new_token(token)
+        return sender.tokens, sender.thinking_counts
+
+    def test_text_block_emits_clean_token(self) -> None:
+        import asyncio
+
+        tokens, counts = asyncio.run(self._run(KIMI_TEXT))
+        assert tokens == ["晚上好！"]
+        assert counts == []
+
+    def test_thinking_block_emits_count_only(self) -> None:
+        import asyncio
+
+        tokens, counts = asyncio.run(self._run(KIMI_THINKING))
+        assert tokens == []
+        assert counts == [1]
+
+    def test_plain_string_emits_token(self) -> None:
+        import asyncio
+
+        tokens, counts = asyncio.run(self._run("你好"))
+        assert tokens == ["你好"]
+        assert counts == []
+
+    def test_empty_token_emits_thinking_count(self) -> None:
+        import asyncio
+
+        tokens, counts = asyncio.run(self._run(""))
+        assert tokens == []
+        assert counts == [1]
+
+    def test_thinking_count_accumulates(self) -> None:
+        import asyncio
+
+        cb = WebSocketCallback(self._FakeSender())
+        sender = cb._sender
+        asyncio.run(cb.on_llm_new_token(KIMI_THINKING))
+        asyncio.run(cb.on_llm_new_token(KIMI_THINKING))
+        asyncio.run(cb.on_llm_new_token(KIMI_THINKING))
+        assert sender.thinking_counts == [1, 2, 3]

--- a/tests/test_api/test_message_flatten.py
+++ b/tests/test_api/test_message_flatten.py
@@ -1,0 +1,98 @@
+"""消息 content 展平回归测试 — 修复 Anthropic blocks list 在前端渲染为 [object Object]。
+
+Anthropic 的 ``AIMessage.content`` 是 blocks list（``[{"type":"text","text":...}, ...]``），
+直接返回给前端会被 ``messagesToTurns`` 当作数组赋给 ``finalAnswer`` 渲染成 ``[object Object]``。
+本测试锁定 GET /sessions/{id}/messages 与轮末 answer 的展平行为。
+"""
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from api.agent.turn import _get_final_answer
+from api.session.const_store import flatten_content
+
+# Anthropic 风格 blocks content（含 tool_use 块，模拟带工具 agent 的输出）
+ANTHROPIC_BLOCKS = [
+    {"type": "text", "text": "你好"},
+    {
+        "type": "tool_use",
+        "id": "toolu_01",
+        "name": "search",
+        "input": {"query": "Sonetto"},
+    },
+    {"type": "text", "text": "，这是答案。"},
+]
+
+
+class TestFlattenContent:
+    def test_anthropic_blocks_extract_text_only(self) -> None:
+        # tool_use 块被忽略，text 块按序拼接
+        assert flatten_content(ANTHROPIC_BLOCKS) == "你好\n，这是答案。"
+
+    def test_single_text_block(self) -> None:
+        assert flatten_content([{"type": "text", "text": "Hello"}]) == "Hello"
+
+    def test_plain_string_passthrough(self) -> None:
+        assert flatten_content("Hello") == "Hello"
+
+    def test_empty_list(self) -> None:
+        assert flatten_content([]) == ""
+
+    def test_openai_style_content_unchanged(self) -> None:
+        # OpenAI/DeepSeek 的 content 是纯字符串，flatten 后必须原样返回
+        assert flatten_content("正常回答") == "正常回答"
+
+
+class TestGetFinalAnswerFlatten:
+    def test_anthropic_blocks_flattened_to_text(self) -> None:
+        event = {
+            "data": {"output": {"messages": [AIMessage(content=ANTHROPIC_BLOCKS)]}}
+        }
+        assert _get_final_answer(event) == "你好\n，这是答案。"
+
+    def test_openai_string_content_passthrough(self) -> None:
+        event = {
+            "data": {"output": {"messages": [AIMessage(content="正常回答")]}}
+        }
+        assert _get_final_answer(event) == "正常回答"
+
+    def test_no_messages_returns_empty(self) -> None:
+        assert _get_final_answer({"data": {"output": {"messages": []}}}) == ""
+
+
+class TestMessagesEndpointSerialization:
+    """GET /sessions/{id}/messages 必须返回展平后的字符串 content。"""
+
+    def _call(self, monkeypatch, msgs: list) -> list:
+        import api.routes.sessions as sessions_module
+
+        class _FakeSession:
+            def __init__(self, msgs):
+                self._msgs = msgs
+
+            async def get_messages(self) -> list:
+                return self._msgs
+
+        fake_manager = type("FakeManager", (), {"get": lambda self, sid: _FakeSession(msgs)})()
+        monkeypatch.setattr(sessions_module, "session_manager", fake_manager)
+
+        import asyncio
+
+        result = asyncio.run(sessions_module.get_messages("sid-1", request=None))
+        return result["messages"]
+
+    def test_anthropic_content_flattened(self, monkeypatch) -> None:
+        msgs = [
+            HumanMessage(content="用户问题"),
+            AIMessage(content=ANTHROPIC_BLOCKS),
+        ]
+        messages = self._call(monkeypatch, msgs)
+        assert messages[1]["content"] == "你好\n，这是答案。"
+        assert not isinstance(messages[1]["content"], list)
+
+    def test_openai_string_content_preserved(self, monkeypatch) -> None:
+        msgs = [
+            HumanMessage(content="用户问题"),
+            AIMessage(content="正常回答"),
+        ]
+        messages = self._call(monkeypatch, msgs)
+        assert messages[1]["content"] == "正常回答"

--- a/tests/test_api/test_providers.py
+++ b/tests/test_api/test_providers.py
@@ -1,0 +1,109 @@
+"""Provider 层单元测试 — build_provider 分发、thinking 门控、AnthropicProvider 构造。
+
+均为无网络测试：构造 Provider/LLM 不发起请求。
+"""
+
+from pathlib import Path
+
+import pytest
+
+from api.providers import ProviderConfig, build_provider
+from api.providers.anthropic_provider import DEFAULT_BASE_URL, AnthropicProvider
+from api.providers.manager import ProviderManager
+from api.providers.openai_provider import OpenAIProvider
+from api.providers.store import ProviderConfigStore
+
+
+def _config(**overrides: object) -> ProviderConfig:
+    base: dict[str, object] = {
+        "id": "test-provider",
+        "provider_type": "openai",
+        "label": "Test",
+        "api_key": "sk-test",
+        "base_url": "https://api.example.com/v1",
+        "models": ["test-model"],
+        "enabled": True,
+    }
+    base.update(overrides)
+    return ProviderConfig(**base)
+
+
+class TestBuildProvider:
+    def test_anthropic_type_returns_anthropic_provider(self) -> None:
+        assert isinstance(
+            build_provider(_config(provider_type="anthropic")), AnthropicProvider
+        )
+
+    def test_openai_type_returns_openai_provider(self) -> None:
+        assert isinstance(
+            build_provider(_config(provider_type="openai")), OpenAIProvider
+        )
+
+    def test_openrouter_type_returns_openai_provider(self) -> None:
+        # openrouter 也是 OpenAI 兼容协议，仍走 OpenAIProvider
+        assert isinstance(
+            build_provider(_config(provider_type="openrouter")), OpenAIProvider
+        )
+
+
+class TestAnthropicProviderCreateLlm:
+    def test_base_url_empty_uses_official_default(self) -> None:
+        provider = AnthropicProvider(_config(provider_type="anthropic", base_url=""))
+        llm = provider.create_llm("claude-sonnet-5")
+        assert llm.model == "claude-sonnet-5"
+        assert llm.anthropic_api_url == DEFAULT_BASE_URL
+        assert llm.anthropic_api_key.get_secret_value() == "sk-test"
+
+    def test_custom_base_url_is_passed_through(self) -> None:
+        provider = AnthropicProvider(
+            _config(provider_type="anthropic", base_url="https://proxy.example.com")
+        )
+        llm = provider.create_llm("claude-sonnet-5")
+        assert llm.anthropic_api_url == "https://proxy.example.com"
+
+
+class TestGetDefaultLlmThinkingGate:
+    def _make_manager(self, tmp_path: Path, provider_type: str) -> ProviderManager:
+        store = ProviderConfigStore(tmp_path / "providers.yaml")
+        store.save(
+            _config(
+                provider_type=provider_type,
+                id="p",
+                models=["test-model"],
+                is_default_provider=True,
+                default_model="test-model",
+            )
+        )
+        manager = ProviderManager(store)
+        manager.load_all()
+        return manager
+
+    def test_anthropic_does_not_get_extra_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = self._make_manager(tmp_path, "anthropic")
+        captured: dict[str, object] = {}
+
+        def fake_create_llm(self: object, model: str, **kwargs: object) -> object:
+            captured.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(AnthropicProvider, "create_llm", fake_create_llm)
+        manager.get_default_llm(thinking_enabled=True)
+        assert "extra_body" not in captured
+
+    def test_openai_gets_thinking_extra_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = self._make_manager(tmp_path, "openai")
+        captured: dict[str, object] = {}
+
+        def fake_create_llm(self: object, model: str, **kwargs: object) -> object:
+            captured.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(OpenAIProvider, "create_llm", fake_create_llm)
+        manager.get_default_llm(thinking_enabled=True)
+        thinking = captured.get("extra_body", {})
+        assert isinstance(thinking, dict)
+        assert thinking.get("thinking") == {"type": "enabled"}

--- a/tests/test_api/test_providers.py
+++ b/tests/test_api/test_providers.py
@@ -1,8 +1,9 @@
-"""Provider 层单元测试 — build_provider 分发、thinking 门控、AnthropicProvider 构造。
+"""Provider 层单元测试 — build_provider 分发、thinking 能力、模型发现、AnthropicProvider 构造。
 
-均为无网络测试：构造 Provider/LLM 不发起请求。
+均为无网络测试：构造 Provider/LLM 不发起请求，SDK 客户端用 monkeypatch 模拟。
 """
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -107,3 +108,101 @@ class TestGetDefaultLlmThinkingGate:
         thinking = captured.get("extra_body", {})
         assert isinstance(thinking, dict)
         assert thinking.get("thinking") == {"type": "enabled"}
+
+
+class TestApplyThinking:
+    """apply_thinking 能力方法：OpenAI 注入 extra_body，Anthropic 无操作。"""
+
+    def test_openai_enabled_injects_extra_body(self) -> None:
+        provider = OpenAIProvider(_config())
+        assert provider.apply_thinking({}, True) == {
+            "extra_body": {"thinking": {"type": "enabled"}}
+        }
+
+    def test_openai_disabled_injects_disabled(self) -> None:
+        provider = OpenAIProvider(_config())
+        assert provider.apply_thinking({}, False) == {
+            "extra_body": {"thinking": {"type": "disabled"}}
+        }
+
+    def test_openai_preserves_existing_extra_body(self) -> None:
+        provider = OpenAIProvider(_config())
+        out = provider.apply_thinking({"extra_body": {"other": 1}}, True)
+        assert out == {"extra_body": {"other": 1, "thinking": {"type": "enabled"}}}
+
+    def test_anthropic_is_noop(self) -> None:
+        provider = AnthropicProvider(_config(provider_type="anthropic"))
+        kwargs = {"extra_body": {"thinking": {"type": "enabled"}}, "temperature": 0.7}
+        # 原对象原样返回，不注入也不修改
+        assert provider.apply_thinking(kwargs, True) is kwargs
+
+
+class _FakeModel:
+    def __init__(self, model_id: str) -> None:
+        self.id = model_id
+
+
+class _FakeModelsList:
+    def __init__(self, ids: list[str]) -> None:
+        self.data = [_FakeModel(i) for i in ids]
+
+    async def list(self) -> "_FakeModelsList":
+        return self
+
+
+class _FakeModelsClient:
+    """模拟 openai/anthropic SDK 异步客户端（仅需 models.list()）。"""
+
+    def __init__(self, **kwargs: object) -> None:
+        self.models = _FakeModelsList(["b-model", "a-model"])
+
+
+class TestListModels:
+    """list_models：返回排序后的模型 ID，SDK 客户端按厂商类型构建。"""
+
+    def test_openai_returns_sorted_ids(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_client(**kwargs: object) -> _FakeModelsClient:
+            captured.update(kwargs)
+            return _FakeModelsClient()
+
+        monkeypatch.setattr("openai.AsyncOpenAI", fake_client)
+        provider = OpenAIProvider(_config())
+        assert asyncio.run(provider.list_models()) == ["a-model", "b-model"]
+        assert captured == {
+            "api_key": "sk-test",
+            "base_url": "https://api.example.com/v1",
+        }
+
+    def test_anthropic_defaults_to_official_base_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_client(**kwargs: object) -> _FakeModelsClient:
+            captured.update(kwargs)
+            return _FakeModelsClient()
+
+        monkeypatch.setattr("anthropic.AsyncAnthropic", fake_client)
+        provider = AnthropicProvider(_config(provider_type="anthropic", base_url=""))
+        assert asyncio.run(provider.list_models()) == ["a-model", "b-model"]
+        assert captured["base_url"] == DEFAULT_BASE_URL
+
+    def test_anthropic_passes_custom_base_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_client(**kwargs: object) -> _FakeModelsClient:
+            captured.update(kwargs)
+            return _FakeModelsClient()
+
+        monkeypatch.setattr("anthropic.AsyncAnthropic", fake_client)
+        provider = AnthropicProvider(
+            _config(provider_type="anthropic", base_url="https://proxy.example.com")
+        )
+        assert asyncio.run(provider.list_models()) == ["a-model", "b-model"]
+        assert captured["base_url"] == "https://proxy.example.com"

--- a/web/src/composables/useChat.handlers.ts
+++ b/web/src/composables/useChat.handlers.ts
@@ -8,24 +8,93 @@ import type { ServerEvent, ChatTurn, TokenEvent, ThinkingTokenEvent, AnswerEvent
 /** 事件路由处理器签名（turn 已由调用方守卫保证存在）。 */
 type TurnEventHandler = (ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent) => void
 
+/**
+ * 从块式 token 中提取纯文本（与后端 websocket_callback._extract_block_token 对应）。
+ *
+ * 部分 Anthropic 适配模型（如 Kimi K3）把流式 content blocks 透传为 token：
+ * JSON 字符串（如 `[{"type":"thinking","thinking":"用","index":0}]`）或数组。
+ * 这里解析并提取 text 块正文（`type:"text"`）与 thinking 块正文（`type:"thinking"`）。
+ *
+ * @returns `{ text, thinking }` — 两者都为空表示 token 不是块式结构。
+ */
+function extractBlockToken(token: unknown): { text: string; thinking: string } {
+  let blocks: unknown[] | null = null
+  if (Array.isArray(token)) {
+    blocks = token
+  } else if (typeof token === 'string' && token.trimStart().startsWith('[')) {
+    try {
+      const parsed = JSON.parse(token) as unknown
+      if (Array.isArray(parsed)) {
+        blocks = parsed
+      } else if (typeof parsed === 'string') {
+        // JSON 字符串字面量（如 `"hello"`）当作普通文本
+        return { text: parsed, thinking: '' }
+      } else {
+        return { text: '', thinking: '' }
+      }
+    } catch {
+      return { text: '', thinking: '' }
+    }
+  }
+  if (!blocks) return { text: '', thinking: '' }
+
+  let text = ''
+  let thinking = ''
+  for (const block of blocks) {
+    if (!block || typeof block !== 'object') continue
+    const b = block as { type?: unknown; text?: unknown; thinking?: unknown }
+    if (b.type === 'text' && typeof b.text === 'string') {
+      text += b.text
+    } else if (b.type === 'thinking' && typeof b.thinking === 'string') {
+      thinking += b.thinking
+    }
+  }
+  return { text, thinking }
+}
+
 /** thinking_start：压入思考块。 */
 function handleThinkingStart(ch: SessionChannel, _sid: string, turn: ChatTurn, _event: ServerEvent): void {
+  // 调试：确认流式思考块何时创建（排查是否有 token 在 thinking 块之前到达）
+  console.log('[useChat:thinking_start] 创建思考块, turn.events.length=', turn.events.length)
   turn.events.push({ kind: 'thinking', thinkingCount: 0, tokens: '', done: false, becameAnswer: false })
 }
 
 /** thinking_token：更新最后一个思考块的思考进度计数。 */
 function handleThinkingToken(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
   const lastThink = findLastThinking(turn.events)
+  const count = (event as ThinkingTokenEvent).payload.count
+  // 调试：确认 thinking 计数到达（用于排查空 token chunk 计数是否正常触发）
+  if (typeof count !== 'number' || count % 10 === 0) {
+    console.log('[useChat:thinking_token] count=', count, 'typeof=', typeof count, 'hasThinkingBlock=', !!lastThink)
+  }
   if (lastThink) {
-    lastThink.thinkingCount = (event as ThinkingTokenEvent).payload.count
+    lastThink.thinkingCount = count
   }
 }
 
 /** token：追加正文到最后一个思考块。 */
 function handleToken(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const rawToken = (event as TokenEvent).payload.token
   const lastThink = findLastThinking(turn.events)
-  if (lastThink) {
-    lastThink.tokens += (event as TokenEvent).payload.token
+  // 调试：定位 [object Object] 来源——payload.token 必须是字符串。
+  // 若 typeof 不是 string，说明后端把结构化对象（如 content blocks 数组）当作 token 推送。
+  if (typeof rawToken !== 'string' || rawToken === '[object Object]') {
+    let serialized: string
+    try {
+      serialized = JSON.stringify(rawToken)
+    } catch {
+      serialized = `[unserializable:${typeof rawToken}]`
+    }
+    console.warn('[useChat:token] ⚠️ token 非字符串！typeof=', typeof rawToken, 'value=', serialized?.slice(0, 300), 'hasThinkingBlock=', !!lastThink)
+  }
+  // 归一化块式 token（Kimi K3 等 Anthropic 适配模型）：提取 text 块正文，
+  // thinking 块正文不展示（与后端"不展示思考明文"策略一致）。
+  const { text: blockText } = extractBlockToken(rawToken)
+  const token = blockText !== ''
+    ? blockText
+    : (typeof rawToken === 'string' ? rawToken : '')
+  if (lastThink && token) {
+    lastThink.tokens += token
   }
 }
 
@@ -95,11 +164,24 @@ function handleToolError(ch: SessionChannel, _sid: string, turn: ChatTurn, event
 
 /** answer：标记思考块为 becameAnswer，设置 finalAnswer。 */
 function handleAnswer(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const content = (event as AnswerEvent).payload.content
+  // 调试：answer 必须是字符串，否则 MessageBubble 会渲染 [object Object]
+  if (typeof content !== 'string') {
+    let serialized: string
+    try {
+      serialized = JSON.stringify(content)
+    } catch {
+      serialized = `[unserializable:${typeof content}]`
+    }
+    console.warn('[useChat:answer] ⚠️ content 非字符串！typeof=', typeof content, 'value=', serialized?.slice(0, 500))
+  }
   const lastThink = findLastThinking(turn.events)
   if (lastThink) {
     lastThink.becameAnswer = true
   }
-  turn.finalAnswer = (event as AnswerEvent).payload.content
+  turn.finalAnswer = typeof content === 'string' ? content : (() => {
+    try { return JSON.stringify(content) } catch { return String(content) }
+  })()
 }
 
 /** done：finalize 当前轮次，持久化，刷新会话列表。 */

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -228,7 +228,20 @@ export const useChatStore = defineStore('chat', () => {
               becameAnswer: false,
             } as ThinkingBlock)
           }
-          finalAnswer = m.content
+          // 调试 + 防御：后端必须返回字符串 content，若为对象则记录并字符串化，
+          // 避免渲染为 [object Object]
+          if (typeof m.content !== 'string') {
+            let serialized: string
+            try {
+              serialized = JSON.stringify(m.content)
+            } catch {
+              serialized = `[unserializable:${typeof m.content}]`
+            }
+            console.warn('[messagesToTurns] ⚠️ ai content 非字符串（role=%s）typeof=%s value=%s', m.role, typeof m.content, serialized?.slice(0, 300))
+          }
+          finalAnswer = typeof m.content === 'string' ? m.content : (() => {
+            try { return JSON.stringify(m.content) } catch { return String(m.content) }
+          })()
         }
         i++
       }
@@ -327,6 +340,19 @@ export const useChatStore = defineStore('chat', () => {
       try {
         const msg: ServerEvent = JSON.parse(event.data)
         console.debug('[chatStore] WS onmessage: sid=%s, type=%s', sid, msg.type)
+        // 调试：转储流式事件原始 payload，定位 [object Object] 来源。
+        // 仅打印流式相关事件，避免刷屏。
+        if (['token', 'thinking_token', 'thinking_start', 'thinking_end', 'answer', 'done', 'tool_start', 'tool_end'].includes(msg.type)) {
+          const payload = (msg as { payload: unknown }).payload
+          let rendered: string
+          try {
+            rendered = typeof payload === 'string' ? payload : JSON.stringify(payload)
+          } catch {
+            rendered = `[unserializable:${typeof payload}]`
+          }
+          // eslint-disable-next-line no-console
+          console.log(`[ws-stream] ${msg.type} → typeof=${typeof payload}`, rendered?.slice(0, 500))
+        }
         handleEventForChannel(sid, msg)
       } catch (e) {
         console.error('[chatStore] WS message error:', e)

--- a/web/src/views/ProvidersView.vue
+++ b/web/src/views/ProvidersView.vue
@@ -20,7 +20,7 @@
             <div class="card-title-row">
               <span class="card-label">{{ p.label }}</span>
               <span v-if="p.is_default_provider" class="default-provider-badge">默认</span>
-              <span class="card-type-badge">OPENAI</span>
+              <span class="card-type-badge">{{ (p.provider_type || 'openai').toUpperCase() }}</span>
             </div>
             <button
               class="toggle-btn"
@@ -72,7 +72,7 @@
             {{ preset.label }}
           </option>
         </select>
-        <div class="form-hint">目前仅支持 OpenAI 兼容适配器</div>
+        <div class="form-hint">支持 OpenAI 兼容与 Anthropic 适配器</div>
       </div>
 
       <div class="form-section">
@@ -160,6 +160,7 @@ import Icon from '@/components/Icon.vue'
 // ── 预设提供商列表 ──
 const presets = [
   { id: 'openai', label: 'OpenAI Compatible', base_url: '' },
+  { id: 'anthropic', label: 'Anthropic', base_url: 'https://api.anthropic.com' },
 ]
 
 // ── 模式 ──
@@ -214,6 +215,7 @@ async function handleTest() {
     const res = await api.testConnection({
       api_key: form.value.api_key,
       base_url: form.value.base_url,
+      provider_type: form.value.provider_type,
     })
     if (res.status === 'ok') {
       testOk.value = true
@@ -265,6 +267,7 @@ async function handleDiscover() {
       const res = await api.discoverModels({
         api_key: form.value.api_key,
         base_url: form.value.base_url,
+        provider_type: form.value.provider_type,
       })
       discoveredModels.value = res.models
       selectedModels.value = res.models.filter(m => prevSelected.includes(m))


### PR DESCRIPTION
新增 Anthropic 官方 API（含兼容代理）适配，并将厂商能力差异封装进 Provider 抽象层。

## 功能（feat）
- AnthropicProvider 适配器 + build_provider 按 provider_type 分发
- 流式块式 token 归一化（Kimi K3 等 Anthropic 适配模型）
- 消息 content 展平，修复 [object Object] 渲染
- ProvidersView 支持 Anthropic 预设与徽章

## 重构（refactor）
- thinking 注入收敛为 Provider.apply_thinking 能力方法：基类默认不注入，
  OpenAI 兼容实现注入 extra_body.thinking，Anthropic v1 保持不思考
- 模型发现收敛为 Provider.list_models 抽象方法，删除 routes 中平行于
  build_provider 的第二分发点 _build_models_client
- 工程内 anthropic 分发仅剩 build_provider 工厂一处

## 测试
tests/test_api/test_providers.py 14 项全部通过（新增 apply_thinking /
list_models 单元测试，SDK 客户端 monkeypatch 模拟，无网络依赖）。