### PR TITLE
docs: 回填更新动态 PR 编号

### DIFF
--- a/api/data/news.yaml
+++ b/api/data/news.yaml
@@ -6,7 +6,7 @@ news:
     date: "2026-08-23"
     tags: ["Python", "停止", "交互"]
     version: ""
-    pr_number:
+    pr_number: 294
   - id: "run-python-stream-output"
     title: "Python 输出实时流式显示"
     description: "run_python 工具执行代码时，每次 print 的输出都会实时推送并显示在气泡中，运行过程不再是黑盒等待，调试长任务时反馈更直观。"


### PR DESCRIPTION
回填 `run-python-mid-run-stop` 更新动态的 `pr_number: 294`（对应功能 PR）。