### PR TITLE
feat(web): 结果气泡同步审核气泡的红绿增减显示

### DIFF
--- a/api/callbacks/tool_extractors.py
+++ b/api/callbacks/tool_extractors.py
@@ -4,6 +4,7 @@
 """
 
 import ast
+import json
 from collections.abc import Callable
 from typing import Any
 
@@ -384,20 +385,59 @@ def _extract_file_search(
 def _extract_file_edit(
     _tool_name: str,
     parsed: dict[str, Any],
-    _tool_input: str | None = None,
+    tool_input: str | None = None,
 ) -> dict[str, Any] | None:
-    """多笔精确替换：返回批量结果统计。"""
+    """多笔精确替换：返回批量结果统计 + 每笔 old/new（供前端结果气泡渲染 diff）。"""
     data = _get_data(parsed)
     if data is None:
         return None
     results = data.get("results", [])
+
+    # 从完整入参中解析 edits，按 index 回填 old_string/new_string。
+    # tool_start 推送的 input 被截断到 500 字符，此处收到的是未截断的原始入参；
+    # langchain-core 传入的 input_str 为 str(dict)（单引号，需 literal_eval），
+    # 个别路径为 JSON 字符串，两种格式都兼容（与 _extract_run_python 一致）。
+    edits_by_index: dict[int, dict[str, str]] = {}
+    if tool_input:
+        args: Any = None
+        for parser in (json.loads, ast.literal_eval):
+            try:
+                args = parser(tool_input)
+                break
+            except (ValueError, SyntaxError, TypeError):
+                continue
+        if isinstance(args, dict):
+            raw_edits = args.get("edits", "")
+            try:
+                edit_list = json.loads(raw_edits) if isinstance(raw_edits, str) else raw_edits
+            except (json.JSONDecodeError, TypeError):
+                edit_list = None
+            if isinstance(edit_list, list):
+                for i, edit in enumerate(edit_list):
+                    if isinstance(edit, dict):
+                        old = edit.get("old_string", "")
+                        new = edit.get("new_string", "")
+                        if isinstance(old, str) and isinstance(new, str):
+                            edits_by_index[i] = {"old_string": old, "new_string": new}
+
+    enriched: list[Any] = []
+    for r in results:
+        if not isinstance(r, dict):
+            enriched.append(r)
+            continue
+        item = dict(r)
+        pair = edits_by_index.get(item.get("index", -1))
+        if pair:
+            item.update(pair)
+        enriched.append(item)
+
     return {
         "operation": "edit",
         "file_path": data.get("file_path", ""),
         "total_edits": data.get("total_edits", 0),
         "success_count": data.get("success_count", 0),
         "failed_count": data.get("failed_count", 0),
-        "results": results,
+        "results": enriched,
     }
 
 

--- a/tests/test_tool_extractors.py
+++ b/tests/test_tool_extractors.py
@@ -1,0 +1,97 @@
+"""Tests: 工具输出提取器（api/callbacks/tool_extractors.py）。
+
+当前覆盖 file_edit 提取器的 old_string/new_string 回填（供前端结果气泡渲染 diff）：
+- tool_input 为 str(dict)（langchain-core 实际传入格式，需 literal_eval 解析）
+- tool_input 为 JSON 字符串（个别路径）
+- tool_input 缺失 / 非法 → 优雅降级，results 原样返回
+"""
+
+import json
+
+from api.callbacks.tool_extractors import _dispatch
+
+
+def _make_parsed() -> dict:
+    """模拟 file_edit 工具输出（format_success 结构）。"""
+    return {
+        "success": True,
+        "data": {
+            "file_path": "C:/tmp/a.py",
+            "total_edits": 3,
+            "success_count": 2,
+            "failed_count": 1,
+            "results": [
+                {"index": 0, "status": "ok", "replaced_count": 1},
+                {"index": 1, "status": "error", "message": "未找到匹配"},
+                {"index": 2, "status": "ok", "replaced_count": 3},
+            ],
+        },
+    }
+
+
+def test_file_edit_backfill_from_str_dict_input() -> None:
+    """tool_input 为 str(dict)（单引号）时按 index 回填 old/new。"""
+    edits = json.dumps([
+        {"old_string": "print(1)", "new_string": "print(2)"},
+        {"old_string": "missing", "new_string": "x"},
+        {"old_string": "b", "new_string": "", "replace_all": True},
+    ])
+    # langchain-core 1.x 实际传入格式：str(dict)，嵌套 JSON 串外层为单引号
+    tool_input = f"{{'file_path': 'C:/tmp/a.py', 'edits': {edits!r}}}"
+    out = _dispatch("file_edit", _make_parsed(), tool_input)
+
+    assert out is not None
+    assert out["operation"] == "edit"
+    assert out["results"][0]["old_string"] == "print(1)"
+    assert out["results"][0]["new_string"] == "print(2)"
+    assert out["results"][1]["old_string"] == "missing"
+    assert out["results"][2]["new_string"] == ""
+
+
+def test_file_edit_backfill_from_json_input() -> None:
+    """tool_input 为 JSON 字符串时同样回填。"""
+    tool_input = json.dumps({
+        "file_path": "C:/tmp/a.py",
+        "edits": json.dumps([{"old_string": "a", "new_string": "b"}]),
+    })
+    out = _dispatch("file_edit", _make_parsed(), tool_input)
+
+    assert out is not None
+    assert out["results"][0]["old_string"] == "a"
+    assert out["results"][0]["new_string"] == "b"
+
+
+def test_file_edit_backfill_with_quotes_in_edits() -> None:
+    """edits 内容含单引号/双引号时 str(dict) 解析不炸、回填不失真。"""
+    edits = json.dumps([{"old_string": "it's \"a\"", "new_string": 'b"c'}])
+    tool_input = f"{{'edits': {edits!r}}}"
+    out = _dispatch("file_edit", _make_parsed(), tool_input)
+
+    assert out is not None
+    assert out["results"][0]["old_string"] == "it's \"a\""
+    assert out["results"][0]["new_string"] == 'b"c'
+
+
+def test_file_edit_backfill_edits_as_list() -> None:
+    """edits 直接是数组（非 JSON 串）时也能回填（防御）。"""
+    tool_input = repr({"file_path": "C:/tmp/a.py", "edits": [{"old_string": "a", "new_string": "b"}]})
+    out = _dispatch("file_edit", _make_parsed(), tool_input)
+
+    assert out is not None
+    assert out["results"][0]["old_string"] == "a"
+
+
+def test_file_edit_degrades_without_tool_input() -> None:
+    """tool_input 缺失或非法时不回填、不报错，results 原样返回。"""
+    parsed = _make_parsed()
+    for tool_input in (None, "", "{bad json", "['not', 'a', 'dict']"):
+        out = _dispatch("file_edit", parsed, tool_input)
+        assert out is not None
+        assert out["results"] == parsed["data"]["results"]
+        assert "old_string" not in out["results"][0]
+
+
+def test_file_edit_degrades_on_error_output() -> None:
+    """success=false 的输出不提取（与既有提取器行为一致）。"""
+    parsed = {"success": False, "error": "文件不存在"}
+    assert _dispatch("file_edit", parsed, "{'edits': '[]'}") is None

--- a/web/src/components/tools/FileEditBubble.vue
+++ b/web/src/components/tools/FileEditBubble.vue
@@ -36,9 +36,17 @@
               class="edit-result-item"
               :class="r.status"
             >
-              <span class="eri-icon">{{ r.status === 'ok' ? '&#10003;' : '&#10007;' }}</span>
-              <span class="eri-index">#{{ i + 1 }}</span>
-              <span class="eri-msg">{{ r.message || r.replaced_count + ' 处替换' }}</span>
+              <div class="eri-head">
+                <span class="eri-icon">{{ r.status === 'ok' ? '✓' : '✗' }}</span>
+                <span class="eri-index">#{{ i + 1 }}</span>
+                <span class="eri-msg">{{ r.message || r.replaced_count + ' 处替换' }}</span>
+              </div>
+              <EditDiffPair
+                v-if="r.old_string"
+                class="eri-diff"
+                :old-string="r.old_string"
+                :new-string="r.new_string || ''"
+              />
             </div>
           </div>
           <div class="file-actions">
@@ -91,6 +99,7 @@
 import { computed } from 'vue'
 import type { ToolCall } from '@/types'
 import BubbleChrome from './_shared/BubbleChrome.vue'
+import EditDiffPair from './_shared/EditDiffPair.vue'
 import SonettoBlockerError from './_shared/SonettoBlockerError.vue'
 
 const props = defineProps<{ toolCall: ToolCall }>()
@@ -122,7 +131,7 @@ const multiClass = computed(() => {
 })
 
 const multiIcon = computed(() => {
-  return (td.value.failed_count as number) > 0 ? '&#9888;' : '&#10003;'
+  return (td.value.failed_count as number) > 0 ? '⚠' : '✓'
 })
 
 const multiTitle = computed(() => {
@@ -248,16 +257,26 @@ function copyPath() {
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 4px 0;
-  max-height: 200px;
+  max-height: 300px;
   overflow-y: auto;
 }
 
 .edit-result-item {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  gap: 2px;
   padding: 5px 10px;
   font-size: 13px;
+}
+
+.eri-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.eri-diff {
+  margin-left: 24px;
 }
 
 .edit-result-item.ok {

--- a/web/src/components/tools/FilesBubble.vue
+++ b/web/src/components/tools/FilesBubble.vue
@@ -103,7 +103,7 @@
               :key="i"
               class="item-row"
             >
-              <span class="item-icon">{{ item.type === 'directory' ? '&#128193;' : '&#128196;' }}</span>
+              <span class="item-icon">{{ item.type === 'directory' ? '📁' : '📄' }}</span>
               <span class="item-name">{{ item.name }}</span>
               <span class="item-size" v-if="item.size_bytes != null">{{ formatSize(item.size_bytes) }}</span>
             </div>

--- a/web/src/components/tools/_shared/ConfirmBubble.vue
+++ b/web/src/components/tools/_shared/ConfirmBubble.vue
@@ -41,10 +41,12 @@
             <span class="confirm-section-label">✂️ {{ editsList.length }} 笔编辑</span>
           </div>
           <div class="confirm-edits-block">
-            <div v-for="(e, i) in visibleEdits" :key="i" class="edit-pair">
-              <div class="edit-line edit-old">− {{ e.old_string }}</div>
-              <div class="edit-line edit-new">+ {{ e.new_string }}</div>
-            </div>
+            <EditDiffPair
+              v-for="(e, i) in visibleEdits"
+              :key="i"
+              :old-string="e.old_string"
+              :new-string="e.new_string"
+            />
             <div v-if="editsList.length > MAX_VISIBLE_EDITS" class="edit-more">
               …等 {{ editsList.length }} 笔
             </div>
@@ -85,6 +87,7 @@
 import { computed, ref, watch } from 'vue'
 import type { ConfirmResponse, ToolCall } from '@/types'
 import BubbleChrome from './BubbleChrome.vue'
+import EditDiffPair from './EditDiffPair.vue'
 import { highlightPython } from '@/utils/python-highlight'
 
 const props = defineProps<{ toolCall: ToolCall }>()
@@ -412,25 +415,13 @@ function submitRejection() {
   overflow-y: auto;
 }
 
-.edit-pair {
-  padding: 4px 0;
+.confirm-edits-block :deep(.edit-pair) {
   border-bottom: 1px dashed var(--border);
 }
 
-.edit-pair:last-child {
+.confirm-edits-block :deep(.edit-pair:last-child) {
   border-bottom: none;
 }
-
-.edit-line {
-  font-family: 'SF Mono', 'Consolas', monospace;
-  font-size: 12px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-
-.edit-old { color: #c0392b; }
-.edit-new { color: #2e7d32; }
 
 .edit-more {
   font-size: 11px;

--- a/web/src/components/tools/_shared/EditDiffPair.vue
+++ b/web/src/components/tools/_shared/EditDiffPair.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="edit-pair">
+    <div class="edit-line edit-old">− {{ oldString }}</div>
+    <div class="edit-line edit-new">+ {{ newString }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/** 单笔替换的红绿对照行（− 旧内容 / + 新内容），供确认气泡与结果气泡共用。 */
+defineProps<{ oldString: string; newString: string }>()
+</script>
+
+<style scoped>
+.edit-pair {
+  padding: 4px 0;
+}
+
+.edit-line {
+  font-family: 'SF Mono', 'Consolas', monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.edit-old { color: #c0392b; }
+.edit-new { color: #2e7d32; }
+</style>


### PR DESCRIPTION
## 变更内容

`file_edit` 工具执行完成后，结果气泡此前仅显示「✓/✗ #序号 + 消息」汇总，缺少确认气泡中的红绿替换内容预览。本 PR 将确认气泡的红绿增减显示同步到结果气泡：

### 后端（api/callbacks/tool_extractors.py）
- `_extract_file_edit` 从完整入参中解析 `edits`，按 index 回填每笔的 `old_string` / `new_string` 到 `tool_data.results`（tool_end 的 `tool_data` 通道不截断，不受 `tool_start` 500 字符截断影响）
- 关键点：langchain-core 1.x 回调传入的 `tool_input` 为 `str(dict)`（单引号）格式，`json.loads` 必然失败 → 与 `_extract_run_python` 一致，采用 JSON 优先、`ast.literal_eval` 兜底的双解析器；两种格式均兼容

### 前端（web/src/components/tools/）
- 新增共享组件 `EditDiffPair.vue`：单笔替换的红绿对照行（− 旧 / + 新），样式自确认气泡迁移
- `ConfirmBubble.vue` 编辑列表改用该组件（虚线分隔经 `:deep` 保留，视觉不变）
- `FileEditBubble.vue` 结果项改为「状态头 + diff」，diff 数据缺失时优雅降级为原样汇总；`file_search_text` 分支不动
- `FileEditBubble.vue` / `FilesBubble.vue` 将插值中的 HTML 实体（`&#10003;` 等）替换为字面字符，避免旧环境渲染为原样文本

## 测试

- [x] 新增 `tests/test_tool_extractors.py`：覆盖 str(dict) / JSON / 含引号内容 / edits 为数组 / 入参缺失或非法降级 / 错误输出不提取 共 6 场景
- [x] `pytest tests/test_tool_extractors.py tests/test_file_tools.py tests/test_file_tools_confirm.py` → 49 passed
- [x] `vue-tsc --noEmit` 通过（仅剩 WeatherBubble 既有报错，与本 PR 无关）
- [x] 实测：编辑工具放行后，结果气泡每笔编辑显示红绿替换行；无 diff 数据时降级正常
