### PR TITLE
feat(tools): run_python 实时流式推送 stdout 到前端

### DIFF
--- a/api/events/tool.py
+++ b/api/events/tool.py
@@ -35,6 +35,18 @@ class ToolSender(WsTransport):
             payload["code"] = code
         await self._send("ask_user", payload)
 
+    async def tool_stream(self, call_id: str, tool_name: str, chunk: str) -> None:
+        """推送工具执行过程中的实时输出片段（如 run_python 的逐条 print）。
+
+        ``call_id`` 与 tool_start/tool_end 事件一致（均为 LangChain run_id），
+        前端据此精确匹配到对应的工具气泡。
+        """
+        await self._send("tool_stream", {
+            "call_id": call_id,
+            "tool_name": tool_name,
+            "chunk": chunk,
+        })
+
     async def sub_session_created(
         self,
         sub_session_id: str,

--- a/api/events/transport.py
+++ b/api/events/transport.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Self
 from fastapi import WebSocket, WebSocketDisconnect
 
 from api.agent import interaction
-from api.session.manager import session_manager
 
 if TYPE_CHECKING:
     from api.session.manager import SessionState
@@ -63,6 +62,10 @@ class WsTransport:
         记忆层等无法直接拿到 ws 和 SessionState 的场景使用此方式。
         会话不存在或 ws 已断开时返回 None。
         """
+        # 延迟导入：api.session.manager 会经 api.memory 拉入整条依赖链，
+        # 顶层导入会与 api.events 包初始化形成循环（events → session → memory → events）。
+        from api.session.manager import session_manager  # noqa: PLC0415
+
         session = session_manager.get(session_id)
         if session is None or session.ws is None:
             return None

--- a/api/memory/callback.py
+++ b/api/memory/callback.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from langchain_core.callbacks import BaseCallbackHandler
 
-from api.events import MemorySender
 from api.utils.logger import get_logger
 
 _log = get_logger("ltm-cb")
@@ -20,6 +19,10 @@ class MemoryToolCallback(BaseCallbackHandler):
         turn_id: str,
     ) -> None:
         super().__init__()
+        # 延迟导入：api.events 包初始化会经 session.manager → api.memory 回到本模块，
+        # 顶层导入 MemorySender 会触发 api.events.memory → api.events.transport 的循环。
+        from api.events.memory import MemorySender  # noqa: PLC0415
+
         self._sender = MemorySender.from_session_id(session_id)
         self._turn_id = turn_id
         self._tool_start_time: dict[str, float] = {}

--- a/tests/test_tool_python_stream.py
+++ b/tests/test_tool_python_stream.py
@@ -1,0 +1,126 @@
+"""测试：run_python 流式推送（tool_stream 事件）。
+
+核心保证：
+1. 每执行一次 print 就推送一条 tool_stream，chunk 即该次 print 的输出；
+2. tool_stream 的 call_id 与 run_manager.run_id 一致（与 tool_start/end 事件
+   共用同一个 run_id，前端可精确匹配气泡，不依赖 tool_name）；
+3. 无 run_manager（run_id 为空）时退化为一次性捕获，不推送流、不依赖
+   WebSocket 上下文。
+"""
+
+import uuid
+
+import pytest
+
+from api.agent import interaction
+from tools.system import tool_python as tool_module
+from tools.system.tool_python import RunPythonTool
+
+
+class _FakeSender:
+    """记录 tool_stream 事件的假发送器。"""
+
+    def __init__(self) -> None:
+        self.streams: list[dict] = []
+
+    async def tool_stream(self, call_id: str, tool_name: str, chunk: str) -> None:
+        self.streams.append({"call_id": call_id, "tool_name": tool_name, "chunk": chunk})
+
+
+class _FakeRunManager:
+    """最小 run_manager 替身：仅暴露 run_id。"""
+
+    def __init__(self, run_id: uuid.UUID) -> None:
+        self.run_id = run_id
+
+
+@pytest.mark.asyncio
+async def test_run_python_streams_each_print(monkeypatch):
+    """每次 print 推送一条 tool_stream，且 call_id 与 run_id 一致。"""
+    sid = "stream-session"
+    run_id = uuid.uuid4()
+    interaction.current_session_id.set(sid)
+    interaction.set_session_auto_approve(sid, True)
+
+    fake_sender = _FakeSender()
+    monkeypatch.setattr(
+        tool_module,
+        "ToolSender",
+        type("TS", (), {"from_context": staticmethod(lambda: fake_sender)}),
+    )
+
+    try:
+        result = await RunPythonTool()._arun(
+            code="print('第一行'); print('第二行')",
+            run_manager=_FakeRunManager(run_id),
+        )
+
+        # 返回值仍为完整输出（LLM / tool_data 需要）
+        assert "第一行" in result
+        assert "第二行" in result
+
+        # 输出按增量逐段推送（print 的正文与换行是两次 write，故至少 2 段），
+        # 顺序拼接后与一次捕获完全一致
+        assert len(fake_sender.streams) >= 2
+        joined = "".join(s["chunk"] for s in fake_sender.streams)
+        assert joined == "第一行\n第二行\n"
+
+        # 逐条携带与 tool_start/end 一致的 call_id
+        assert all(s["call_id"] == str(run_id) for s in fake_sender.streams)
+        assert all(s["tool_name"] == "run_python" for s in fake_sender.streams)
+    finally:
+        interaction.clear_session_settings(sid)
+        interaction.current_session_id.set("")
+
+
+@pytest.mark.asyncio
+async def test_run_python_streams_stderr_as_well(monkeypatch):
+    """stderr 写入同样被实时推送（如 print(..., file=sys.stderr)）。"""
+    sid = "stream-stderr"
+    run_id = uuid.uuid4()
+    interaction.current_session_id.set(sid)
+    interaction.set_session_auto_approve(sid, True)
+
+    fake_sender = _FakeSender()
+    monkeypatch.setattr(
+        tool_module,
+        "ToolSender",
+        type("TS", (), {"from_context": staticmethod(lambda: fake_sender)}),
+    )
+
+    try:
+        result = await RunPythonTool()._arun(
+            code="import sys; print('到stderr', file=sys.stderr); print('到stdout')",
+            run_manager=_FakeRunManager(run_id),
+        )
+        assert "到stderr" in result
+        assert "到stdout" in result
+        joined = "".join(s["chunk"] for s in fake_sender.streams)
+        assert "到stderr" in joined
+        assert "到stdout" in joined
+        assert all(s["call_id"] == str(run_id) for s in fake_sender.streams)
+    finally:
+        interaction.clear_session_settings(sid)
+        interaction.current_session_id.set("")
+
+
+@pytest.mark.asyncio
+async def test_run_python_no_run_manager_falls_back_to_oneshot(monkeypatch):
+    """无 run_manager（run_id 为空）时不推送流、不获取 sender，退化为一次性捕获。"""
+    sid = "stream-fallback"
+    interaction.current_session_id.set(sid)
+    interaction.set_session_auto_approve(sid, True)
+
+    class BoomSender:
+        @staticmethod
+        def from_context():
+            raise AssertionError("无 run_id 时不应获取 sender")
+
+    monkeypatch.setattr(tool_module, "ToolSender", BoomSender)
+
+    try:
+        result = await RunPythonTool()._arun(code="print('仅一次性捕获')")
+        assert "仅一次性捕获" in result
+    finally:
+        interaction.clear_session_settings(sid)
+        interaction.current_session_id.set("")

--- a/tools/system/tool_python.py
+++ b/tools/system/tool_python.py
@@ -1,9 +1,11 @@
-"""Tool: run_python — 执行 Python 代码。"""
+"""Tool: run_python — 执行 Python 代码（实时流式推送 stdout）。"""
 
 import asyncio
 import io
 import sys
+from collections.abc import Callable
 
+from langchain_core.callbacks.manager import AsyncCallbackManagerForToolRun
 from pydantic import BaseModel, Field
 
 from api.agent import interaction
@@ -13,9 +15,39 @@ from tools.base import ToolBase, format_error, format_success, get_safe_builtins
 # 模块级常量：安全 builtins 只构造一次
 _SAFE_BUILTINS = get_safe_builtins()
 
+# 流式队列结束哨兵：worker 执行完毕后（finally）入队，消费侧据此停止
+_DONE: object = object()
+
+
+class _StreamToQueue(io.TextIOBase):
+    """自定义 stdout/stderr 流：每次 write() 触发一次 emit（实时转发）。
+
+    替代原一次性捕获的 ``io.StringIO``：exec 中每调用一次 print 就推送一次。
+    同时把片段累积到 ``buf``，供执行结束后返回完整输出。
+    """
+
+    def __init__(self, buf: list[str], emit: Callable[[str], None]) -> None:
+        self._buf = buf
+        self._emit = emit
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, s: str) -> int:
+        if s:
+            self._buf.append(s)
+            self._emit(s)
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
 
 def _exec_code(code: str) -> str:
-    """在线程中执行代码并捕获 stdout。返回输出文本。"""
+    """在线程中执行代码并一次性捕获 stdout。返回输出文本。
+
+    无 WebSocket 连接或 run_id 缺失时的回退路径（不推送流式事件）。
+    """
     old_stdout = sys.stdout
     sys.stdout = io.StringIO()
     try:
@@ -25,6 +57,80 @@ def _exec_code(code: str) -> str:
         raise RuntimeError(f"代码执行错误: {e}") from e
     finally:
         sys.stdout = old_stdout
+
+
+async def _exec_code_streaming(
+    code: str, tool_name: str, run_id: str, sender: ToolSender
+) -> str:
+    """流式执行代码：每产生一段输出就推送一条 ``tool_stream`` 事件。
+
+    线程→异步桥接：exec 跑在 ``asyncio.to_thread`` 工作线程，自定义流把每段
+    输出通过 ``loop.call_soon_threadsafe`` 塞进 ``asyncio.Queue``，主协程并发
+    消费队列逐条推送。执行完毕（含异常，由 finally）入队结束哨兵。
+
+    Args:
+        code: 要执行的 Python 代码。
+        tool_name: 工具名（用于 tool_stream 事件）。
+        run_id: 当前工具调用的 run_id（作为 tool_stream 的 call_id，
+            与 tool_start/tool_end 事件一致，前端据此精确匹配气泡）。
+        sender: WebSocket 发送器，用于推送流式事件。
+
+    Returns:
+        累积的完整输出文本（供 LLM 与 tool_data 使用）。
+    """
+    loop = asyncio.get_running_loop()
+    queue: asyncio.Queue[str | object] = asyncio.Queue()
+
+    def emit(chunk: str | object) -> None:
+        loop.call_soon_threadsafe(queue.put_nowait, chunk)
+
+    def worker() -> str:
+        old_stdout, old_stderr = sys.stdout, sys.stderr
+        buf: list[str] = []
+        stream = _StreamToQueue(buf, emit)
+        sys.stdout = stream
+        sys.stderr = stream
+        try:
+            exec(code, {"__builtins__": _SAFE_BUILTINS})
+            return "".join(buf)
+        except Exception as e:
+            raise RuntimeError(f"代码执行错误: {e}") from e
+        finally:
+            sys.stdout, sys.stderr = old_stdout, old_stderr
+            emit(_DONE)  # 结束哨兵：保证即使异常也发出，消费侧不会悬挂
+
+    exec_task = asyncio.create_task(asyncio.to_thread(worker))
+
+    async def drain() -> None:
+        while True:
+            chunk = await queue.get()
+            if chunk is _DONE:
+                return
+            if isinstance(chunk, str):
+                await sender.tool_stream(call_id=run_id, tool_name=tool_name, chunk=chunk)
+
+    drain_task = asyncio.create_task(drain())
+
+    try:
+        output = await exec_task
+    finally:
+        await drain_task
+    return output or "（代码执行完毕，无输出）"
+
+
+async def _run_code(code: str, run_id: str, sender: ToolSender | None) -> str:
+    """执行代码并返回统一成功/错误响应。
+
+    sender 与 run_id 均可用时流式推送；否则退化为一次性捕获。
+    """
+    try:
+        if sender is not None and run_id:
+            output = await _exec_code_streaming(code, "run_python", run_id, sender)
+        else:
+            output = await asyncio.to_thread(_exec_code, code)
+        return format_success({"output": output, "code": code})
+    except Exception as e:
+        return format_error(str(e))
 
 
 class RunPythonInput(BaseModel):
@@ -45,23 +151,38 @@ class RunPythonTool(ToolBase):
     def _run(self, get_doc: bool = False, code: str = "") -> str:
         raise NotImplementedError("run_python 仅支持异步模式，请使用 _arun")
 
-    async def _arun(self, get_doc: bool = False, code: str = "") -> str:
+    async def _arun(
+        self,
+        get_doc: bool = False,
+        code: str = "",
+        run_manager: AsyncCallbackManagerForToolRun | None = None,
+    ) -> str:
+        """执行代码，实时向前端推送每条 stdout。
+
+        ``run_manager`` 由 LangChain 自动注入（``BaseTool.arun`` 检测到
+        ``_arun`` 声明该形参即注入当前调用的 run manager），其 ``run_id``
+        与 WebSocket 回调 ``on_tool_start`` 收到的 run_id 完全一致，用作
+        ``tool_stream`` 事件的 call_id，前端据此与工具气泡精确匹配
+        （不依赖 tool_name，并行调用也不会串流）。
+        """
         if get_doc:
             return self._load_doc()
         if not code:
             return format_error("code 不能为空")
 
+        run_id = str(run_manager.run_id) if run_manager and run_manager.run_id else ""
+
         session_id = interaction.current_session_id.get()
         if session_id and interaction.get_session_auto_approve(session_id):
-            try:
-                output = await asyncio.to_thread(_exec_code, code)
-                return format_success({"output": output, "code": code})
-            except Exception as e:
-                return format_error(str(e))
+            # 仅当有 run_id 时才获取 sender 尝试流式；否则保持原一次性捕获，
+            # 避免无 run_id 场景（如直接调用）无谓地依赖 WebSocket 上下文。
+            sender = ToolSender.from_context() if run_id else None
+            return await _run_code(code, run_id, sender)
 
         sender = ToolSender.from_context()
         if sender is None:
             return format_error("WebSocket 连接不可用")
+
         interaction_id, future = interaction.register()
 
         await sender.ask_user(
@@ -83,16 +204,11 @@ class RunPythonTool(ToolBase):
                 reason = answer.get("reason", "")
 
             if action == "approve":
-                try:
-                    output = await asyncio.to_thread(_exec_code, code)
-                    return format_success({"output": output, "code": code})
-                except Exception as e:
-                    return format_error(str(e))
+                return await _run_code(code, run_id, sender)
             else:
                 if reason:
                     return format_error(f"用户拒绝执行代码。原因：{reason}")
-                else:
-                    return format_error("用户拒绝执行代码")
+                return format_error("用户拒绝执行代码")
 
         except asyncio.CancelledError:
             return format_error("用户取消了回复")

--- a/web/src/components/tools/PythonBubble.vue
+++ b/web/src/components/tools/PythonBubble.vue
@@ -47,9 +47,14 @@
       </div>
     </template>
 
-    <!-- 运行中 -->
+    <!-- 运行中：有实时输出则流式渲染（tool_stream 逐条累积），否则显示占位文案 -->
     <div v-else-if="toolCall.status === 'running'" class="bubble-running">
-      <span>正在执行代码...</span>
+      <pre
+        v-if="liveStdout"
+        ref="liveOutEl"
+        class="py-stdout"
+      >{{ liveStdout }}</pre>
+      <span v-else>正在执行代码...</span>
     </div>
 
     <!-- 错误 -->
@@ -81,7 +86,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import type { ToolCall } from '@/types'
 import BubbleChrome from './_shared/BubbleChrome.vue'
 import { highlightPython } from '@/utils/python-highlight'
@@ -94,6 +99,19 @@ const rejectionReason = ref('')
 
 const isConfirmMode = computed(() => {
   return props.toolCall.interaction?.mode === 'confirm'
+})
+
+/** 实时输出缓冲（tool_stream 累积，仅 running 期间有值） */
+const liveStdout = computed(() => props.toolCall.stream ?? '')
+
+// 实时输出容器高度受限（200px），每条新输出到达时滚动到底部
+const liveOutEl = ref<HTMLElement | null>(null)
+watch(liveStdout, () => {
+  void nextTick(() => {
+    if (liveOutEl.value) {
+      liveOutEl.value.scrollTop = liveOutEl.value.scrollHeight
+    }
+  })
 })
 
 const code = computed(() => {

--- a/web/src/composables/useChat.handlers.ts
+++ b/web/src/composables/useChat.handlers.ts
@@ -3,7 +3,7 @@ import type { SessionChannel } from '@/stores/chatStore'
 import { findLastThinking, findToolByCallId, findBestMatchingTool, findFirstRunningToolForInteraction } from '@/stores/chatStore'
 import { useChatStore } from '@/stores/chatStore'
 import { useSessionStore } from '@/stores/sessionStore'
-import type { ServerEvent, ChatTurn, TokenEvent, ThinkingTokenEvent, AnswerEvent, ErrorEvent, DoneEvent, AskUserEvent } from '@/types'
+import type { ServerEvent, ChatTurn, TokenEvent, ThinkingTokenEvent, AnswerEvent, ErrorEvent, DoneEvent, AskUserEvent, ToolStreamEvent } from '@/types'
 
 /** 事件路由处理器签名（turn 已由调用方守卫保证存在）。 */
 type TurnEventHandler = (ch: SessionChannel, sid: string, turn: ChatTurn, event: ServerEvent) => void
@@ -162,6 +162,18 @@ function handleToolError(ch: SessionChannel, _sid: string, turn: ChatTurn, event
   }
 }
 
+/** tool_stream：把实时输出片段追加到匹配工具调用的 stream 缓冲。 */
+function handleToolStream(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
+  const tsEvent = event as ToolStreamEvent
+  // 精确匹配优先（call_id 与 tool_start/end 一致），缺省再按 tool_name 兜底，
+  // 与 tool_end / tool_error 的匹配策略保持一致。
+  const tc = findToolByCallId(turn.events, tsEvent.payload.call_id)
+    ?? findBestMatchingTool(turn.events, tsEvent.payload.tool_name)
+  if (tc) {
+    tc.stream = (tc.stream ?? '') + tsEvent.payload.chunk
+  }
+}
+
 /** answer：标记思考块为 becameAnswer，设置 finalAnswer。 */
 function handleAnswer(ch: SessionChannel, _sid: string, turn: ChatTurn, event: ServerEvent): void {
   const content = (event as AnswerEvent).payload.content
@@ -304,6 +316,7 @@ export const turnHandlers = new Map<string, TurnEventHandler>([
   ['tool_start', handleToolStart],
   ['tool_end', handleToolEnd],
   ['tool_error', handleToolError],
+  ['tool_stream', handleToolStream],
   ['answer', handleAnswer],
   ['done', handleDone],
   ['error', handleError],

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -37,6 +37,12 @@ export interface ToolErrorEvent {
   payload: { call_id: string; tool_name: string; error: string }
 }
 
+/** tool_stream — 工具执行过程中的实时输出片段（如 run_python 的逐条 print） */
+export interface ToolStreamEvent {
+  type: 'tool_stream'
+  payload: { call_id: string; tool_name: string; chunk: string }
+}
+
 export interface AnswerEvent {
   type: 'answer'
   payload: { content: string }
@@ -204,6 +210,7 @@ export type ServerEvent =
   | ToolStartEvent
   | ToolEndEvent
   | ToolErrorEvent
+  | ToolStreamEvent
   | AnswerEvent
   | DoneEvent
   | ErrorEvent
@@ -328,6 +335,8 @@ export interface ToolCall {
   status: 'running' | 'done' | 'error'
   callId?: string
   toolData?: Record<string, unknown>
+  /** tool_stream 实时输出缓冲（仅 running 期间有意义，tool_end 后由 output/toolData 接管） */
+  stream?: string
   /** ask_user 交互工具的额外数据 */
   interaction?: AskUserInteraction
 }


### PR DESCRIPTION
## 变更内容

`run_python` 工具执行 Python 代码时，每产生一段 stdout/stderr 输出（每次 `print`）就实时向前端推送一条 `tool_stream` 事件；前端 `PythonBubble` 在运行状态流式渲染输出并自动滚动到底部。

### 后端
- `tools/system/tool_python.py`：`_arun` 新增 `run_manager` 形参（LangChain 自动注入），`run_id` 与 WebSocket 回调 `on_tool_start` 完全一致。`_exec_code_streaming()` 以线程→异步桥接（自定义 stdout/stderr 流 + `asyncio.Queue` + 哨兵）逐段推送；无 run_id 时退化为原一次性捕获。
- `api/events/tool.py`：`ToolSender.tool_stream()` 新事件，`call_id` = run_id。
- 修复 `api.events ↔ api.memory` 的循环导入（`api/events/transport.py`、`api/memory/callback.py` 惰性导入）。

### 前端
- `types/index.ts`：`ToolStreamEvent` + `ServerEvent` 联合类型 + `ToolCall.stream` 缓冲。
- `useChat.handlers.ts`：`handleToolStream` 以 `findToolByCallId` 精确匹配（与 tool_end/error 同策略），`findBestMatchingTool` 兜底，追加到 `stream`。
- `PythonBubble.vue`：running 状态实时渲染 live stdout，输出区受限高度内自动滚动。

## 验证

- `tests/test_tool_python_stream.py`：3 项通过（逐条 print、stderr、无 run_id 回退）
- `ruff`：改动文件全部通过
- `vue-tsc --noEmit`：改动文件无类型错误
- 完整后端套件 203 passed / 36 failed，失败项均经 stash 基线确认与本次改动无关（`test_narrative*` 测试漂移、`test_auth_middleware` 既有失败）