### PR TITLE
fix(api): 修复启动时序竞争导致 API 请求 401

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -17,6 +17,7 @@ from api.core.health import get_health_report
 from api.providers.manager import init_manager, get_manager
 from api.providers.enrich import enrich_all_providers
 from api.providers.store import ProviderConfigStore
+from api.core.auth import load_or_create_token
 from api.routes import chat, files, images, memory, sessions, balance, providers
 from api.routes import path_whitelist as path_whitelist_router
 from api.routes import persona as persona_router
@@ -108,6 +109,10 @@ async def _load_const_sessions(app: FastAPI):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # 0. 确保认证 Token 提前就绪：Vite dev/build 启动时会读取 auth_token.yaml
+    #    注入 __API_TOKEN__，若后端尚未生成该文件，前端将嵌入空 Token 导致全站 401。
+    load_or_create_token()
+
     # 1. 初始化 Provider 管理器（从 YAML 加载）
     provider_store = ProviderConfigStore()
     provider_manager = init_manager(provider_store)


### PR DESCRIPTION
## 概述

修复后端 Token 生成时机与前端 API Token 注入之间的启动时序竞争：`/providers/test` 等 API 全站返回 `401 Unauthorized — X-Sonetto-Token 缺失或不匹配`。

## 根因

- 认证 Token 仅在首个**受保护请求**到达时由中间件 `load_or_create_token()` 懒生成，而 `/api/health` 在白名单中，健康检查不会触发生成；
- 前端 Vite dev/build 启动时即读取 `config/auth_token.yaml` 并冻结 `__API_TOKEN__`（`web/vite.config.ts` 的 `loadApiToken()`），一旦文件尚不存在，前端 bundle 将永远不携带 `X-Sonetto-Token`；
- `start.bat` 先起后端、经 `/api/health` 确认就绪后再起前端，恰好构成「前端先于 Token 文件生成」的时序窗口。

## 修复

- `api/server.py`：`lifespan` 启动阶段显式调用 `load_or_create_token()`，保证后端提供任何服务前 Token 文件必然存在，与 `start.bat` 的启动顺序天然契合。

## 测试

- 模拟 `start.bat` 完整时序验证：修复前 Vite 读到空 Token（复现 401），修复后后端启动即生成文件、Vite 读取到非空 Token 且两端一致；
- `python -m py_compile api/server.py` 语法检查通过。

---

这是我第一次用PR进行项目维护，请见谅。