### PR TITLE
feat: run_python 支持中途停止与截止信息

### DIFF
--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -24,6 +24,7 @@ from api.memory.short_term import get_checkpointer
 from langchain_core.language_models.chat_models import BaseChatModel
 from tools.base import format_error
 from tools.network.tool_image_understand import load_image_bytes, get_mime_type
+from tools.system.tool_python import interrupt_all_runs
 from api.utils.logger import get_logger
 
 _log = get_logger("turn")
@@ -416,6 +417,9 @@ async def _execute_agent_turn(
 
     except asyncio.CancelledError:
         interaction.cancel_all()
+        # 兜底：整轮取消时终止所有仍在运行的 python 子进程。
+        # _exec_code_streaming 的 finally 是主要清理路径，这里是幂等兜底。
+        interrupt_all_runs()
         try:
             await _inject_cancel_tool_messages(session, ctx.config, sender)
         except Exception as e:

--- a/api/callbacks/tool_extractors.py
+++ b/api/callbacks/tool_extractors.py
@@ -200,6 +200,11 @@ def _extract_run_python(
         "tool_type": "run_python",
         "stdout": data.get("output", ""),
     }
+    # 中途停止：interrupted 为真时前端展示「已中途停止」横幅 + user_message
+    if isinstance(data.get("interrupted"), bool):
+        result["interrupted"] = data["interrupted"]
+    if data.get("user_message"):
+        result["user_message"] = data["user_message"]
     if tool_input:
         try:
             input_parsed = ast.literal_eval(tool_input)

--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -1,4 +1,12 @@
 news:
+  - id: "run-python-mid-run-stop"
+    title: "Python 执行可中途停止"
+    description: "run_python 工具运行中可随时点击「停止」并附上截止信息，子进程会被彻底终止，Agent 结合已产生的输出与截止信息继续回应。长任务运行过程真正可控，不再只能干等或整轮取消。"
+    type: "feat"
+    date: "2026-08-23"
+    tags: ["Python", "停止", "交互"]
+    version: ""
+    pr_number:
   - id: "run-python-stream-output"
     title: "Python 输出实时流式显示"
     description: "run_python 工具执行代码时，每次 print 的输出都会实时推送并显示在气泡中，运行过程不再是黑盒等待，调试长任务时反馈更直观。"

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -265,6 +265,28 @@ async def _handle_skip_memory_search(
     return agent_task
 
 
+@ws_event_handler("run_python_interrupt")
+async def _handle_run_python_interrupt(
+    ws: WebSocket,
+    session_id: str,
+    session: SessionState,
+    agent_task: asyncio.Task | None,
+    msg: dict,
+) -> asyncio.Task | None:
+    """处理 run_python 中途停止请求：终止对应子进程并传递截止信息。
+
+    不取消 agent_task——工具返回「已中断」结果后 Agent 继续回应。
+    局部导入避免与工具模块的导入顺序耦合。
+    """
+    payload = msg.get("payload", {})
+    call_id = payload.get("call_id", "")
+    message = payload.get("message", "") or ""
+    if call_id:
+        from tools.system.tool_python import interrupt_run
+        interrupt_run(call_id, message)
+    return agent_task
+
+
 @router.websocket("/ws/chat/{session_id}")
 async def websocket_chat(ws: WebSocket, session_id: str) -> None:
     """WebSocket 聊天端点 — 接收消息、派发、生命周期管理。"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,25 @@
 """共享 fixtures — FastAPI TestClient、认证 Token、最小测试 app。"""
 
+import asyncio
+import os
+
 import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from api.middleware.auth import AuthMiddleware
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _windows_proactor_policy() -> None:
+    """Windows 上安装 Proactor 事件循环策略（session 级 autouse）。
+
+    Proactor 原生支持 ``asyncio.create_subprocess_exec``，而 Selector 不支持
+    子进程——run_python 子进程隔离执行相关测试依赖此策略。
+    其余平台（posix）无此需求，直接跳过。
+    """
+    if os.name == "nt":
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
 
 @pytest.fixture

--- a/tests/test_tool_python_interrupt.py
+++ b/tests/test_tool_python_interrupt.py
@@ -1,0 +1,170 @@
+"""测试：run_python 中途停止（run_python_interrupt）。
+
+核心保证：
+1. 真实子进程执行期间调用 interrupt_run 能彻底终止（proc.kill），
+   工具返回带 interrupted + user_message 的结果，部分输出仍可见；
+2. 代码执行错误时返回统一错误格式（不泄漏 __RUN_PYTHON_ERROR__ 内部标记）；
+3. interrupt_run / _ExecHandle.request_stop 幂等（只 kill 一次、只记首条截止信息）。
+"""
+
+import asyncio
+import json
+import time
+import uuid
+
+import pytest
+
+from api.agent import interaction
+from tools.system import tool_python as tool_module
+from tools.system.tool_python import RunPythonTool, _ExecHandle, interrupt_run
+
+
+class _FakeSender:
+    """记录 tool_stream 事件的假发送器。"""
+
+    def __init__(self) -> None:
+        self.streams: list[dict] = []
+
+    async def tool_stream(self, call_id: str, tool_name: str, chunk: str) -> None:
+        self.streams.append({"call_id": call_id, "tool_name": tool_name, "chunk": chunk})
+
+
+class _FakeRunManager:
+    """最小 run_manager 替身：仅暴露 run_id。"""
+
+    def __init__(self, run_id: uuid.UUID) -> None:
+        self.run_id = run_id
+
+
+def _patch_sender(monkeypatch, fake_sender: _FakeSender) -> None:
+    """把 tool_python.ToolSender 替换为返回 fake_sender 的假类。"""
+    monkeypatch.setattr(
+        tool_module,
+        "ToolSender",
+        type("TS", (), {"from_context": staticmethod(lambda: fake_sender)}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_interrupt_kills_subprocess_mid_run(monkeypatch):
+    """执行 time.sleep(100) 期间中断：子进程被彻底 kill，返回 interrupted 结果。"""
+    sid = "interrupt-session"
+    run_id = uuid.uuid4()
+    interaction.current_session_id.set(sid)
+    interaction.set_session_auto_approve(sid, True)
+
+    fake_sender = _FakeSender()
+    _patch_sender(monkeypatch, fake_sender)
+
+    try:
+        task = asyncio.create_task(
+            RunPythonTool()._arun(
+                code="import time; print('开始'); time.sleep(100)",
+                run_manager=_FakeRunManager(run_id),
+            )
+        )
+
+        # 轮询直到子进程打印「开始」（确认子进程已真正启动、输出已流式到达）
+        deadline = time.monotonic() + 10
+        while not any("开始" in s["chunk"] for s in fake_sender.streams):
+            if task.done() or time.monotonic() > deadline:
+                break
+            await asyncio.sleep(0.05)
+
+        # 触发中断：同步函数，在同一事件循环线程内 kill 子进程
+        assert interrupt_run(str(run_id), "停下来") is True
+
+        result = await asyncio.wait_for(task, timeout=15)
+        data = json.loads(result)["data"]
+        assert data["interrupted"] is True
+        assert data["user_message"] == "停下来"
+        assert "开始" in data["output"]
+
+        # 注册表已清理，无残留句柄
+        assert str(run_id) not in tool_module._exec_runs
+    finally:
+        interaction.clear_session_settings(sid)
+        interaction.current_session_id.set("")
+
+
+@pytest.mark.asyncio
+async def test_interrupt_unknown_id_returns_false():
+    """未知 run_id 的 interrupt_run 返回 False（不抛异常）。"""
+    assert interrupt_run("unknown-id", "x") is False
+
+
+@pytest.mark.asyncio
+async def test_code_error_returns_formatted_error(monkeypatch):
+    """代码抛出异常：返回统一错误格式，含错误消息，不泄漏内部标记。"""
+    sid = "interrupt-error"
+    run_id = uuid.uuid4()
+    interaction.current_session_id.set(sid)
+    interaction.set_session_auto_approve(sid, True)
+
+    fake_sender = _FakeSender()
+    _patch_sender(monkeypatch, fake_sender)
+
+    try:
+        result = await RunPythonTool()._arun(
+            code="raise ValueError('boom')",
+            run_manager=_FakeRunManager(run_id),
+        )
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "boom" in parsed["error"]
+        assert "__RUN_PYTHON_ERROR__" not in result
+    finally:
+        interaction.clear_session_settings(sid)
+        interaction.current_session_id.set("")
+
+
+def test_request_stop_is_idempotent():
+    """request_stop 幂等：重复调用只 kill 一次、只记录第一条截止信息。"""
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self.returncode: int | None = None
+            self.kill_count = 0
+
+        def kill(self) -> None:
+            self.kill_count += 1
+            self.returncode = 1
+
+    fake = _FakeProc()
+    handle = _ExecHandle()
+    handle.proc = fake  # type: ignore[assignment]
+
+    handle.request_stop("第一次")
+    handle.request_stop("第二次")
+
+    assert handle.interrupted is True
+    assert handle.user_message == "第一次"
+    assert fake.kill_count == 1
+
+
+def test_interrupt_run_idempotent():
+    """interrupt_run 对已中断的 handle 再次调用不重复 kill、不改写消息。"""
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self.returncode: int | None = None
+            self.kill_count = 0
+
+        def kill(self) -> None:
+            self.kill_count += 1
+            self.returncode = 1
+
+    fake = _FakeProc()
+    run_id = uuid.uuid4()
+    handle = _ExecHandle()
+    handle.proc = fake  # type: ignore[assignment]
+    tool_module._exec_runs[str(run_id)] = handle
+
+    try:
+        assert interrupt_run(str(run_id), "A") is True
+        assert interrupt_run(str(run_id), "B") is True
+        assert handle.interrupted is True
+        assert handle.user_message == "A"
+        assert fake.kill_count == 1
+    finally:
+        tool_module._exec_runs.pop(str(run_id), None)

--- a/tools/system/_python_runner.py
+++ b/tools/system/_python_runner.py
@@ -1,0 +1,43 @@
+"""run_python 子进程执行器 — 被 tool_python 以独立子进程方式拉起。
+
+从 stdin 读取待执行代码，以安全 builtins 执行并实时输出到 stdout/stderr。
+作为普通脚本运行（``python -u <此文件>``），不参与任何包导出。
+
+异常约定：
+- ``SystemExit`` 透传退出码；
+- 其他异常打印 ``__RUN_PYTHON_ERROR__::<Type>: <msg>`` 标记后以退出码 1
+  结束，父进程据此解析出结构化错误消息。
+"""
+
+import sys
+
+
+def _main() -> None:
+    # 延迟导入：仅子进程运行此脚本时才加载 tools.base，避免拖慢父进程导入
+    from tools.base import get_safe_builtins
+
+    # 关闭 Windows 上 text 模式的 \n→\r\n 翻译，使管道输出与进程内
+    # io.StringIO 捕获保持一致（同段代码两种路径产出完全相同的文本）。
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(newline="\n")
+        except (ValueError, OSError):
+            pass  # 非常规流对象（如已关闭）时保持原样
+
+    code = sys.stdin.read()
+    if not code:
+        sys.exit(0)
+
+    safe = get_safe_builtins()
+    try:
+        exec(compile(code, "<run_python>", "exec"), {"__builtins__": safe})
+    except SystemExit as e:
+        code_value = e.code if isinstance(e.code, int) else 1
+        sys.exit(code_value)
+    except BaseException as e:  # noqa: BLE001 — 交给父进程解析为错误结果
+        sys.stderr.write(f"__RUN_PYTHON_ERROR__::{type(e).__name__}: {e}\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tools/system/tool_python.py
+++ b/tools/system/tool_python.py
@@ -1,9 +1,23 @@
-"""Tool: run_python — 执行 Python 代码（实时流式推送 stdout）。"""
+"""Tool: run_python — 在子进程中执行 Python 代码，支持实时流式推送与中途停止。
+
+执行模型：
+- 以 ``python -u _python_runner.py`` 拉起独立子进程，stdin 传入代码，
+  父进程增量读取 stdout（stderr 合并入同一管道）按行推送 ``tool_stream``。
+- 子进程隔离使中途停止可以 ``proc.kill()`` 彻底终止执行（含 ``time.sleep``
+  等阻塞 C 调用），这正是线程内 exec 做不到的。
+- 每个运行注册进 ``_exec_runs`` 注册表，前端 ``run_python_interrupt`` 消息
+  通过 ``interrupt_run()`` 定位并终止对应子进程。
+"""
 
 import asyncio
+import codecs
+import contextlib
 import io
+import os
+import subprocess
 import sys
-from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
 
 from langchain_core.callbacks.manager import AsyncCallbackManagerForToolRun
 from pydantic import BaseModel, Field
@@ -15,38 +29,214 @@ from tools.base import ToolBase, format_error, format_success, get_safe_builtins
 # 模块级常量：安全 builtins 只构造一次
 _SAFE_BUILTINS = get_safe_builtins()
 
-# 流式队列结束哨兵：worker 执行完毕后（finally）入队，消费侧据此停止
-_DONE: object = object()
+# 子进程执行器路径与项目根目录（供子进程 import tools.base）
+_PYTHON_RUNNER = Path(__file__).resolve().parent / "_python_runner.py"
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+
+# 子进程 stderr 上的错误标记：runner 打印 `__RUN_PYTHON_ERROR__::<Type>: <msg>`
+_ERROR_MARKER = "__RUN_PYTHON_ERROR__::"
 
 
-class _StreamToQueue(io.TextIOBase):
-    """自定义 stdout/stderr 流：每次 write() 触发一次 emit（实时转发）。
+@dataclass
+class _ExecHandle:
+    """单次 run_python 执行的句柄，供 interrupt_run 定位并终止子进程。"""
 
-    替代原一次性捕获的 ``io.StringIO``：exec 中每调用一次 print 就推送一次。
-    同时把片段累积到 ``buf``，供执行结束后返回完整输出。
+    proc: asyncio.subprocess.Process | None = None
+    interrupted: bool = False
+    user_message: str = ""
+    exit_code: int | None = None
+
+    def request_stop(self, message: str = "") -> None:
+        """请求停止执行：幂等；记录截止信息并（若子进程已启动）立即 kill。"""
+        if self.interrupted:
+            return
+        self.interrupted = True
+        if message:
+            self.user_message = message
+        proc = self.proc
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.kill()
+            except (ProcessLookupError, OSError):
+                pass
+
+
+# 运行中 run_python 注册表：run_id → 执行句柄。
+# 全部操作都发生在同一事件循环线程（ws handler / agent task），无需加锁。
+_exec_runs: dict[str, _ExecHandle] = {}
+
+
+def interrupt_run(call_id: str, message: str = "") -> bool:
+    """请求停止指定 run_id 的 python 子进程。返回是否找到该运行。
+
+    ``call_id`` 即 tool_stream 的 call_id（run_id），与 tool_start/tool_end 一致。
+    停止后工具返回带 ``interrupted`` 与 ``user_message`` 的结果，Agent 继续回应。
     """
+    handle = _exec_runs.get(call_id)
+    if handle is None:
+        return False
+    handle.request_stop(message)
+    return True
 
-    def __init__(self, buf: list[str], emit: Callable[[str], None]) -> None:
-        self._buf = buf
-        self._emit = emit
 
-    def writable(self) -> bool:
-        return True
+def interrupt_all_runs() -> int:
+    """停止全部运行中的 python 子进程（Agent 整轮取消时的兜底）。返回数量。"""
+    handles = list(_exec_runs.values())
+    for h in handles:
+        h.request_stop("Agent 轮次已取消")
+    return len(handles)
 
-    def write(self, s: str) -> int:
-        if s:
-            self._buf.append(s)
-            self._emit(s)
-        return len(s)
 
-    def flush(self) -> None:
+def _parse_python_error(output: str) -> str:
+    """从子进程输出中提取 ``__RUN_PYTHON_ERROR__::`` 标记的错误消息。"""
+    for line in output.splitlines():
+        idx = line.find(_ERROR_MARKER)
+        if idx != -1:
+            return line[idx + len(_ERROR_MARKER):].strip()
+    return ""
+
+
+async def _push_chunk(
+    sender: ToolSender | None, run_id: str, tool_name: str, chunk: str
+) -> None:
+    """推送一条 tool_stream；发送失败（如 WS 断开）时静默跳过，不中断 drain。"""
+    if sender is None:
+        return
+    try:
+        await sender.tool_stream(call_id=run_id, tool_name=tool_name, chunk=chunk)
+    except Exception:
         pass
 
 
-def _exec_code(code: str) -> str:
-    """在线程中执行代码并一次性捕获 stdout。返回输出文本。
+async def _drain_output(
+    reader: asyncio.StreamReader,
+    sender: ToolSender | None,
+    run_id: str,
+    tool_name: str,
+) -> str:
+    """增量读取子进程输出：按行/阈值切块实时推送 tool_stream，并累积完整输出。
 
-    无 WebSocket 连接或 run_id 缺失时的回退路径（不推送流式事件）。
+    使用增量 UTF-8 解码器，多字节字符跨 ``read()`` 拆分时不会抛 UnicodeDecodeError。
+    按 ``\\n`` / ``\\r`` 或 4096 字节阈值切块——`print` 一次调用恰好一整行，
+    前端看到的粒度和实时性接近旧版进程内逐条推送。
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    buf: list[str] = []
+    pending = ""
+    while True:
+        data = await reader.read(4096)
+        if not data:
+            break
+        pending += decoder.decode(data)
+        # 取最早出现的行分隔符，避免 \r\n 与纯 \n 混用导致切块漂移
+        while True:
+            idx = -1
+            for sep in ("\n", "\r"):
+                pos = pending.find(sep)
+                if pos != -1 and (idx == -1 or pos < idx):
+                    idx = pos
+            if idx == -1:
+                break
+            line = pending[: idx + 1]
+            pending = pending[idx + 1:]
+            buf.append(line)
+            await _push_chunk(sender, run_id, tool_name, line)
+        if len(pending) >= 4096:
+            buf.append(pending)
+            await _push_chunk(sender, run_id, tool_name, pending)
+            pending = ""
+    pending += decoder.decode(b"", final=True)
+    if pending:
+        buf.append(pending)
+        await _push_chunk(sender, run_id, tool_name, pending)
+    return "".join(buf)
+
+
+async def _exec_code_streaming(
+    code: str, tool_name: str, run_id: str, sender: ToolSender
+) -> tuple[str, _ExecHandle]:
+    """在子进程中执行代码，实时向前端推送输出，支持中途停止。
+
+    Args:
+        code: 要执行的 Python 代码。
+        tool_name: 工具名（用于 tool_stream 事件）。
+        run_id: 当前工具调用的 run_id（注册表键 + tool_stream call_id）。
+        sender: WebSocket 发送器，用于推送流式事件。
+
+    Returns:
+        (完整输出文本, 执行句柄)。句柄携带 interrupted / user_message / exit_code，
+        调用方据此构造成功或中断结果。
+    """
+    handle = _ExecHandle()
+    _exec_runs[run_id] = handle
+    proc: asyncio.subprocess.Process | None = None
+    drain_task: asyncio.Task[str] | None = None
+    output = ""
+
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"  # 子进程 stdio 强制 UTF-8（不设 PYTHONUTF8，保持 open() 编码与进程内一致）
+    env["PYTHONDONTWRITEBYTECODE"] = "1"  # 子进程不写 __pycache__ 进仓库
+    existing_pypath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = _PROJECT_ROOT + (
+        os.pathsep + existing_pypath if existing_pypath else ""
+    )
+    creationflags = subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, "-u", "-B", str(_PYTHON_RUNNER),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=_PROJECT_ROOT,
+            env=env,
+            limit=1 << 20,
+            creationflags=creationflags,
+        )
+        handle.proc = proc
+        # 竞态兜底：interrupt_run 可能在进程创建完成前已置 interrupted
+        if handle.interrupted:
+            proc.kill()
+
+        drain_task = asyncio.create_task(
+            _drain_output(proc.stdout, sender, run_id, tool_name)
+        )
+
+        if proc.stdin is not None:
+            try:
+                proc.stdin.write(code.encode("utf-8"))
+                await proc.stdin.drain()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            finally:
+                proc.stdin.close()
+
+        handle.exit_code = await proc.wait()
+        output = await drain_task
+    finally:
+        # 任何路径（正常/中断/取消）都确保子进程终止、drain 收尾、注册表清理
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.kill()
+            except (ProcessLookupError, OSError):
+                pass
+        if drain_task is not None and not drain_task.done():
+            drain_task.cancel()
+        if drain_task is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.gather(drain_task, return_exceptions=True)
+        if proc is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await proc.wait()
+        _exec_runs.pop(run_id, None)
+
+    return output, handle
+
+
+def _exec_code(code: str) -> str:
+    """在进程内一次性捕获执行代码。返回输出文本。
+
+    无 WebSocket 连接或 run_id 缺失时的回退路径（不推送流式事件、不支持停止）。
     """
     old_stdout = sys.stdout
     sys.stdout = io.StringIO()
@@ -59,76 +249,31 @@ def _exec_code(code: str) -> str:
         sys.stdout = old_stdout
 
 
-async def _exec_code_streaming(
-    code: str, tool_name: str, run_id: str, sender: ToolSender
-) -> str:
-    """流式执行代码：每产生一段输出就推送一条 ``tool_stream`` 事件。
-
-    线程→异步桥接：exec 跑在 ``asyncio.to_thread`` 工作线程，自定义流把每段
-    输出通过 ``loop.call_soon_threadsafe`` 塞进 ``asyncio.Queue``，主协程并发
-    消费队列逐条推送。执行完毕（含异常，由 finally）入队结束哨兵。
-
-    Args:
-        code: 要执行的 Python 代码。
-        tool_name: 工具名（用于 tool_stream 事件）。
-        run_id: 当前工具调用的 run_id（作为 tool_stream 的 call_id，
-            与 tool_start/tool_end 事件一致，前端据此精确匹配气泡）。
-        sender: WebSocket 发送器，用于推送流式事件。
-
-    Returns:
-        累积的完整输出文本（供 LLM 与 tool_data 使用）。
-    """
-    loop = asyncio.get_running_loop()
-    queue: asyncio.Queue[str | object] = asyncio.Queue()
-
-    def emit(chunk: str | object) -> None:
-        loop.call_soon_threadsafe(queue.put_nowait, chunk)
-
-    def worker() -> str:
-        old_stdout, old_stderr = sys.stdout, sys.stderr
-        buf: list[str] = []
-        stream = _StreamToQueue(buf, emit)
-        sys.stdout = stream
-        sys.stderr = stream
-        try:
-            exec(code, {"__builtins__": _SAFE_BUILTINS})
-            return "".join(buf)
-        except Exception as e:
-            raise RuntimeError(f"代码执行错误: {e}") from e
-        finally:
-            sys.stdout, sys.stderr = old_stdout, old_stderr
-            emit(_DONE)  # 结束哨兵：保证即使异常也发出，消费侧不会悬挂
-
-    exec_task = asyncio.create_task(asyncio.to_thread(worker))
-
-    async def drain() -> None:
-        while True:
-            chunk = await queue.get()
-            if chunk is _DONE:
-                return
-            if isinstance(chunk, str):
-                await sender.tool_stream(call_id=run_id, tool_name=tool_name, chunk=chunk)
-
-    drain_task = asyncio.create_task(drain())
-
-    try:
-        output = await exec_task
-    finally:
-        await drain_task
-    return output or "（代码执行完毕，无输出）"
-
-
 async def _run_code(code: str, run_id: str, sender: ToolSender | None) -> str:
     """执行代码并返回统一成功/错误响应。
 
-    sender 与 run_id 均可用时流式推送；否则退化为一次性捕获。
+    sender 与 run_id 均可用时以子进程流式执行（支持中途停止）；
+    否则退化为进程内一次性捕获。
     """
     try:
         if sender is not None and run_id:
-            output = await _exec_code_streaming(code, "run_python", run_id, sender)
+            output, handle = await _exec_code_streaming(
+                code, "run_python", run_id, sender
+            )
+            if handle.interrupted:
+                return format_success({
+                    "output": output,
+                    "code": code,
+                    "interrupted": True,
+                    "user_message": handle.user_message or "用户中途停止执行",
+                })
+            if handle.exit_code != 0:
+                error = _parse_python_error(output) or f"执行失败，退出码 {handle.exit_code}"
+                return format_error(error)
+            return format_success({"output": output, "code": code})
         else:
             output = await asyncio.to_thread(_exec_code, code)
-        return format_success({"output": output, "code": code})
+            return format_success({"output": output, "code": code})
     except Exception as e:
         return format_error(str(e))
 
@@ -157,13 +302,13 @@ class RunPythonTool(ToolBase):
         code: str = "",
         run_manager: AsyncCallbackManagerForToolRun | None = None,
     ) -> str:
-        """执行代码，实时向前端推送每条 stdout。
+        """执行代码，实时向前端推送每条 stdout，支持前端中途停止。
 
         ``run_manager`` 由 LangChain 自动注入（``BaseTool.arun`` 检测到
         ``_arun`` 声明该形参即注入当前调用的 run manager），其 ``run_id``
         与 WebSocket 回调 ``on_tool_start`` 收到的 run_id 完全一致，用作
         ``tool_stream`` 事件的 call_id，前端据此与工具气泡精确匹配
-        （不依赖 tool_name，并行调用也不会串流）。
+        （不依赖 tool_name，并行调用也不会串流），也是中途停止注册表的键。
         """
         if get_doc:
             return self._load_doc()

--- a/web/src/components/tools/PythonBubble.vue
+++ b/web/src/components/tools/PythonBubble.vue
@@ -76,8 +76,8 @@
           :disabled="stopping"
           @click="stopExecution"
         >
-          <span v-if="stopping">⏳ 停止中…</span>
-          <span v-else>⏹ 停止执行</span>
+          <span v-if="stopping">停止中…</span>
+          <span v-else>停止执行</span>
         </button>
       </div>
     </div>
@@ -91,10 +91,7 @@
     <template v-else-if="toolCall.status === 'done'">
       <!-- 中途停止横幅 -->
       <div v-if="isInterrupted" class="py-interrupted-banner">
-        <span class="py-interrupted-icon">⏹</span>
-        <span class="py-interrupted-text">
-          已中途停止{{ userMessageText ? `：${userMessageText}` : '' }}
-        </span>
+        已中途停止{{ userMessageText ? `：${userMessageText}` : '' }}
       </div>
 
       <div class="py-section">
@@ -499,7 +496,7 @@ function copyCode() {
 
 .btn-stop {
   border-color: color-mix(in srgb, #000 40%, transparent);
-  background: color-mix(in srgb, #000 10%, transparent);
+  background: transparent;
   color: #000;
 }
 
@@ -516,21 +513,12 @@ function copyCode() {
 
 /* ── 已中途停止横幅 ── */
 .py-interrupted-banner {
-  display: flex;
-  align-items: center;
-  gap: 8px;
   margin-bottom: 12px;
   padding: 10px 14px;
-  background: color-mix(in srgb, #000 10%, transparent);
   border: 1px solid color-mix(in srgb, #000 35%, transparent);
   border-radius: 8px;
   color: #000;
   font-size: 12px;
   font-weight: 500;
-}
-
-.py-interrupted-icon {
-  font-size: 13px;
-  flex-shrink: 0;
 }
 </style>

--- a/web/src/components/tools/PythonBubble.vue
+++ b/web/src/components/tools/PythonBubble.vue
@@ -48,7 +48,7 @@
     </template>
 
     <!-- 运行中：有实时输出则流式渲染（tool_stream 逐条累积），否则显示占位文案 -->
-    <div v-else-if="toolCall.status === 'running'" class="bubble-running">
+    <div v-else-if="toolCall.status === 'running'" class="bubble-running py-running">
       <pre
         v-if="liveStdout"
         ref="liveOutEl"
@@ -56,23 +56,28 @@
       >{{ liveStdout }}</pre>
       <span v-else>正在执行代码...</span>
 
-      <!-- 中途停止：截止信息输入框 + 停止按钮（确认分支不渲染此区） -->
-      <div class="py-stop-section">
+      <!-- 中途停止：与批准执行菜单同构——截止信息整行在下，按钮右下对齐 -->
+      <div class="py-section py-stop-section">
+        <div class="py-section-header">
+          <span class="py-section-label">✏️ 截止信息（可选）</span>
+        </div>
         <input
           v-model="stopMessage"
           class="py-stop-input"
           type="text"
-          placeholder="输入截止信息（可选），回车或点击停止…"
+          placeholder="输入传给 Agent 的截止信息（可留空），回车或点击停止…"
           :disabled="stopping"
           @keyup.enter="stopExecution"
         />
+      </div>
+      <div class="py-stop-actions">
         <button
-          class="btn-stop"
+          class="btn-action btn-stop"
           :disabled="stopping"
           @click="stopExecution"
         >
           <span v-if="stopping">⏳ 停止中…</span>
-          <span v-else>⏹ 停止</span>
+          <span v-else>⏹ 停止执行</span>
         </button>
       </div>
     </div>
@@ -448,18 +453,21 @@ function copyCode() {
   background: color-mix(in srgb, var(--accent) 90%, #fff);
 }
 
-/* ── 中途停止控制区 ── */
+/* ── 中途停止菜单：与批准执行菜单同构（整行输入在下，按钮右下对齐） ── */
+.py-running {
+  /* 覆盖 shared.css 的 .bubble-running { display: flex }——运行中要展示
+     实时输出 + 停止菜单，必须是纵向堆叠而非横向排列（否则输入区会跑到
+     输出的右侧）。scoped 属性选择器比全局单类选择器优先级更高。 */
+  display: block;
+}
+
 .py-stop-section {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 10px;
+  margin-top: 14px;
 }
 
 .py-stop-input {
-  flex: 1;
-  min-width: 0;
-  padding: 8px 12px;
+  width: 100%;
+  padding: 10px 12px;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -483,18 +491,16 @@ function copyCode() {
   opacity: 0.6;
 }
 
+.py-stop-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
 .btn-stop {
-  flex-shrink: 0;
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  font-family: inherit;
-  border: 1px solid color-mix(in srgb, #d4766a 40%, transparent);
+  border-color: color-mix(in srgb, #d4766a 40%, transparent);
   background: color-mix(in srgb, #d4766a 10%, transparent);
   color: #d4766a;
-  transition: all 0.15s;
 }
 
 .btn-stop:hover:not(:disabled) {

--- a/web/src/components/tools/PythonBubble.vue
+++ b/web/src/components/tools/PythonBubble.vue
@@ -498,15 +498,15 @@ function copyCode() {
 }
 
 .btn-stop {
-  border-color: color-mix(in srgb, #d4766a 40%, transparent);
-  background: color-mix(in srgb, #d4766a 10%, transparent);
-  color: #d4766a;
+  border-color: color-mix(in srgb, #000 40%, transparent);
+  background: color-mix(in srgb, #000 10%, transparent);
+  color: #000;
 }
 
 .btn-stop:hover:not(:disabled) {
-  background: #d4766a;
+  background: #000;
   color: #fff;
-  border-color: #d4766a;
+  border-color: #000;
 }
 
 .btn-stop:disabled {
@@ -521,10 +521,10 @@ function copyCode() {
   gap: 8px;
   margin-bottom: 12px;
   padding: 10px 14px;
-  background: color-mix(in srgb, #d4766a 10%, transparent);
-  border: 1px solid color-mix(in srgb, #d4766a 35%, transparent);
+  background: color-mix(in srgb, #000 10%, transparent);
+  border: 1px solid color-mix(in srgb, #000 35%, transparent);
   border-radius: 8px;
-  color: #d4766a;
+  color: #000;
   font-size: 12px;
   font-weight: 500;
 }

--- a/web/src/components/tools/PythonBubble.vue
+++ b/web/src/components/tools/PythonBubble.vue
@@ -55,6 +55,26 @@
         class="py-stdout"
       >{{ liveStdout }}</pre>
       <span v-else>正在执行代码...</span>
+
+      <!-- 中途停止：截止信息输入框 + 停止按钮（确认分支不渲染此区） -->
+      <div class="py-stop-section">
+        <input
+          v-model="stopMessage"
+          class="py-stop-input"
+          type="text"
+          placeholder="输入截止信息（可选），回车或点击停止…"
+          :disabled="stopping"
+          @keyup.enter="stopExecution"
+        />
+        <button
+          class="btn-stop"
+          :disabled="stopping"
+          @click="stopExecution"
+        >
+          <span v-if="stopping">⏳ 停止中…</span>
+          <span v-else>⏹ 停止</span>
+        </button>
+      </div>
     </div>
 
     <!-- 错误 -->
@@ -64,6 +84,14 @@
 
     <!-- 完成 -->
     <template v-else-if="toolCall.status === 'done'">
+      <!-- 中途停止横幅 -->
+      <div v-if="isInterrupted" class="py-interrupted-banner">
+        <span class="py-interrupted-icon">⏹</span>
+        <span class="py-interrupted-text">
+          已中途停止{{ userMessageText ? `：${userMessageText}` : '' }}
+        </span>
+      </div>
+
       <div class="py-section">
         <div class="py-section-header">
           <span class="py-section-label">📝 代码</span>
@@ -96,6 +124,37 @@ const emit = defineEmits<{ (e: 'action', p: { action: string; data?: unknown }):
 
 const submitted = ref(false)
 const rejectionReason = ref('')
+
+// 中途停止状态：点击后置 stopping 禁用输入与按钮，防止重复发送
+const stopping = ref(false)
+const stopMessage = ref('')
+
+// 每个新工具调用重置停止状态（防止组件复用残留）
+watch(() => props.toolCall.callId, () => {
+  stopping.value = false
+  stopMessage.value = ''
+})
+
+const isInterrupted = computed(() => {
+  return props.toolCall.toolData?.interrupted === true
+})
+
+const userMessageText = computed(() => {
+  const m = props.toolCall.toolData?.user_message
+  return typeof m === 'string' && m ? m : ''
+})
+
+function stopExecution() {
+  if (stopping.value || !props.toolCall.callId) return
+  stopping.value = true
+  emit('action', {
+    action: 'run_python_interrupt',
+    data: {
+      callId: props.toolCall.callId,
+      message: stopMessage.value.trim(),
+    },
+  })
+}
 
 const isConfirmMode = computed(() => {
   return props.toolCall.interaction?.mode === 'confirm'
@@ -387,5 +446,85 @@ function copyCode() {
 
 .btn-approve:hover {
   background: color-mix(in srgb, var(--accent) 90%, #fff);
+}
+
+/* ── 中途停止控制区 ── */
+.py-stop-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.py-stop-input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--text-primary);
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+
+.py-stop-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.py-stop-input::placeholder {
+  color: var(--text-secondary);
+}
+
+.py-stop-input:disabled {
+  opacity: 0.6;
+}
+
+.btn-stop {
+  flex-shrink: 0;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  border: 1px solid color-mix(in srgb, #d4766a 40%, transparent);
+  background: color-mix(in srgb, #d4766a 10%, transparent);
+  color: #d4766a;
+  transition: all 0.15s;
+}
+
+.btn-stop:hover:not(:disabled) {
+  background: #d4766a;
+  color: #fff;
+  border-color: #d4766a;
+}
+
+.btn-stop:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── 已中途停止横幅 ── */
+.py-interrupted-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  background: color-mix(in srgb, #d4766a 10%, transparent);
+  border: 1px solid color-mix(in srgb, #d4766a 35%, transparent);
+  border-radius: 8px;
+  color: #d4766a;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.py-interrupted-icon {
+  font-size: 13px;
+  flex-shrink: 0;
 }
 </style>

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -109,6 +109,11 @@ export function useChat(sessionId: Ref<string>) {
     store.sendUserResponse(sessionId.value, interactionId, response)
   }
 
+  /** 请求停止某个运行中的 python 子进程（run_python_interrupt），附带用户截止信息。 */
+  function interruptRunPython(callId: string, message: string) {
+    store.interruptRunPython(sessionId.value, callId, message)
+  }
+
   function removeTurns(count: number) {
     store.removeTurns(sessionId.value, count)
   }
@@ -117,6 +122,7 @@ export function useChat(sessionId: Ref<string>) {
     connected, isStreaming, turns, currentTurn, pendingMessages, pendingCount,
     error, contextUsage, taskTrackerData,
     send, cancel, sendUserResponse, removeTurns,
+    interruptRunPython,
     privateMode, setPrivateMode,
     skipRecall, setSkipRecall,
     autoApprove, setAutoApprove,

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -628,6 +628,16 @@ export const useChatStore = defineStore('chat', () => {
     } as ClientMessage))
   }
 
+  /** 请求停止某个运行中的 python 子进程（run_python_interrupt），附带用户截止信息。 */
+  function interruptRunPython(sid: string, callId: string, message: string) {
+    const ch = channels.get(sid)
+    if (!ch?.ws || ch.ws.readyState !== WebSocket.OPEN) return
+    ch.ws.send(JSON.stringify({
+      type: 'run_python_interrupt',
+      payload: { call_id: callId, message },
+    } as ClientMessage))
+  }
+
   function sendUserResponse(sid: string, interactionId: string, response: string | string[]) {
     const ch = channels.get(sid)
     if (!ch?.ws || ch.ws.readyState !== WebSocket.OPEN) return
@@ -681,6 +691,7 @@ export const useChatStore = defineStore('chat', () => {
     send,
     cancel,
     skipMemorySearch,
+    interruptRunPython,
     sendUserResponse,
     removeTurns,
     updateAutoApprove,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -302,7 +302,18 @@ export interface ClearPendingMessage {
   payload: Record<string, never>
 }
 
-export type ClientMessage = ChatMessage | CancelMessage | PingMessage | UserResponseMessage | UpdateAutoApproveMessage | SkipMemorySearchMessage | RemovePendingMessage | ClearPendingMessage
+/** run_python_interrupt — 请求停止某个正在运行的 python 子进程并附带截止信息 */
+export interface RunPythonInterruptMessage {
+  type: 'run_python_interrupt'
+  payload: {
+    /** 目标工具调用的 call_id（= run_id，与 tool_start/tool_end 一致） */
+    call_id: string
+    /** 用户输入的截止信息（可选） */
+    message?: string
+  }
+}
+
+export type ClientMessage = ChatMessage | CancelMessage | PingMessage | UserResponseMessage | UpdateAutoApproveMessage | SkipMemorySearchMessage | RemovePendingMessage | ClearPendingMessage | RunPythonInterruptMessage
 
 // === 前端 UI 状态类型 ===
 

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -181,6 +181,9 @@ function handleToolAction(payload: { action: string; data?: unknown }) {
     sendUserResponse(d.interactionId, d.response)
   } else if (payload.action === 'skip_memory_search') {
     chatStore.skipMemorySearch(sessionId.value)
+  } else if (payload.action === 'run_python_interrupt') {
+    const d = payload.data as { callId: string; message: string }
+    chatStore.interruptRunPython(sessionId.value, d.callId, d.message ?? '')
   } else if (payload.action === 'undo') {
     handleUndo()
   }


### PR DESCRIPTION
## 概述

run_python 工具运行中新增「停止执行」按钮与截止信息输入框。点击停止会**彻底关闭**执行子进程（`proc.kill()`），并将 `interrupted` + `user_message` 返回给 Agent，Agent 结合已产生的部分输出与用户截止信息继续回应，而非整轮取消。

## 后端

- `tools/system/_python_runner.py`：新增子进程执行器（stdin 读代码 → 安全 builtins → `exec`），异常打印 `__RUN_PYTHON_ERROR__` 标记，父进程解析为结构化错误。
- `tools/system/tool_python.py`：流式执行从「进程内线程 exec」改为「子进程隔离执行」。新增 `_ExecHandle` 注册表 + 幂等的 `interrupt_run` / `interrupt_all_runs`（置 flag + 记截止信息 + guarded `proc.kill()`）；增量 UTF-8 解码 + 按行分块推送 `tool_stream`；Windows text 模式 `\n→\r\n` 翻译已修正（与进程内输出字节一致）。
- `api/routes/chat.py`：新增 `run_python_interrupt` WebSocket 消息 handler。
- `api/agent/turn.py`：整轮取消时 `interrupt_all_runs()` 幂等兜底。
- `api/callbacks/tool_extractors.py`：透传 `interrupted` / `user_message` 到工具数据。

## 前端

- `PythonBubble.vue`：运行态气泡内新增截止信息输入框 + 停止按钮（与批准执行菜单同构——输入区整行在输出下方、按钮右下对齐；黑色描边无填充背景）。完成态显示「已中途停止」横幅。
- `types / chatStore / useChat / ChatView`：新增 `run_python_interrupt` 消息类型与发送链路。

## 测试

新增 `tests/test_tool_python_interrupt.py`（真实子进程中断、未知 ID、错误格式化、幂等性），`conftest.py` 安装 Windows Proactor 事件循环策略。相关测试全部通过。
