### PR TITLE
refactor(tools): 全量工具统一 async _arun 执行

### DIFF
--- a/tests/test_background_decorator.py
+++ b/tests/test_background_decorator.py
@@ -74,14 +74,14 @@ def _setup_session() -> str:
 
 def test_schema_field_injected() -> None:
     """装饰后 args_schema 注入 background 字段（默认 False），未装饰工具不受影响。"""
-    from tools.policies import current_input
+    from tools.policies import get_args_schema
 
     decorated = background(ProbeTool)
-    # pydantic 2.13 下类级字段经 model_fields 读取（与 policies.current_input 一致）
-    assert "background" in current_input(decorated).model_fields
-    assert current_input(decorated).model_fields["background"].default is False
+    # pydantic 2.13 下类级字段经 model_fields 读取（与 policies.get_args_schema 一致）
+    assert "background" in get_args_schema(decorated).model_fields
+    assert get_args_schema(decorated).model_fields["background"].default is False
     # 原类不被原地修改（enrich_tool_class 返回新子类）
-    assert "background" not in current_input(ProbeTool).model_fields
+    assert "background" not in get_args_schema(ProbeTool).model_fields
 
 
 # ── 直通路径 ────────────────────────────────────────────────
@@ -215,11 +215,11 @@ async def test_get_doc_stacks_outer(monkeypatch: pytest.MonkeyPatch) -> None:
     sid = _setup_session()
     try:
         from tools.get_doc import get_doc
-        from tools.policies import current_input
+        from tools.policies import get_args_schema
 
         stacked = get_doc(background(ProbeTool))
-        assert "background" in current_input(stacked).model_fields
-        assert "get_doc" in current_input(stacked).model_fields
+        assert "background" in get_args_schema(stacked).model_fields
+        assert "get_doc" in get_args_schema(stacked).model_fields
 
         tool = stacked()
         doc = await tool.arun({"get_doc": True})

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -185,11 +185,12 @@ async def test_file_create_directory_empty(whitelist_tmp: Path) -> None:
 # ── file_list_directory（保持同步） ────────────────────────
 
 
-def test_file_list_directory(whitelist_tmp: Path) -> None:
+@pytest.mark.asyncio
+async def test_file_list_directory(whitelist_tmp: Path) -> None:
     (whitelist_tmp / "a.txt").write_text("a", encoding="utf-8")
     (whitelist_tmp / "sub").mkdir()
 
-    result = FileListDirectoryTool()._run(directory_path=str(whitelist_tmp))
+    result = await FileListDirectoryTool()._arun(directory_path=str(whitelist_tmp))
     data = _success_data(result)
 
     assert data["count"] == 2
@@ -197,14 +198,15 @@ def test_file_list_directory(whitelist_tmp: Path) -> None:
     assert data["dir_count"] == 1
 
 
-# ── file_search（glob，保持同步） ──────────────────────────
+# ── file_search（glob，后台化，仅异步） ────────────────────
 
 
-def test_file_search_glob(whitelist_tmp: Path) -> None:
+@pytest.mark.asyncio
+async def test_file_search_glob(whitelist_tmp: Path) -> None:
     (whitelist_tmp / "a.txt").write_text("a", encoding="utf-8")
     (whitelist_tmp / "b.py").write_text("b", encoding="utf-8")
 
-    result = FileSearchTool()._run(
+    result = await FileSearchTool()._arun(
         search_pattern="*.txt", directory_path=str(whitelist_tmp)
     )
     data = _success_data(result)
@@ -270,21 +272,23 @@ async def test_file_edit_no_match(whitelist_tmp: Path) -> None:
 # ── file_search_text（保持同步） ───────────────────────────
 
 
-def test_file_search_text(whitelist_tmp: Path) -> None:
+@pytest.mark.asyncio
+async def test_file_search_text(whitelist_tmp: Path) -> None:
     p = whitelist_tmp / "a.txt"
     p.write_text("line1 alpha\nline2 beta\nalpha again", encoding="utf-8")
 
-    result = FileSearchTextTool()._run(file_path=str(p), pattern="alpha")
+    result = await FileSearchTextTool()._arun(file_path=str(p), pattern="alpha")
     data = _success_data(result)
 
     assert data["total_matches"] == 2
 
 
-def test_file_search_text_bad_regex(whitelist_tmp: Path) -> None:
+@pytest.mark.asyncio
+async def test_file_search_text_bad_regex(whitelist_tmp: Path) -> None:
     p = whitelist_tmp / "a.txt"
     p.write_text("hello", encoding="utf-8")
 
-    result = FileSearchTextTool()._run(file_path=str(p), pattern="[unclosed")
+    result = await FileSearchTextTool()._arun(file_path=str(p), pattern="[unclosed")
     assert "正则表达式错误" in _error_msg(result)
 
 

--- a/tests/test_get_doc.py
+++ b/tests/test_get_doc.py
@@ -11,7 +11,7 @@
 - 无参装饰器：所有工具的 get_doc 字段统一用默认文案（不再提供 per-tool 覆写，
   更长引导文案交由同目录 TOOL.md 承载）。
 
-代表工具：sync 用 TodoAddTool，async 用 CallSubAgentTool
+代表工具：TodoAddTool（已异步化，包装 ``_arun``）与 CallSubAgentTool
 （包装 ``_arun``），Command 用 ReadImageTool（本阶段特例）。
 """
 
@@ -52,28 +52,31 @@ def test_decorator_uses_default_description() -> None:
         assert prop["description"] == _DEFAULT_DESC
 
 
-# ── sync 行为（包装 _run）────────────────────────────────
+# ── async 行为（包装 _arun，TodoAddTool 已异步化）─────────
 
 
-def test_sync_get_doc_short_circuits() -> None:
+@pytest.mark.asyncio
+async def test_todo_add_get_doc_short_circuits() -> None:
     """get_doc=True → 返回 _load_doc() 文档，不触达业务逻辑。"""
     tool = TodoAddTool()
-    result = tool._run(get_doc=True)
+    result = await tool._arun(get_doc=True)
     assert result == tool._load_doc()
     assert "Todoist" in result or "本 Tool 暂无文档" in result
 
 
-def test_sync_get_doc_false_forwards_to_logic() -> None:
+@pytest.mark.asyncio
+async def test_todo_add_get_doc_false_forwards_to_logic() -> None:
     """get_doc=False → 原样转发，校验逻辑照常执行。"""
     tool = TodoAddTool()
-    result = tool._run(get_doc=False, content="")
+    result = await tool._arun(get_doc=False, content="")
     assert "不能为空" in result
 
 
-def test_sync_without_get_doc_forwards_to_logic() -> None:
+@pytest.mark.asyncio
+async def test_todo_add_without_get_doc_forwards_to_logic() -> None:
     """不传 get_doc（缺省 False）→ 同样转发。"""
     tool = TodoAddTool()
-    result = tool._run(content="")
+    result = await tool._arun(content="")
     assert "不能为空" in result
 
 
@@ -99,20 +102,22 @@ async def test_async_get_doc_false_forwards_to_logic() -> None:
 # ── read_image 特例（Command 工具普通返回文档）────────────
 
 
-def test_read_image_get_doc_returns_plain_string() -> None:
+@pytest.mark.asyncio
+async def test_read_image_get_doc_returns_plain_string() -> None:
     """get_doc 走普通字符串返回（不再包 Command/ToolMessage）。"""
     tool = ReadImageTool()
-    result = tool._run(get_doc=True)
+    result = await tool._arun(get_doc=True)
     assert isinstance(result, str)
     assert result == tool._load_doc()
 
 
-def test_read_image_normal_path_still_returns_command() -> None:
+@pytest.mark.asyncio
+async def test_read_image_normal_path_still_returns_command() -> None:
     """正常路径（get_doc=False）仍返回 Command 注入消息流，未受影响。"""
     from langgraph.types import Command
 
     tool = ReadImageTool()
-    result = tool._run(image_path="")
+    result = await tool._arun(image_path="")
     assert isinstance(result, Command)
     assert "不能为空" in result.update["messages"][0].content  # type: ignore[union-attr]
 

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -1,0 +1,135 @@
+"""钉住 tools/policies.py 底层原语的契约测试。
+
+不实例化任何工具（仅做类级判定/组装），因此不依赖具体工具模块。
+
+覆盖：
+- ``exec_method_name`` 镜像 langchain 的执行方法判定（sync → _run，async → _arun）；
+  这是与 langchain-core 内部实现绑定的版本敏感契约，升级时此测试应最先报红。
+- ``get_args_schema`` 对未显式设置 args_schema 的工具返回 None。
+- ``enrich_tool_class`` 的幂等性：字段已存在时不再注入、不再产生新子类。
+- 未显式设置 args_schema 却请求注入字段 → 导入期 TypeError（拒绝静默失效）。
+- 只包装方法（confirm 路径）不要求工具显式设置 args_schema。
+"""
+
+from typing import Any
+
+import pytest
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from tools.policies import enrich_tool_class, exec_method_name, get_args_schema
+
+
+# ── 探针：直接子类化 langchain BaseTool，最小可用 ──────────────
+
+class SyncInput(BaseModel):
+    x: int = 0
+
+
+class AsyncInput(BaseModel):
+    y: int = 0
+
+
+class SyncTool(BaseTool):
+    name: str = "sync-tool"
+    description: str = "sync tool"
+    args_schema: type[BaseModel] = SyncInput
+
+    def _run(self, x: int = 0) -> str:  # type: ignore[override]
+        return str(x)
+
+
+class AsyncTool(BaseTool):
+    name: str = "async-tool"
+    description: str = "async tool"
+    args_schema: type[BaseModel] = AsyncInput
+
+    async def _arun(self, y: int = 0) -> str:  # type: ignore[override]
+        return str(y)
+
+
+class SchemalessTool(BaseTool):
+    name: str = "schemaless-tool"
+    description: str = "no explicit args_schema"
+
+    def _run(self) -> str:  # type: ignore[override]
+        return "ok"
+
+
+def _identity_wrap(orig: Any) -> Any:
+    """生成一个新函数对象的包装（换一层但行为不变），用于类级替换判定。"""
+
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        return orig(self, *args, **kwargs)
+
+    return wrapper
+
+
+# ── exec_method_name 契约 ────────────────────────────────────
+
+
+def test_exec_method_name_sync_tool_is_run() -> None:
+    """未覆写 _arun 的工具走同步 _run（BaseTool._arun 默认经线程池执行 _run）。"""
+    assert exec_method_name(SyncTool) == "_run"
+
+
+def test_exec_method_name_async_tool_is_arun() -> None:
+    """覆写了 _arun 的工具，langchain 的同步/异步调用最终都走 _arun。"""
+    assert exec_method_name(AsyncTool) == "_arun"
+
+
+def test_exec_method_name_survives_enrich() -> None:
+    """包装后仍是同一种执行方法名（子类套子类不改变解析结果）。"""
+    enriched = enrich_tool_class(AsyncTool, wrap_method=_identity_wrap)
+    assert exec_method_name(enriched) == "_arun"
+
+
+# ── get_args_schema ──────────────────────────────────────────
+
+
+def test_get_args_schema_returns_model_when_set() -> None:
+    assert get_args_schema(SyncTool) is SyncInput
+
+
+def test_get_args_schema_none_when_unset() -> None:
+    assert get_args_schema(SchemalessTool) is None
+
+
+# ── enrich_tool_class 幂等与失效策略 ──────────────────────────
+
+
+def test_enrich_no_op_returns_same_class() -> None:
+    """无 schema_fields 且无 wrap_method → 原样返回，不产生子类。"""
+    assert enrich_tool_class(SyncTool) is SyncTool
+
+
+def test_enrich_field_already_present_returns_same_class() -> None:
+    """字段已存在（幂等）且不包装 → 不再注入、不再套子类。"""
+    schema_fields = {"x": (int, Field(default=0))}  # x 已在 SyncInput
+    assert enrich_tool_class(SyncTool, schema_fields=schema_fields) is SyncTool
+
+
+def test_enrich_schema_on_schemaless_tool_raises() -> None:
+    """请求注入字段却无显式 args_schema → 导入期 TypeError（拒绝静默失效）。"""
+    schema_fields = {"flag": (bool, Field(default=False))}
+    with pytest.raises(TypeError):
+        enrich_tool_class(SchemalessTool, schema_fields=schema_fields)
+
+
+def test_enrich_wrap_only_works_on_schemaless_tool() -> None:
+    """只包装方法（confirm 路径）不要求工具显式设置 args_schema。"""
+    enriched = enrich_tool_class(SchemalessTool, wrap_method=_identity_wrap)
+    assert enriched is not SchemalessTool
+    assert enriched._run is not SchemalessTool._run
+
+
+def test_enrich_adds_field_to_subclass_not_original() -> None:
+    """注入只落在新子类上，原类 schema 不被原地改写。"""
+    schema_fields = {"flag": (bool, Field(default=False))}
+    enriched = enrich_tool_class(SyncTool, schema_fields=schema_fields)
+    assert enriched is not SyncTool
+    assert "flag" in get_args_schema(enriched).model_fields
+    assert "flag" not in get_args_schema(SyncTool).model_fields
+    # 重复注入同一字段 → 幂等，不再套新层
+    again = enrich_tool_class(enriched, schema_fields=schema_fields)
+    assert again is enriched

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -3,12 +3,11 @@
 不实例化任何工具（仅做类级判定/组装），因此不依赖具体工具模块。
 
 覆盖：
-- ``exec_method_name`` 镜像 langchain 的执行方法判定（sync → _run，async → _arun）；
-  这是与 langchain-core 内部实现绑定的版本敏感契约，升级时此测试应最先报红。
 - ``get_args_schema`` 对未显式设置 args_schema 的工具返回 None。
-- ``enrich_tool_class`` 的幂等性：字段已存在时不再注入、不再产生新子类。
-- 未显式设置 args_schema 却请求注入字段 → 导入期 TypeError（拒绝静默失效）。
-- 只包装方法（confirm 路径）不要求工具显式设置 args_schema。
+- ``enrich_tool_class`` 恒返回「新子类」且不原地修改原类：
+  注入只落在新子类上、包装恒作用在 ``_arun``（全工具 arun 化后不再解析
+  ``_run``）、字段已存在时不重复注入、未显式设置 args_schema 却请求注入字段
+  时导入期 TypeError。
 """
 
 from typing import Any
@@ -17,7 +16,7 @@ import pytest
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
-from tools.policies import enrich_tool_class, exec_method_name, get_args_schema
+from tools.policies import enrich_tool_class, get_args_schema
 
 
 # ── 探针：直接子类化 langchain BaseTool，最小可用 ──────────────
@@ -39,15 +38,6 @@ class SyncTool(BaseTool):
         return str(x)
 
 
-class AsyncTool(BaseTool):
-    name: str = "async-tool"
-    description: str = "async tool"
-    args_schema: type[BaseModel] = AsyncInput
-
-    async def _arun(self, y: int = 0) -> str:  # type: ignore[override]
-        return str(y)
-
-
 class SchemalessTool(BaseTool):
     name: str = "schemaless-tool"
     description: str = "no explicit args_schema"
@@ -65,25 +55,6 @@ def _identity_wrap(orig: Any) -> Any:
     return wrapper
 
 
-# ── exec_method_name 契约 ────────────────────────────────────
-
-
-def test_exec_method_name_sync_tool_is_run() -> None:
-    """未覆写 _arun 的工具走同步 _run（BaseTool._arun 默认经线程池执行 _run）。"""
-    assert exec_method_name(SyncTool) == "_run"
-
-
-def test_exec_method_name_async_tool_is_arun() -> None:
-    """覆写了 _arun 的工具，langchain 的同步/异步调用最终都走 _arun。"""
-    assert exec_method_name(AsyncTool) == "_arun"
-
-
-def test_exec_method_name_survives_enrich() -> None:
-    """包装后仍是同一种执行方法名（子类套子类不改变解析结果）。"""
-    enriched = enrich_tool_class(AsyncTool, wrap_method=_identity_wrap)
-    assert exec_method_name(enriched) == "_arun"
-
-
 # ── get_args_schema ──────────────────────────────────────────
 
 
@@ -95,18 +66,46 @@ def test_get_args_schema_none_when_unset() -> None:
     assert get_args_schema(SchemalessTool) is None
 
 
-# ── enrich_tool_class 幂等与失效策略 ──────────────────────────
+# ── enrich_tool_class：恒新建子类、不原地改原类 ────────────────
 
 
-def test_enrich_no_op_returns_same_class() -> None:
-    """无 schema_fields 且无 wrap_method → 原样返回，不产生子类。"""
-    assert enrich_tool_class(SyncTool) is SyncTool
+def test_enrich_always_returns_new_subclass_not_mutating_original() -> None:
+    """即便无任何增强也返回一个新子类；原类与其 args_schema 原封不动。"""
+    enriched = enrich_tool_class(SyncTool)
+    assert enriched is not SyncTool
+    assert issubclass(enriched, SyncTool)
+    assert get_args_schema(SyncTool) is SyncInput
 
 
-def test_enrich_field_already_present_returns_same_class() -> None:
-    """字段已存在（幂等）且不包装 → 不再注入、不再套子类。"""
-    schema_fields = {"x": (int, Field(default=0))}  # x 已在 SyncInput
-    assert enrich_tool_class(SyncTool, schema_fields=schema_fields) is SyncTool
+def test_enrich_adds_field_to_subclass_not_original() -> None:
+    """注入只落在新子类上；重复注入同一字段不再重复叠加、不再改原 schema。"""
+    schema_fields = {"flag": (bool, Field(default=False))}
+    enriched = enrich_tool_class(SyncTool, schema_fields=schema_fields)
+    assert enriched is not SyncTool
+    assert "flag" in get_args_schema(enriched).model_fields
+    assert "flag" not in get_args_schema(SyncTool).model_fields
+
+    again = enrich_tool_class(enriched, schema_fields=schema_fields)
+    assert again is not enriched  # 每次调用都是新子类
+    assert "flag" in get_args_schema(again).model_fields
+    assert len(get_args_schema(again).model_fields) == len(
+        get_args_schema(enriched).model_fields
+    )  # flag 未被重复注入
+
+
+def test_enrich_wrap_always_targets_arun() -> None:
+    """包装恒作用在 ``_arun``（SyncTool 未覆写时取 BaseTool._arun 默认实现）。"""
+    enriched = enrich_tool_class(SyncTool, wrap_method=_identity_wrap)
+    assert issubclass(enriched, SyncTool)
+    assert enriched._arun is not SyncTool._arun
+    assert enriched._run is SyncTool._run  # _run 不被触碰
+
+
+def test_enrich_wrap_only_works_on_schemaless_tool() -> None:
+    """只包装方法（confirm 路径）不要求工具显式设置 args_schema。"""
+    enriched = enrich_tool_class(SchemalessTool, wrap_method=_identity_wrap)
+    assert enriched is not SchemalessTool
+    assert enriched._arun is not SchemalessTool._arun
 
 
 def test_enrich_schema_on_schemaless_tool_raises() -> None:
@@ -114,22 +113,3 @@ def test_enrich_schema_on_schemaless_tool_raises() -> None:
     schema_fields = {"flag": (bool, Field(default=False))}
     with pytest.raises(TypeError):
         enrich_tool_class(SchemalessTool, schema_fields=schema_fields)
-
-
-def test_enrich_wrap_only_works_on_schemaless_tool() -> None:
-    """只包装方法（confirm 路径）不要求工具显式设置 args_schema。"""
-    enriched = enrich_tool_class(SchemalessTool, wrap_method=_identity_wrap)
-    assert enriched is not SchemalessTool
-    assert enriched._run is not SchemalessTool._run
-
-
-def test_enrich_adds_field_to_subclass_not_original() -> None:
-    """注入只落在新子类上，原类 schema 不被原地改写。"""
-    schema_fields = {"flag": (bool, Field(default=False))}
-    enriched = enrich_tool_class(SyncTool, schema_fields=schema_fields)
-    assert enriched is not SyncTool
-    assert "flag" in get_args_schema(enriched).model_fields
-    assert "flag" not in get_args_schema(SyncTool).model_fields
-    # 重复注入同一字段 → 幂等，不再套新层
-    again = enrich_tool_class(enriched, schema_fields=schema_fields)
-    assert again is enriched

--- a/tests/test_todo/conftest.py
+++ b/tests/test_todo/conftest.py
@@ -23,9 +23,9 @@ def mock_client():
 
 
 @pytest.fixture
-def helper(mock_api):
+def helper(mock_api, mock_client):
     """TodoAPIHelper with mocked api property."""
-    h = TodoAPIHelper("fake-token")
+    h = TodoAPIHelper(mock_client)
     type(h).api = PropertyMock(return_value=mock_api)
     return h
 

--- a/tests/test_todo/helpers.py
+++ b/tests/test_todo/helpers.py
@@ -1,0 +1,13 @@
+"""Todo 测试共享的异步 mock 辅助。"""
+from unittest.mock import AsyncMock
+
+
+async def _apages(pages):
+    """把「每页一个 list」的列表逐页 yield（模拟 AsyncResultsPaginator）。"""
+    for page in pages:
+        yield page
+
+
+def apaginate(pages):
+    """把分页 api 方法 mock 成 async：await → async iterable of pages。"""
+    return AsyncMock(return_value=_apages(pages))

--- a/tests/test_todo/test_complete_uncomplete_delete.py
+++ b/tests/test_todo/test_complete_uncomplete_delete.py
@@ -1,6 +1,8 @@
 """todo_complete / todo_uncomplete / todo_delete 工具测试。"""
 
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
+
+import pytest
 
 from tools.todo.tool_complete import TodoCompleteTool
 from tools.todo.tool_uncomplete import TodoUncompleteTool
@@ -16,43 +18,47 @@ class _BaseTest:
 
 
 class TestComplete(_BaseTest):
-    def test_empty_id_returns_error(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_empty_id_returns_error(self, mock_api, mock_client):
         tool = self._make_tool(TodoCompleteTool, mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="")
+        result = await tool._arun(get_doc=False, task_id="")
         assert "不能为空" in result
 
-    def test_complete_success(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_complete_success(self, mock_api, mock_client):
         t = MagicMock()
         t.id = "t1"
         t.content = "Task"
-        mock_api.get_task.return_value = t
-        mock_api.complete_task.return_value = True
+        mock_api.get_task = AsyncMock(return_value=t)
+        mock_api.complete_task = AsyncMock(return_value=True)
 
         tool = self._make_tool(TodoCompleteTool, mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="t1")
+        result = await tool._arun(get_doc=False, task_id="t1")
         assert "success" in result
         mock_api.complete_task.assert_called_once_with("t1")
 
 
 class TestUncomplete(_BaseTest):
-    def test_uncomplete_success(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_uncomplete_success(self, mock_api, mock_client):
         t = MagicMock()
         t.id = "t1"
         t.content = "Task"
-        mock_api.get_task.return_value = t
-        mock_api.uncomplete_task.return_value = True
+        mock_api.get_task = AsyncMock(return_value=t)
+        mock_api.uncomplete_task = AsyncMock(return_value=True)
 
         tool = self._make_tool(TodoUncompleteTool, mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="t1")
+        result = await tool._arun(get_doc=False, task_id="t1")
         assert "success" in result
         mock_api.uncomplete_task.assert_called_once_with("t1")
 
 
 class TestDelete(_BaseTest):
-    def test_delete_success(self, mock_api, mock_client):
-        mock_api.delete_task.return_value = True
+    @pytest.mark.asyncio
+    async def test_delete_success(self, mock_api, mock_client):
+        mock_api.delete_task = AsyncMock(return_value=True)
 
         tool = self._make_tool(TodoDeleteTool, mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="t1")
+        result = await tool._arun(get_doc=False, task_id="t1")
         assert "success" in result
         mock_api.delete_task.assert_called_once_with("t1")

--- a/tests/test_todo/test_todo_base.py
+++ b/tests/test_todo/test_todo_base.py
@@ -2,6 +2,9 @@
 
 from datetime import date, datetime
 
+import pytest
+
+from tests.test_todo.helpers import apaginate
 from tools.todo.todo_base import TodoAPIHelper
 
 
@@ -58,115 +61,129 @@ class TestParseDatetime:
 
 
 class TestGetProjectId:
-    def test_found(self, helper, mock_api):
+    @pytest.mark.asyncio
+    async def test_found(self, helper, mock_api):
         p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_projects = apaginate([[p]])
 
-        result = helper.get_project_id("Work")
+        result = await helper.get_project_id("Work")
         assert result == "p1"
 
-    def test_case_insensitive(self, helper, mock_api):
+    @pytest.mark.asyncio
+    async def test_case_insensitive(self, helper, mock_api):
         p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_projects = apaginate([[p]])
 
-        result = helper.get_project_id("work")
+        result = await helper.get_project_id("work")
         assert result == "p1"
 
-    def test_not_found(self, helper, mock_api):
+    @pytest.mark.asyncio
+    async def test_not_found(self, helper, mock_api):
         p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_projects = apaginate([[p]])
 
-        result = helper.get_project_id("Nope")
+        result = await helper.get_project_id("Nope")
         assert result is None
 
 
 class TestGetProjectName:
-    def test_found(self, helper, mock_api):
+    @pytest.mark.asyncio
+    async def test_found(self, helper, mock_api):
         p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_projects = apaginate([[p]])
 
-        result = helper.get_project_name("p1")
+        result = await helper.get_project_name("p1")
         assert result == "Work"
 
-    def test_not_found_returns_inbox(self, helper, mock_api):
-        mock_api.get_projects.return_value = [[]]
-        result = helper.get_project_name("nope")
+    @pytest.mark.asyncio
+    async def test_not_found_returns_inbox(self, helper, mock_api):
+        mock_api.get_projects = apaginate([[]])
+        result = await helper.get_project_name("nope")
         assert result == "Inbox"
 
 
 class TestGetSectionId:
-    def test_found(self, helper, mock_api):
+    @pytest.mark.asyncio
+    async def test_found(self, helper, mock_api):
         s = type("FakeSection", (), {"id": "s1", "name": "Backlog", "project_id": "p1"})()
-        mock_api.get_sections.return_value = [[s]]
+        mock_api.get_sections = apaginate([[s]])
 
-        result = helper.get_section_id("Backlog", "p1")
+        result = await helper.get_section_id("Backlog", "p1")
         assert result == "s1"
 
-    def test_case_insensitive(self, helper, mock_api):
+    @pytest.mark.asyncio
+    async def test_case_insensitive(self, helper, mock_api):
         s = type("FakeSection", (), {"id": "s1", "name": "Backlog", "project_id": "p1"})()
-        mock_api.get_sections.return_value = [[s]]
+        mock_api.get_sections = apaginate([[s]])
 
-        result = helper.get_section_id("backlog", "p1")
+        result = await helper.get_section_id("backlog", "p1")
         assert result == "s1"
 
-    def test_not_found(self, helper, mock_api):
-        mock_api.get_sections.return_value = [[]]
-        result = helper.get_section_id("Nope", "p1")
+    @pytest.mark.asyncio
+    async def test_not_found(self, helper, mock_api):
+        mock_api.get_sections = apaginate([[]])
+        result = await helper.get_section_id("Nope", "p1")
         assert result is None
 
 
 class TestGetSectionName:
-    def test_found(self, helper, mock_api):
+    @pytest.mark.asyncio
+    async def test_found(self, helper, mock_api):
         s = type("FakeSection", (), {"id": "s1", "name": "Backlog", "project_id": "p1"})()
-        mock_api.get_sections.return_value = [[s]]
+        mock_api.get_sections = apaginate([[s]])
 
-        result = helper.get_section_name("s1")
+        result = await helper.get_section_name("s1")
         assert result == "Backlog"
 
-    def test_not_found(self, helper, mock_api):
-        mock_api.get_sections.return_value = [[]]
-        result = helper.get_section_name("nope")
+    @pytest.mark.asyncio
+    async def test_not_found(self, helper, mock_api):
+        mock_api.get_sections = apaginate([[]])
+        result = await helper.get_section_name("nope")
         assert result is None
 
 
 class TestFindSectionGlobal:
-    def test_found(self, helper, mock_api):
+    @pytest.mark.asyncio
+    async def test_found(self, helper, mock_api):
         s = type("FakeSection", (), {"id": "s1", "name": "Backlog", "project_id": "p1"})()
-        mock_api.get_sections.return_value = [[s]]
+        mock_api.get_sections = apaginate([[s]])
 
-        result = helper.find_section_global("Backlog")
+        result = await helper.find_section_global("Backlog")
         assert result == ("p1", "s1")
 
-    def test_not_found(self, helper, mock_api):
-        mock_api.get_sections.return_value = [[]]
-        result = helper.find_section_global("Nope")
+    @pytest.mark.asyncio
+    async def test_not_found(self, helper, mock_api):
+        mock_api.get_sections = apaginate([[]])
+        result = await helper.find_section_global("Nope")
         assert result is None
 
 
 class TestGetAllLabels:
-    def test_returns_flat_list(self, helper, mock_api):
+    @pytest.mark.asyncio
+    async def test_returns_flat_list(self, helper, mock_api):
         l1 = type("FakeLabel", (), {"id": "l1", "name": "urgent", "color": "red",
                                      "order": 1, "is_favorite": False})()
         l2 = type("FakeLabel", (), {"id": "l2", "name": "work", "color": "blue",
                                      "order": 2, "is_favorite": False})()
-        mock_api.get_labels.return_value = [[l1], [l2]]
+        mock_api.get_labels = apaginate([[l1], [l2]])
 
-        result = helper.get_all_labels()
+        result = await helper.get_all_labels()
         assert len(result) == 2
         assert result[0].name == "urgent"
         assert result[1].name == "work"
 
 
 class TestTaskToDict:
-    def test_all_fields_present(self, helper, mock_task, mock_api):
-        mock_api.get_projects.return_value = [
+    @pytest.mark.asyncio
+    async def test_all_fields_present(self, helper, mock_task, mock_api):
+        mock_api.get_projects = apaginate([
             [type("FakeProject", (), {"id": "proj123", "name": "Work"})()]
-        ]
-        mock_api.get_sections.return_value = [
+        ])
+        mock_api.get_sections = apaginate([
             [type("FakeSection", (), {"id": "sec789", "name": "Backlog", "project_id": "proj123"})()]
-        ]
+        ])
 
-        result = helper.task_to_dict(mock_task)
+        result = await helper.task_to_dict(mock_task)
 
         assert result["task_id"] == "task999"
         assert result["content"] == "Test task"
@@ -203,11 +220,12 @@ class TestProjectToDict:
 
 
 class TestSectionToDict:
-    def test_all_fields_present(self, helper, mock_section, mock_api):
-        mock_api.get_projects.return_value = [
+    @pytest.mark.asyncio
+    async def test_all_fields_present(self, helper, mock_section, mock_api):
+        mock_api.get_projects = apaginate([
             [type("FakeProject", (), {"id": "proj123", "name": "Work"})()]
-        ]
-        result = helper.section_to_dict(mock_section)
+        ])
+        result = await helper.section_to_dict(mock_section)
         assert result["section_id"] == "sec789"
         assert result["name"] == "Backlog"
         assert result["project_name"] == "Work"

--- a/tests/test_todo/test_tool_add.py
+++ b/tests/test_todo/test_tool_add.py
@@ -1,7 +1,10 @@
 """todo_add 工具测试。"""
 
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
+import pytest
+
+from tests.test_todo.helpers import apaginate
 from tools.todo.tool_add import TodoAddTool
 
 
@@ -14,25 +17,29 @@ def _make_tool(mock_api, mock_client):
 
 
 class TestValidation:
-    def test_get_doc_returns_doc(self, mock_client):
+    @pytest.mark.asyncio
+    async def test_get_doc_returns_doc(self, mock_client):
         """get_doc=True → 不调 API，返回文档。"""
         tool = TodoAddTool(client=mock_client)
-        result = tool._run(get_doc=True)
+        result = await tool._arun(get_doc=True)
         assert "本 Tool 暂无文档" in result or "Todoist" in result
 
-    def test_empty_content_returns_error(self, mock_client):
+    @pytest.mark.asyncio
+    async def test_empty_content_returns_error(self, mock_client):
         tool = TodoAddTool(client=mock_client)
-        result = tool._run(get_doc=False, content="")
+        result = await tool._arun(get_doc=False, content="")
         assert "不能为空" in result
 
-    def test_invalid_priority_returns_error(self, mock_client):
+    @pytest.mark.asyncio
+    async def test_invalid_priority_returns_error(self, mock_client):
         tool = TodoAddTool(client=mock_client)
-        result = tool._run(get_doc=False, content="test", priority=5)
+        result = await tool._arun(get_doc=False, content="test", priority=5)
         assert "无效" in result
 
 
 class TestCreateTask:
-    def test_basic_create(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_basic_create(self, mock_api, mock_client):
         """最基本创建：仅传 content。"""
         mock_task = MagicMock()
         mock_task.id = "new123"
@@ -53,22 +60,23 @@ class TestCreateTask:
         mock_task.creator_id = "u1"
         mock_task.is_completed = False
         mock_task.url = None
-        mock_api.add_task.return_value = mock_task
+        mock_api.add_task = AsyncMock(return_value=mock_task)
 
         # Mock project + section lookups
         p = type("FakeProject", (), {"id": "inbox_id", "name": "Inbox"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, content="Hello")
+        result = await tool._arun(get_doc=False, content="Hello")
 
         assert '"success": true' in result or "success" in result
         mock_api.add_task.assert_called_once()
         kwargs = mock_api.add_task.call_args[1]
         assert kwargs["content"] == "Hello"
 
-    def test_create_with_all_basic_fields(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_create_with_all_basic_fields(self, mock_api, mock_client):
         """创建时传所有基本字段。"""
         mock_task = MagicMock()
         mock_task.id = "new456"
@@ -89,15 +97,15 @@ class TestCreateTask:
         mock_task.creator_id = "u1"
         mock_task.is_completed = False
         mock_task.url = None
-        mock_api.add_task.return_value = mock_task
+        mock_api.add_task = AsyncMock(return_value=mock_task)
 
         p1 = type("FakeProject", (), {"id": "proj123", "name": "My Project"})()
         s1 = type("FakeSection", (), {"id": "sec789", "name": "Backlog", "project_id": "proj123"})()
-        mock_api.get_projects.return_value = [[p1]]
-        mock_api.get_sections.return_value = [[s1]]
+        mock_api.get_projects = apaginate([[p1]])
+        mock_api.get_sections = apaginate([[s1]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(
+        result = await tool._arun(
             get_doc=False,
             content="Test task",
             description="A description",
@@ -123,79 +131,85 @@ class TestCreateTask:
         assert kwargs["assignee_id"] == "user2"
         assert kwargs["order"] == 5
 
-    def test_create_with_due_date(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_create_with_due_date(self, mock_api, mock_client):
         """due_date 被正确解析为 date 对象。"""
         mock_task = MagicMock()
         mock_task.id = "t1"
-        mock_api.add_task.return_value = mock_task
+        mock_api.add_task = AsyncMock(return_value=mock_task)
         p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, content="Test", due_date="2026-07-15")
+        await tool._arun(get_doc=False, content="Test", due_date="2026-07-15")
 
         kwargs = mock_api.add_task.call_args[1]
         from datetime import date
         assert kwargs["due_date"] == date(2026, 7, 15)
 
-    def test_create_with_labels(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_create_with_labels(self, mock_api, mock_client):
         """labels 列表被正确传递。"""
         mock_task = MagicMock()
         mock_task.id = "t1"
-        mock_api.add_task.return_value = mock_task
+        mock_api.add_task = AsyncMock(return_value=mock_task)
         p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, content="Test", labels=["urgent", "work"])
+        await tool._arun(get_doc=False, content="Test", labels=["urgent", "work"])
 
         kwargs = mock_api.add_task.call_args[1]
         assert kwargs["labels"] == ["urgent", "work"]
 
-    def test_create_with_duration(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_create_with_duration(self, mock_api, mock_client):
         """duration / duration_unit 被传入。"""
         mock_task = MagicMock()
         mock_task.id = "t1"
-        mock_api.add_task.return_value = mock_task
+        mock_api.add_task = AsyncMock(return_value=mock_task)
         p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, content="Test", duration=30, duration_unit="minute")
+        await tool._arun(get_doc=False, content="Test", duration=30, duration_unit="minute")
 
         kwargs = mock_api.add_task.call_args[1]
         assert kwargs["duration"] == 30
         assert kwargs["duration_unit"] == "minute"
 
-    def test_create_with_deadline(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_create_with_deadline(self, mock_api, mock_client):
         """deadline_date 被解析为 date 对象。"""
         mock_task = MagicMock()
         mock_task.id = "t1"
-        mock_api.add_task.return_value = mock_task
+        mock_api.add_task = AsyncMock(return_value=mock_task)
         p = type("FakeProject", (), {"id": "p1", "name": "Inbox"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, content="Test", deadline_date="2026-08-01")
+        await tool._arun(get_doc=False, content="Test", deadline_date="2026-08-01")
 
         from datetime import date
         kwargs = mock_api.add_task.call_args[1]
         assert kwargs["deadline_date"] == date(2026, 8, 1)
 
-    def test_nonexistent_project_returns_error(self, mock_api, mock_client):
-        mock_api.get_projects.return_value = [[]]
+    @pytest.mark.asyncio
+    async def test_nonexistent_project_returns_error(self, mock_api, mock_client):
+        mock_api.get_projects = apaginate([[]])
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, content="Test", project_name="Nope")
+        result = await tool._arun(get_doc=False, content="Test", project_name="Nope")
         assert "不存在" in result
 
-    def test_nonexistent_section_returns_error(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_nonexistent_section_returns_error(self, mock_api, mock_client):
         p = type("FakeProject", (), {"id": "p1", "name": "MyProject"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, content="Test", project_name="MyProject", section_name="Nope")
+        result = await tool._arun(get_doc=False, content="Test", project_name="MyProject", section_name="Nope")
         assert "不存在" in result

--- a/tests/test_todo/test_tool_list.py
+++ b/tests/test_todo/test_tool_list.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import MagicMock, PropertyMock
 
+import pytest
+
+from tests.test_todo.helpers import apaginate
 from tools.todo.tool_list import TodoListTool
 
 
@@ -38,52 +41,59 @@ def _fake_task(tid="t1", project_id="proj1", **kw):
 
 
 class TestFilters:
-    def test_no_filter_returns_all(self, mock_api, mock_client):
-        mock_api.get_tasks.return_value = [[_fake_task(), _fake_task("t2")]]
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_all(self, mock_api, mock_client):
+        mock_api.get_tasks = apaginate([[_fake_task(), _fake_task("t2")]])
         p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False)
+        result = await tool._arun(get_doc=False)
         assert "success" in result
         mock_api.get_tasks.assert_called_once_with()
 
-    def test_filter_by_project_name(self, mock_api, mock_client):
-        mock_api.get_tasks.return_value = [[_fake_task()]]
+    @pytest.mark.asyncio
+    async def test_filter_by_project_name(self, mock_api, mock_client):
+        mock_api.get_tasks = apaginate([[_fake_task()]])
         p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_projects = apaginate([[p]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, project_name="Work")
+        await tool._arun(get_doc=False, project_name="Work")
         mock_api.get_tasks.assert_called_once_with(project_id="proj1")
 
-    def test_filter_by_label(self, mock_api, mock_client):
-        mock_api.get_tasks.return_value = [[]]
+    @pytest.mark.asyncio
+    async def test_filter_by_label(self, mock_api, mock_client):
+        mock_api.get_tasks = apaginate([[]])
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, label="urgent")
+        await tool._arun(get_doc=False, label="urgent")
         mock_api.get_tasks.assert_called_once_with(label="urgent")
 
-    def test_filter_by_parent_id(self, mock_api, mock_client):
-        mock_api.get_tasks.return_value = [[]]
+    @pytest.mark.asyncio
+    async def test_filter_by_parent_id(self, mock_api, mock_client):
+        mock_api.get_tasks = apaginate([[]])
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, parent_id="parent1")
+        await tool._arun(get_doc=False, parent_id="parent1")
         mock_api.get_tasks.assert_called_once_with(parent_id="parent1")
 
-    def test_filter_by_ids(self, mock_api, mock_client):
-        mock_api.get_tasks.return_value = [[]]
+    @pytest.mark.asyncio
+    async def test_filter_by_ids(self, mock_api, mock_client):
+        mock_api.get_tasks = apaginate([[]])
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, ids=["t1", "t2"])
+        await tool._arun(get_doc=False, ids=["t1", "t2"])
         mock_api.get_tasks.assert_called_once_with(ids=["t1", "t2"])
 
-    def test_filter_by_limit(self, mock_api, mock_client):
-        mock_api.get_tasks.return_value = [[]]
+    @pytest.mark.asyncio
+    async def test_filter_by_limit(self, mock_api, mock_client):
+        mock_api.get_tasks = apaginate([[]])
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, limit=50)
+        await tool._arun(get_doc=False, limit=50)
         mock_api.get_tasks.assert_called_once_with(limit=50)
 
-    def test_nonexistent_project_returns_empty(self, mock_api, mock_client):
-        mock_api.get_projects.return_value = [[]]
+    @pytest.mark.asyncio
+    async def test_nonexistent_project_returns_empty(self, mock_api, mock_client):
+        mock_api.get_projects = apaginate([[]])
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, project_name="Nope")
+        result = await tool._arun(get_doc=False, project_name="Nope")
         assert '"total": 0' in result

--- a/tests/test_todo/test_tool_list_labels.py
+++ b/tests/test_todo/test_tool_list_labels.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import MagicMock, PropertyMock
 
+import pytest
+
+from tests.test_todo.helpers import apaginate
 from tools.todo.tool_list_labels import TodoListLabelsTool
 
 
@@ -13,16 +16,17 @@ def _make_tool(mock_api, mock_client):
 
 
 class TestListLabels:
-    def test_returns_labels(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_returns_labels(self, mock_api, mock_client):
         l = MagicMock()
         l.id = "l1"
         l.name = "urgent"
         l.color = "red"
         l.order = 1
         l.is_favorite = False
-        mock_api.get_labels.return_value = [[l]]
+        mock_api.get_labels = apaginate([[l]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False)
+        result = await tool._arun(get_doc=False)
         assert "success" in result
         assert "labels" in result

--- a/tests/test_todo/test_tool_list_projects.py
+++ b/tests/test_todo/test_tool_list_projects.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import MagicMock, PropertyMock
 
+import pytest
+
+from tests.test_todo.helpers import apaginate
 from tools.todo.tool_list_projects import TodoListProjectsTool
 
 
@@ -13,7 +16,8 @@ def _make_tool(mock_api, mock_client):
 
 
 class TestListProjects:
-    def test_returns_all_fields(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_returns_all_fields(self, mock_api, mock_client):
         p = MagicMock()
         p.id = "p1"
         p.name = "Work"
@@ -30,10 +34,10 @@ class TestListProjects:
         p.is_inbox_project = False
         p.workspace_id = "ws1"
         p.folder_id = None
-        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_projects = apaginate([[p]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False)
+        result = await tool._arun(get_doc=False)
 
         assert "success" in result
         assert "project_id" in result

--- a/tests/test_todo/test_tool_list_sections.py
+++ b/tests/test_todo/test_tool_list_sections.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import MagicMock, PropertyMock
 
+import pytest
+
+from tests.test_todo.helpers import apaginate
 from tools.todo.tool_list_sections import TodoListSectionsTool
 
 
@@ -13,38 +16,41 @@ def _make_tool(mock_api, mock_client):
 
 
 class TestListSections:
-    def test_list_all_sections(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_list_all_sections(self, mock_api, mock_client):
         s = MagicMock()
         s.id = "s1"
         s.name = "Backlog"
         s.project_id = "p1"
         s.order = 1
         s.is_collapsed = False
-        mock_api.get_sections.return_value = [[s]]
+        mock_api.get_sections = apaginate([[s]])
         p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_projects = apaginate([[p]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False)
+        result = await tool._arun(get_doc=False)
         assert "success" in result
 
-    def test_filter_by_project(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_filter_by_project(self, mock_api, mock_client):
         s = MagicMock()
         s.id = "s1"
         s.name = "Backlog"
         s.project_id = "p1"
         s.order = 1
         s.is_collapsed = False
-        mock_api.get_sections.return_value = [[s]]
+        mock_api.get_sections = apaginate([[s]])
         p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
+        mock_api.get_projects = apaginate([[p]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, project_name="Work")
+        result = await tool._arun(get_doc=False, project_name="Work")
         assert "success" in result
 
-    def test_nonexistent_project_returns_error(self, mock_api, mock_client):
-        mock_api.get_projects.return_value = [[]]
+    @pytest.mark.asyncio
+    async def test_nonexistent_project_returns_error(self, mock_api, mock_client):
+        mock_api.get_projects = apaginate([[]])
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, project_name="Nope")
+        result = await tool._arun(get_doc=False, project_name="Nope")
         assert "不存在" in result

--- a/tests/test_todo/test_tool_query.py
+++ b/tests/test_todo/test_tool_query.py
@@ -1,7 +1,10 @@
 """todo_query 工具测试。"""
 
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
+import pytest
+
+from tests.test_todo.helpers import apaginate
 from tools.todo.tool_query import TodoQueryTool
 
 
@@ -13,18 +16,21 @@ def _make_tool(mock_api, mock_client):
 
 
 class TestQuery:
-    def test_empty_task_id_returns_error(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_empty_task_id_returns_error(self, mock_api, mock_client):
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="")
+        result = await tool._arun(get_doc=False, task_id="")
         assert "不能为空" in result
 
-    def test_nonexistent_task_returns_error(self, mock_api, mock_client):
-        mock_api.get_task.side_effect = Exception("not found")
+    @pytest.mark.asyncio
+    async def test_nonexistent_task_returns_error(self, mock_api, mock_client):
+        mock_api.get_task = AsyncMock(side_effect=Exception("not found"))
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="nope")
+        result = await tool._arun(get_doc=False, task_id="nope")
         assert "不存在" in result
 
-    def test_successful_query_returns_dict(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_successful_query_returns_dict(self, mock_api, mock_client):
         t = MagicMock()
         t.id = "t1"
         t.content = "Task"
@@ -44,12 +50,12 @@ class TestQuery:
         t.creator_id = "u1"
         t.is_completed = False
         t.url = None
-        mock_api.get_task.return_value = t
+        mock_api.get_task = AsyncMock(return_value=t)
         p = type("FakeProject", (), {"id": "p1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="t1")
+        result = await tool._arun(get_doc=False, task_id="t1")
         assert "success" in result
         assert "task_id" in result

--- a/tests/test_todo/test_tool_update.py
+++ b/tests/test_todo/test_tool_update.py
@@ -1,7 +1,10 @@
 """todo_update 工具测试。"""
 
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
+import pytest
+
+from tests.test_todo.helpers import apaginate
 from tools.todo.tool_update import TodoUpdateTool
 
 
@@ -40,101 +43,113 @@ def _fake_task(overrides=None):
 
 
 class TestValidation:
-    def test_empty_task_id_returns_error(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_empty_task_id_returns_error(self, mock_api, mock_client):
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="")
+        result = await tool._arun(get_doc=False, task_id="")
         assert "不能为空" in result
 
-    def test_invalid_priority_returns_error(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_invalid_priority_returns_error(self, mock_api, mock_client):
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="t1", priority=5)
+        result = await tool._arun(get_doc=False, task_id="t1", priority=5)
         assert "无效" in result
 
 
 class TestUpdateFields:
-    def test_update_content_only(self, mock_api, mock_client):
-        mock_api.get_task.return_value = _fake_task()
-        mock_api.update_task.return_value = _fake_task({"content": "New content"})
+    @pytest.mark.asyncio
+    async def test_update_content_only(self, mock_api, mock_client):
+        mock_api.get_task = AsyncMock(return_value=_fake_task())
+        mock_api.update_task = AsyncMock(return_value=_fake_task({"content": "New content"}))
         p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="task1", content="New content")
+        result = await tool._arun(get_doc=False, task_id="task1", content="New content")
         assert "success" in result
         mock_api.update_task.assert_called_once()
         assert mock_api.update_task.call_args[1]["content"] == "New content"
 
-    def test_update_description(self, mock_api, mock_client):
-        mock_api.get_task.return_value = _fake_task()
-        mock_api.update_task.return_value = _fake_task({"description": "New desc"})
+    @pytest.mark.asyncio
+    async def test_update_description(self, mock_api, mock_client):
+        mock_api.get_task = AsyncMock(return_value=_fake_task())
+        mock_api.update_task = AsyncMock(return_value=_fake_task({"description": "New desc"}))
         p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        result = tool._run(get_doc=False, task_id="task1", description="New desc")
+        result = await tool._arun(get_doc=False, task_id="task1", description="New desc")
         assert "success" in result
         assert mock_api.update_task.call_args[1]["description"] == "New desc"
 
-    def test_update_labels(self, mock_api, mock_client):
-        mock_api.get_task.return_value = _fake_task()
-        mock_api.update_task.return_value = _fake_task({"labels": ["urgent"]})
+    @pytest.mark.asyncio
+    async def test_update_labels(self, mock_api, mock_client):
+        mock_api.get_task = AsyncMock(return_value=_fake_task())
+        mock_api.update_task = AsyncMock(return_value=_fake_task({"labels": ["urgent"]}))
         p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, task_id="task1", labels=["urgent"])
+        await tool._arun(get_doc=False, task_id="task1", labels=["urgent"])
         assert mock_api.update_task.call_args[1]["labels"] == ["urgent"]
 
-    def test_update_due_string(self, mock_api, mock_client):
-        mock_api.get_task.return_value = _fake_task()
-        mock_api.update_task.return_value = _fake_task()
+    @pytest.mark.asyncio
+    async def test_update_due_string(self, mock_api, mock_client):
+        mock_api.get_task = AsyncMock(return_value=_fake_task())
+        mock_api.update_task = AsyncMock(return_value=_fake_task())
         p = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, task_id="task1", due_string="next Friday")
+        await tool._arun(get_doc=False, task_id="task1", due_string="next Friday")
         assert mock_api.update_task.call_args[1]["due_string"] == "next Friday"
 
 
 class TestMoveTask:
-    def test_move_project(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_move_project(self, mock_api, mock_client):
         current = _fake_task()
-        mock_api.get_task.return_value = current
-        mock_api.update_task.return_value = current
+        mock_api.get_task = AsyncMock(return_value=current)
+        mock_api.update_task = AsyncMock(return_value=current)
+        mock_api.move_task = AsyncMock()
         p1 = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
         p2 = type("FakeProject", (), {"id": "proj2", "name": "Personal"})()
-        mock_api.get_projects.return_value = [[p1, p2]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p1, p2]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, task_id="task1", project_name="Personal")
+        await tool._arun(get_doc=False, task_id="task1", project_name="Personal")
         mock_api.move_task.assert_called_once_with(task_id="task1", project_id="proj2")
 
-    def test_move_section_within_project(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_move_section_within_project(self, mock_api, mock_client):
         current = _fake_task({"project_id": "proj1", "section_id": None})
-        mock_api.get_task.return_value = current
-        mock_api.update_task.return_value = current
+        mock_api.get_task = AsyncMock(return_value=current)
+        mock_api.update_task = AsyncMock(return_value=current)
+        mock_api.move_task = AsyncMock()
         p1 = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
         s1 = type("FakeSection", (), {"id": "sec1", "name": "Backlog", "project_id": "proj1"})()
-        mock_api.get_projects.return_value = [[p1]]
-        mock_api.get_sections.return_value = [[s1]]
+        mock_api.get_projects = apaginate([[p1]])
+        mock_api.get_sections = apaginate([[s1]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, task_id="task1", section_name="Backlog")
+        await tool._arun(get_doc=False, task_id="task1", section_name="Backlog")
         mock_api.move_task.assert_called_once_with(task_id="task1", section_id="sec1")
 
-    def test_no_move_when_same_project(self, mock_api, mock_client):
+    @pytest.mark.asyncio
+    async def test_no_move_when_same_project(self, mock_api, mock_client):
         current = _fake_task({"project_id": "proj1"})
-        mock_api.get_task.return_value = current
-        mock_api.update_task.return_value = current
+        mock_api.get_task = AsyncMock(return_value=current)
+        mock_api.update_task = AsyncMock(return_value=current)
+        mock_api.move_task = AsyncMock()
         p1 = type("FakeProject", (), {"id": "proj1", "name": "Work"})()
-        mock_api.get_projects.return_value = [[p1]]
-        mock_api.get_sections.return_value = [[]]
+        mock_api.get_projects = apaginate([[p1]])
+        mock_api.get_sections = apaginate([[]])
 
         tool = _make_tool(mock_api, mock_client)
-        tool._run(get_doc=False, task_id="task1", project_name="Work")
+        await tool._arun(get_doc=False, task_id="task1", project_name="Work")
         mock_api.move_task.assert_not_called()

--- a/tools/background.py
+++ b/tools/background.py
@@ -124,9 +124,8 @@ def background(cls: ToolClass) -> ToolClass:
 
     return enrich_tool_class(
         cls,
-        # 强制包装 _arun：sync 工具的 _arun 即 BaseTool._arun 默认实现
-        # （内部线程池执行 _run），spawn 该协程即完成后台化且零阻塞。
-        method_name="_arun",
+        # enrich 恒包装 _arun（见 tools/policies.py）：sync 工具未覆写 _arun 时取
+        # BaseTool._arun 默认实现，其内部线程池执行 _run，spawn 该协程即后台化且零阻塞。
         schema_fields={
             "background": (bool, Field(default=False, description=DEFAULT_DESCRIPTION)),
         },

--- a/tools/background.py
+++ b/tools/background.py
@@ -1,41 +1,19 @@
-"""background — 「后台运行」工具类装饰器。
+"""background — 「后台运行」类装饰器。
 
-把「长耗时操作转入后台、立即返回任务索引」的能力从工具方法中抽离：
+往工具类的 ``args_schema`` 注入非必填 ``background: bool = False`` 字段，并把
+``_arun`` 包一层：``background=True`` 时不等待真实执行体完成，将其作为独立
+``asyncio.Task`` 交给后台任务注册表（api/agent/background.py）运行，本调用立即
+返回统一的任务索引；调用方之后用 ``await_background`` 工具按索引取回结果。
+``background=False``（或缺省）时直通，行为与未装饰一致。
 
-- 类装饰器往工具的 args_schema 注入非必填 ``background: bool = False`` 字段；
-- 强制包装 ``_arun``（见下），``background=False`` 时原样直通（与未装饰行为
-  完全一致）；``background=True`` 时把真实执行体交给后台任务注册表
-  （api/agent/background.py）spawn 为独立 asyncio.Task，调用本身立即返回
-  统一格式的任务索引，agent 之后用 await_background 工具按索引取回结果。
+后台任务运行在 detached 上下文中：spawn 时把 ``background_mode`` ContextVar 置位，
+被装饰工具可据此分支后台专属语义。
 
-双模式支持——同步与异步工具都可装饰：
+用法：
 
-- langchain 的调用最终都走 ``_arun``（子类覆写了 ``_arun`` 时），未覆写时
-  ``_arun`` 即 ``BaseTool._arun`` 默认实现——其内部经线程池执行 ``_run``。
-  因此强制包装 ``_arun`` 后，async 工具 spawn 的是真实 ``_arun``，同步工具
-  spawn 的是「线程池里的 ``_run``」，两条路径统一为同一段 spawn 代码，
-  事件循环均不被阻塞，也无需 run_coroutine_threadsafe。
-- 包装经 ``functools.wraps`` 保留原签名：async 工具签名声明的 ``run_manager``
-  仍会被 langchain 注入并随 kwargs 透传进后台任务（run_python 的流式推送
-  与 run_id 链路因此保持不变）。
-
-用法与叠加顺序：
-
-    @get_doc                 # 最外层：get_doc=True 读文档时不 spawn
-    @confirm_execution(...)  # 审批先于 spawn
     @background
     class SomeTool(ToolBase):
-        ...
-
-适用范围：长耗时工具（网络搜索/抓取、代码执行、大目录扫描、视觉模型
-调用）与子 Agent 调用（call_sub_agent——其结果 Future 由子会话自身轮次
-resolve，与父轮解耦，后台化天然可行；工具侧配套 detached 等待语义）。
-ask_user 系列（值就在于阻塞等用户）、read_image 等返回 Command 的工具
-不适用。
-
-被装饰工具经 ``background_mode`` ContextVar 感知自身是否运行在 detached
-任务中（spawn 时在新任务上下文内置位），用于分支化后台专属语义（如
-call_sub_agent 的等待超时与 detached 事件标记）。
+        async def _arun(self, ...): ...
 """
 
 from __future__ import annotations
@@ -102,8 +80,7 @@ def background(cls: ToolClass) -> ToolClass:
             run_background = bool(kwargs.pop("background", False))
 
             if not run_background:
-                # 直通：sync 工具此时即 BaseTool._arun 默认实现（线程池跑
-                # _run），与未装饰时的行为完全一致。
+                # background=False：直接执行，与未装饰时一致。
                 return await orig(self, *args, **kwargs)
 
             session_id = interaction.current_session_id.get()
@@ -124,8 +101,7 @@ def background(cls: ToolClass) -> ToolClass:
 
     return enrich_tool_class(
         cls,
-        # enrich 恒包装 _arun（见 tools/policies.py）：sync 工具未覆写 _arun 时取
-        # BaseTool._arun 默认实现，其内部线程池执行 _run，spawn 该协程即后台化且零阻塞。
+        # enrich 注入 background 字段并包装 _arun（机制见 tools/policies.py）。
         schema_fields={
             "background": (bool, Field(default=False, description=DEFAULT_DESCRIPTION)),
         },
@@ -136,11 +112,7 @@ def background(cls: ToolClass) -> ToolClass:
 def _spawn_coro(
     orig: Callable[..., Any], self: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
 ) -> Coroutine[Any, Any, Any]:
-    """构造 detached 任务协程：新任务上下文内置位后台模式标记后执行原方法。
-
-    set 发生在新任务自身运行时（协程首次执行），不污染发起调用的上下文，
-    后续同步工具调用读到的 background_mode 仍为 False。
-    """
+    """构造 detached 任务协程：在任务自身上下文里置位后台标记后执行原方法。"""
 
     async def runner() -> Any:
         background_mode.set(True)

--- a/tools/base.py
+++ b/tools/base.py
@@ -1,14 +1,17 @@
 """工具（Tool）基类和共享 HTTP 客户端。"""
 
+import asyncio
 import json
 import os
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 import requests
 from langchain_core.tools import BaseTool
-from todoist_api_python.api import TodoistAPI
+from todoist_api_python.api_async import TodoistAPIAsync
 from uapi import UapiClient
 
 from config.settings import get_settings
@@ -21,7 +24,7 @@ class SharedAPIClient:
         settings = get_settings()
         self._session = requests.Session()
         self._uapi: UapiClient | None = None
-        self._todoist: TodoistAPI | None = None
+        self._todoist: TodoistAPIAsync | None = None
         self._amap_key = settings.amap_api_key
         self._uapis_key = settings.uapis_api_key
         self._todoist_token = settings.todoist_api_token
@@ -33,10 +36,20 @@ class SharedAPIClient:
         return self._uapi
 
     @property
-    def todoist(self) -> TodoistAPI:
+    def todoist(self) -> TodoistAPIAsync:
+        """惰性创建并复用唯一的 Todoist async 客户端（全 Todo 工具共享）。"""
+        if not self._todoist_token:
+            raise ValueError("未找到 Todoist API Token")
         if self._todoist is None:
-            self._todoist = TodoistAPI(self._todoist_token)
+            self._todoist = TodoistAPIAsync(self._todoist_token)
         return self._todoist
+
+    async def aclose(self) -> None:
+        """关闭共享的异步客户端与会话（进程退出 / lifespan shutdown 时调用）。"""
+        if self._todoist is not None:
+            await self._todoist.close()
+            self._todoist = None
+        self._session.close()
 
     @property
     def amap_key(self) -> str:
@@ -97,6 +110,15 @@ def format_success(data: dict) -> str:
 def format_error(message: str) -> str:
     """统一错误响应格式。"""
     return json.dumps({"success": False, "error": message}, ensure_ascii=False)
+
+
+async def off_thread(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """把阻塞的同步 *fn* 丢到默认线程池执行，避免卡住事件循环。
+
+    全工具 arun 化后，`_arun` 内所有会阻塞的同步体（文件 IO、同步 HTTP
+    SDK、目录扫描等）都应经此离环，绝不直接内联在协程里。
+    """
+    return await asyncio.to_thread(fn, *args, **kwargs)
 
 
 def check_sonetto_blocker(target_path: str) -> str | None:

--- a/tools/base.py
+++ b/tools/base.py
@@ -5,7 +5,7 @@ import json
 import os
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, final
 
 import yaml
 
@@ -70,6 +70,16 @@ class ToolBase(BaseTool):
     """所有 Tool 的基类。提供 get_doc 通用实现和统一错误格式。"""
 
     client: SharedAPIClient | None = None
+
+    @final
+    def _run(self, *args: object, **kwargs: object) -> str:
+        """统一占位，满足 ``BaseTool._run`` 抽象；子类一律不覆写。
+
+        全工具统一为异步执行后，langchain 只走 ``_arun``（同步入口 ``run`` /
+        直接 ``_run`` 不被生产调用）。若真有同步路径误入，在此显式失败并提示走
+        ``_arun``。标记 ``@final`` 让类型检查器禁止子类再覆写 ``_run``。
+        """
+        raise NotImplementedError("仅支持异步模式：请覆写 async _arun 并经 arun() 调用")
 
     def _load_doc(self) -> str:
         """读取同目录下的 TOOL.md，作为领域知识返回给 LLM。"""

--- a/tools/confirm.py
+++ b/tools/confirm.py
@@ -1,38 +1,21 @@
-"""confirm_execution — 「执行前确认」工具类装饰器。
+"""confirm_execution — 「执行前确认」类装饰器。
 
-把「执行危险操作前先征得用户同意」的门控逻辑从工具方法中抽离：
+把「执行危险操作前先征得用户同意」的门控逻辑从工具方法中抽离，包装工具的
+``_arun``：
 
-- 会话开启自动执行（auto_approve）时直接放行，不打扰用户；
-- 否则要求 WebSocket 连接可用，通过 ask_user(mode="confirm") 弹出确认，
-  用户 approve 后调用被装饰方法，reject 返回统一拒绝错误；
-- 用户中途取消（CancelledError）返回统一取消错误；注册的交互在 finally 清理。
+- 会话级 auto_approve 开启时直接放行，不打扰用户；
+- 否则经 WebSocket ``ask_user(mode="confirm")`` 请求确认，approve 后才执行原方法，
+  reject 返回统一拒绝错误，用户中途取消返回统一取消错误；
+- 确认期间注册的交互在 finally 清理。
 
-auto mode 信号统一取自会话级 auto_approve（interaction._settings，由 WebSocket
-层写入），对**所有受装饰工具一致生效**，无需逐个传参。
+确认气泡载荷取原方法的用户可见命名参数（已剔除 INJECTED_KWARGS 技术参数）；
+批准后含技术参数的完整 ``**kwargs`` 原样透传给原方法。
 
-作为「针对工具类」的装饰器，与 @get_doc（tools/get_doc.py）共用类装饰器框架
-（tools/policies.py 的 ``enrich_tool_class``）：enrich 恒把 ``_arun`` 包一层
-async wrapper（``functools.wraps`` 保留原签名）。因此：
+用法（作用于工具类，携带参数）：
 
-- 装饰目标是**工具类**而非单个方法；可与其它类装饰器叠层。与 get_doc 同用时
-  必须 ``@get_doc`` 在**外层**、本装饰器在内层：``get_doc=True`` 读文档时在本
-  装饰器（ask_user）之前短路，不弹确认框；顺序反转则读文档也会先弹确认。
-- 确认气泡载荷 = 被装饰方法（除 INJECTED_KWARGS 技术参数：run_manager / config
-  / callbacks / get_doc 外）的全部命名形参，由 wrapper 从 ``**kwargs`` 剔除技术
-  参数后构造，原样转发给 ask_user。langchain 始终以**纯关键字**调用执行方法
-  （输入经 args_schema 校验后透传），故 kwargs 即用户可见入参，前端按工具名选用
-  字段。因此被装饰方法必须以关键字参数被调用、且不含非用户可见的注入注解
-  （InjectedToolCallId 等不在 INJECTED_KWARGS 内，会漏进载荷）。
-- 被装饰方法签名可声明 ``run_manager`` 等技术形参（langchain 仅当签名声明时才
-  注入）。wrapper 批准后把含技术参数的完整 ``**kwargs`` **原样透传**给原方法
-  （只从载荷副本剔除，绝不在 kwargs 上 pop）——run_id 等仅在批准后由原方法取出
-  使用，同一 asyncio 任务内 set/read 天然隔离，确认等待期间 langchain run 保持
-  开启、run_id 不可变，无副作用。
-
-适用范围：run_python 及 5 个破坏性/写入 file 工具（file_write / file_edit /
-file_delete / file_create_directory / file_rename）——仅这些执行前需放行的工具。
-ask_qa / single_choice / multi_choice 属于「采集输入」语义（收集后继续，而非
-确认后放行），不适用。
+    @confirm_execution(question="即将执行危险操作，是否继续？")
+    class SomeTool(ToolBase):
+        async def _arun(self, ...): ...
 """
 
 from __future__ import annotations

--- a/tools/confirm.py
+++ b/tools/confirm.py
@@ -11,14 +11,12 @@ auto mode 信号统一取自会话级 auto_approve（interaction._settings，由
 层写入），对**所有受装饰工具一致生效**，无需逐个传参。
 
 作为「针对工具类」的装饰器，与 @get_doc（tools/get_doc.py）共用类装饰器框架
-（tools/policies.py 的 ``enrich_tool_class``）：解析 langchain 真正会调用的异步
-执行方法（``_arun``，同步 ``_run`` 无法承载异步确认），在其外层包一层同构
-wrapper，并通过 ``functools.wraps`` 保留原签名。因此：
+（tools/policies.py 的 ``enrich_tool_class``）：enrich 恒把 ``_arun`` 包一层
+async wrapper（``functools.wraps`` 保留原签名）。因此：
 
 - 装饰目标是**工具类**而非单个方法；可与其它类装饰器叠层。与 get_doc 同用时
   必须 ``@get_doc`` 在**外层**、本装饰器在内层：``get_doc=True`` 读文档时在本
   装饰器（ask_user）之前短路，不弹确认框；顺序反转则读文档也会先弹确认。
-- 仅支持异步执行工具：装饰到只覆写同步 ``_run`` 的类在导入期抛 TypeError。
 - 确认气泡载荷 = 被装饰方法（除 INJECTED_KWARGS 技术参数：run_manager / config
   / callbacks / get_doc 外）的全部命名形参，由 wrapper 从 ``**kwargs`` 剔除技术
   参数后构造，原样转发给 ask_user。langchain 始终以**纯关键字**调用执行方法
@@ -41,7 +39,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import inspect
 from collections.abc import Callable
 from typing import Any
 
@@ -79,14 +76,6 @@ def confirm_execution(
 
     def decorator(target: ToolClass) -> ToolClass:
         def make_wrapper(orig: Callable[..., Any]) -> Callable[..., Any]:
-            # 确认依赖异步 ask_user，同步 _run 无法承载：在 enrich_tool_class
-            # 内部解析执行方法后、生成子类前校验，非异步工具导入期即 fail-fast。
-            if not inspect.iscoroutinefunction(orig):
-                raise TypeError(
-                    "confirm_execution 仅支持异步执行工具（须覆写 async _arun）；"
-                    f"{target.__name__} 的真实执行方法是同步的 {orig.__name__}"
-                )
-
             @functools.wraps(orig)
             async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
                 # 自动执行：会话级 auto_approve 开启时直接放行，不打扰用户。

--- a/tools/entertainment/tool_tarot.py
+++ b/tools/entertainment/tool_tarot.py
@@ -54,13 +54,6 @@ class TarotTool(ToolBase):
     )
     args_schema: type[BaseModel] = TarotInput
 
-    def _run(
-        self,
-        question: str = "",
-        spread_type: str = "three",
-    ) -> str:
-        raise NotImplementedError("tarot 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         question: str = "",

--- a/tools/entertainment/tool_tarot.py
+++ b/tools/entertainment/tool_tarot.py
@@ -59,6 +59,13 @@ class TarotTool(ToolBase):
         question: str = "",
         spread_type: str = "three",
     ) -> str:
+        raise NotImplementedError("tarot 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
+        self,
+        question: str = "",
+        spread_type: str = "three",
+    ) -> str:
         if not question:
             return format_error("占卜问题不能为空")
         if spread_type not in SPREADS:

--- a/tools/files/tool_file_create_directory.py
+++ b/tools/files/tool_file_create_directory.py
@@ -32,9 +32,6 @@ class FileCreateDirectoryTool(ToolBase):
     )
     args_schema: type[BaseModel] = FileCreateDirectoryInput
 
-    def _run(self, directory_path: str = "") -> str:
-        raise NotImplementedError("file_create_directory 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, directory_path: str = "") -> str:
         """用户确认放行后：离环执行校验与创建目录。"""
         return await off_thread(self._run_impl, directory_path)

--- a/tools/files/tool_file_create_directory.py
+++ b/tools/files/tool_file_create_directory.py
@@ -4,7 +4,13 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_path_access, format_error, format_success
+from tools.base import (
+    ToolBase,
+    check_path_access,
+    format_error,
+    format_success,
+    off_thread,
+)
 from tools.confirm import confirm_execution
 
 
@@ -30,7 +36,11 @@ class FileCreateDirectoryTool(ToolBase):
         raise NotImplementedError("file_create_directory 仅支持异步模式，请使用 _arun")
 
     async def _arun(self, directory_path: str = "") -> str:
-        """用户确认放行后：校验并创建目录（含父目录）。"""
+        """用户确认放行后：离环执行校验与创建目录。"""
+        return await off_thread(self._run_impl, directory_path)
+
+    def _run_impl(self, directory_path: str = "") -> str:
+        """校验并创建目录（含父目录）。"""
         if not directory_path:
             return format_error("创建目录需要提供 directory_path")
 

--- a/tools/files/tool_file_delete.py
+++ b/tools/files/tool_file_delete.py
@@ -33,9 +33,6 @@ class FileDeleteTool(ToolBase):
     )
     args_schema: type[BaseModel] = FileDeleteInput
 
-    def _run(self, file_path: str = "") -> str:
-        raise NotImplementedError("file_delete 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, file_path: str = "") -> str:
         """用户确认放行后：离环执行校验与删除。"""
         return await off_thread(self._run_impl, file_path)

--- a/tools/files/tool_file_delete.py
+++ b/tools/files/tool_file_delete.py
@@ -5,7 +5,13 @@ import shutil
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_path_access, format_error, format_success
+from tools.base import (
+    ToolBase,
+    check_path_access,
+    format_error,
+    format_success,
+    off_thread,
+)
 from tools.confirm import confirm_execution
 
 
@@ -31,7 +37,11 @@ class FileDeleteTool(ToolBase):
         raise NotImplementedError("file_delete 仅支持异步模式，请使用 _arun")
 
     async def _arun(self, file_path: str = "") -> str:
-        """用户确认放行后：校验并删除文件或目录。"""
+        """用户确认放行后：离环执行校验与删除。"""
+        return await off_thread(self._run_impl, file_path)
+
+    def _run_impl(self, file_path: str = "") -> str:
+        """校验并删除文件或目录。"""
         if not file_path:
             return format_error("删除需要提供 file_path")
         if not os.path.exists(file_path):

--- a/tools/files/tool_file_edit.py
+++ b/tools/files/tool_file_edit.py
@@ -49,9 +49,6 @@ class FileEditTool(ToolBase):
     )
     args_schema: type[BaseModel] = FileEditInput
 
-    def _run(self, file_path: str = "", edits: str = "") -> str:
-        raise NotImplementedError("file_edit 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, file_path: str = "", edits: str = "") -> str:
         """用户确认放行后：离环执行校验与编辑。"""
         return await off_thread(self._run_impl, file_path, edits)

--- a/tools/files/tool_file_edit.py
+++ b/tools/files/tool_file_edit.py
@@ -17,6 +17,7 @@ from tools.base import (
     check_sonetto_blocker,
     format_error,
     format_success,
+    off_thread,
 )
 from tools.confirm import confirm_execution
 
@@ -52,7 +53,11 @@ class FileEditTool(ToolBase):
         raise NotImplementedError("file_edit 仅支持异步模式，请使用 _arun")
 
     async def _arun(self, file_path: str = "", edits: str = "") -> str:
-        """用户确认放行后：校验并执行多笔精确编辑。"""
+        """用户确认放行后：离环执行校验与编辑。"""
+        return await off_thread(self._run_impl, file_path, edits)
+
+    def _run_impl(self, file_path: str = "", edits: str = "") -> str:
+        """校验并执行多笔精确编辑。"""
         if not file_path:
             return format_error("file_path 不能为空")
 

--- a/tools/files/tool_file_list_directory.py
+++ b/tools/files/tool_file_list_directory.py
@@ -4,7 +4,13 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_path_access, format_error, format_success
+from tools.base import (
+    ToolBase,
+    check_path_access,
+    format_error,
+    format_success,
+    off_thread,
+)
 
 
 class FileListDirectoryInput(BaseModel):
@@ -22,6 +28,12 @@ class FileListDirectoryTool(ToolBase):
     args_schema: type[BaseModel] = FileListDirectoryInput
 
     def _run(self, directory_path: str = "") -> str:
+        raise NotImplementedError("file_list_directory 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, directory_path: str = "") -> str:
+        return await off_thread(self._run_impl, directory_path)
+
+    def _run_impl(self, directory_path: str = "") -> str:
         if not directory_path:
             directory_path = "."
         if not os.path.exists(directory_path):

--- a/tools/files/tool_file_list_directory.py
+++ b/tools/files/tool_file_list_directory.py
@@ -27,9 +27,6 @@ class FileListDirectoryTool(ToolBase):
     )
     args_schema: type[BaseModel] = FileListDirectoryInput
 
-    def _run(self, directory_path: str = "") -> str:
-        raise NotImplementedError("file_list_directory 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, directory_path: str = "") -> str:
         return await off_thread(self._run_impl, directory_path)
 

--- a/tools/files/tool_file_read.py
+++ b/tools/files/tool_file_read.py
@@ -4,7 +4,13 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_path_access, format_error, format_success
+from tools.base import (
+    ToolBase,
+    check_path_access,
+    format_error,
+    format_success,
+    off_thread,
+)
 
 
 class FileReadInput(BaseModel):
@@ -21,6 +27,12 @@ class FileReadTool(ToolBase):
     args_schema: type[BaseModel] = FileReadInput
 
     def _run(self, file_path: str = "") -> str:
+        raise NotImplementedError("file_read 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, file_path: str = "") -> str:
+        return await off_thread(self._run_impl, file_path)
+
+    def _run_impl(self, file_path: str = "") -> str:
         if not file_path:
             return format_error("读取文件需要提供 file_path")
 

--- a/tools/files/tool_file_read.py
+++ b/tools/files/tool_file_read.py
@@ -26,9 +26,6 @@ class FileReadTool(ToolBase):
     )
     args_schema: type[BaseModel] = FileReadInput
 
-    def _run(self, file_path: str = "") -> str:
-        raise NotImplementedError("file_read 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, file_path: str = "") -> str:
         return await off_thread(self._run_impl, file_path)
 

--- a/tools/files/tool_file_rename.py
+++ b/tools/files/tool_file_rename.py
@@ -4,7 +4,13 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_path_access, format_error, format_success
+from tools.base import (
+    ToolBase,
+    check_path_access,
+    format_error,
+    format_success,
+    off_thread,
+)
 from tools.confirm import confirm_execution
 
 
@@ -31,7 +37,11 @@ class FileRenameTool(ToolBase):
         raise NotImplementedError("file_rename 仅支持异步模式，请使用 _arun")
 
     async def _arun(self, file_path: str = "", new_path: str = "") -> str:
-        """用户确认放行后：校验并重命名/移动。"""
+        """用户确认放行后：离环执行校验与重命名。"""
+        return await off_thread(self._run_impl, file_path, new_path)
+
+    def _run_impl(self, file_path: str = "", new_path: str = "") -> str:
+        """校验并重命名/移动。"""
         if not file_path:
             return format_error("重命名需要提供 file_path")
         if not new_path:

--- a/tools/files/tool_file_rename.py
+++ b/tools/files/tool_file_rename.py
@@ -33,9 +33,6 @@ class FileRenameTool(ToolBase):
     )
     args_schema: type[BaseModel] = FileRenameInput
 
-    def _run(self, file_path: str = "", new_path: str = "") -> str:
-        raise NotImplementedError("file_rename 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, file_path: str = "", new_path: str = "") -> str:
         """用户确认放行后：离环执行校验与重命名。"""
         return await off_thread(self._run_impl, file_path, new_path)

--- a/tools/files/tool_file_search.py
+++ b/tools/files/tool_file_search.py
@@ -5,7 +5,13 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_path_access, format_error, format_success
+from tools.base import (
+    ToolBase,
+    check_path_access,
+    format_error,
+    format_success,
+    off_thread,
+)
 from tools.background import background
 
 
@@ -39,8 +45,23 @@ class FileSearchTool(ToolBase):
         file_filter: str = "all",
         extension: str = "",
     ) -> str:
-        return self._search_files(
-            search_pattern, directory_path, recursive, file_filter, extension
+        raise NotImplementedError("file_search 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
+        self,
+        search_pattern: str = "",
+        directory_path: str = "",
+        recursive: bool = False,
+        file_filter: str = "all",
+        extension: str = "",
+    ) -> str:
+        return await off_thread(
+            self._search_files,
+            search_pattern,
+            directory_path,
+            recursive,
+            file_filter,
+            extension,
         )
 
     def _search_files(

--- a/tools/files/tool_file_search.py
+++ b/tools/files/tool_file_search.py
@@ -37,16 +37,6 @@ class FileSearchTool(ToolBase):
     )
     args_schema: type[BaseModel] = FileSearchInput
 
-    def _run(
-        self,
-        search_pattern: str = "",
-        directory_path: str = "",
-        recursive: bool = False,
-        file_filter: str = "all",
-        extension: str = "",
-    ) -> str:
-        raise NotImplementedError("file_search 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         search_pattern: str = "",

--- a/tools/files/tool_file_search_text.py
+++ b/tools/files/tool_file_search_text.py
@@ -32,14 +32,6 @@ class FileSearchTextTool(ToolBase):
     )
     args_schema: type[BaseModel] = FileSearchTextInput
 
-    def _run(
-        self,
-        file_path: str = "",
-        pattern: str = "",
-        case_insensitive: bool = False,
-    ) -> str:
-        raise NotImplementedError("file_search_text 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         file_path: str = "",

--- a/tools/files/tool_file_search_text.py
+++ b/tools/files/tool_file_search_text.py
@@ -12,6 +12,7 @@ from tools.base import (
     check_sonetto_blocker,
     format_error,
     format_success,
+    off_thread,
 )
 from tools.background import background
 
@@ -32,6 +33,22 @@ class FileSearchTextTool(ToolBase):
     args_schema: type[BaseModel] = FileSearchTextInput
 
     def _run(
+        self,
+        file_path: str = "",
+        pattern: str = "",
+        case_insensitive: bool = False,
+    ) -> str:
+        raise NotImplementedError("file_search_text 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
+        self,
+        file_path: str = "",
+        pattern: str = "",
+        case_insensitive: bool = False,
+    ) -> str:
+        return await off_thread(self._run_impl, file_path, pattern, case_insensitive)
+
+    def _run_impl(
         self,
         file_path: str = "",
         pattern: str = "",

--- a/tools/files/tool_file_write.py
+++ b/tools/files/tool_file_write.py
@@ -33,9 +33,6 @@ class FileWriteTool(ToolBase):
     )
     args_schema: type[BaseModel] = FileWriteInput
 
-    def _run(self, file_path: str = "", content: str = "") -> str:
-        raise NotImplementedError("file_write 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, file_path: str = "", content: str = "") -> str:
         """用户确认放行后：离环执行校验与写入。"""
         return await off_thread(self._run_impl, file_path, content)

--- a/tools/files/tool_file_write.py
+++ b/tools/files/tool_file_write.py
@@ -4,7 +4,13 @@ import os
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, check_path_access, format_error, format_success
+from tools.base import (
+    ToolBase,
+    check_path_access,
+    format_error,
+    format_success,
+    off_thread,
+)
 from tools.confirm import confirm_execution
 
 
@@ -31,7 +37,11 @@ class FileWriteTool(ToolBase):
         raise NotImplementedError("file_write 仅支持异步模式，请使用 _arun")
 
     async def _arun(self, file_path: str = "", content: str = "") -> str:
-        """用户确认放行后：校验并写入（自动创建父目录）。"""
+        """用户确认放行后：离环执行校验与写入。"""
+        return await off_thread(self._run_impl, file_path, content)
+
+    def _run_impl(self, file_path: str = "", content: str = "") -> str:
+        """校验并写入（自动创建父目录）。"""
         if not file_path:
             return format_error("写入文件需要提供 file_path")
         if not content:

--- a/tools/get_doc.py
+++ b/tools/get_doc.py
@@ -33,7 +33,6 @@
 from __future__ import annotations
 
 import functools
-import inspect
 from collections.abc import Callable
 from typing import Any
 
@@ -60,13 +59,6 @@ def get_doc(cls: ToolClass) -> ToolClass:
     """
 
     def make_wrapper(orig: Callable[..., Any]) -> Callable[..., Any]:
-        # 全工具 arun 化后只存在 async 执行方法；同步方法属配置错误，导入期即报错。
-        if not inspect.iscoroutinefunction(orig):
-            raise TypeError(
-                f"@get_doc 仅支持覆写 async _arun 的工具；"
-                f"{orig.__name__} 不是协程函数"
-            )
-
         @functools.wraps(orig)
         async def async_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
             if kwargs.pop("get_doc", False):

--- a/tools/get_doc.py
+++ b/tools/get_doc.py
@@ -1,33 +1,17 @@
 """@get_doc — 「按需返回领域文档」类装饰器。
 
-把散落在每个工具类里的 get_doc 样板（args_schema 的 ``get_doc`` 字段、执行方法
-签名首参、``if get_doc: return self._load_doc()`` 分支）收敛到一处：
-
-- 类装饰器往工具的 ``args_schema`` 注入非必填 ``get_doc: bool = False`` 字段；
-- 包一层 **async** wrapper（全工具 arun 化后执行方法恒为 ``_arun``）：
-  ``get_doc=True`` 时短路返回 ``await off_thread(self._load_doc())``（TOOL.md 按
-  目录加载、读盘离环，返回普通字符串），否则原样转发给原方法；
-- wrapper 通过 ``functools.wraps`` 保留原签名，不影响 langchain 的
-  ``run_manager`` 注入与模型侧 schema（模型侧只认 args_schema）。
+往工具类的 ``args_schema`` 注入非必填 ``get_doc: bool = False`` 字段，并把
+``_arun`` 包一层：``get_doc=True`` 时短路返回 ``self._load_doc()``（同目录
+TOOL.md，经线程池离环读取），否则原样转发原方法。返回的是普通字符串文档。
 
 用法：
 
     @get_doc
     class SomeTool(ToolBase):
-        async def _arun(self, ...): ...   # 须覆写 async _arun（装饰器只支持异步工具）
+        async def _arun(self, ...): ...
 
-无参装饰器：字段描述统一用模块级 ``DEFAULT_DESCRIPTION``。若某工具需要更长
-引导文案，请写到同目录 TOOL.md（``get_doc=True`` 返回的内容），schema 里只放
-通用一句。
-
-设计约定：
-
-- 返回文档走普通字符串路径，绝不发 ask_user、绝不返回 Command。
-  read_image 的 ``Command(goto=model)`` 仅服务于图片 base64 进消息流，
-  get_doc 不做特殊返回（ToolNode 会把 str 归一为 ToolMessage）。
-- 类装饰器返回 pydantic 新子类（见 tools/policies.py），因此可叠在
-  confirm 策略外层：``@get_doc`` 在上、``@confirm_execution`` 在下，
-  ``get_doc=True`` 时在 ask_user 之前短路——读文档不弹确认框。
+无参装饰器；``get_doc`` 字段统一使用 ``DEFAULT_DESCRIPTION`` 文案，更长的引导
+文案请写入同目录 TOOL.md（``get_doc=True`` 返回的内容），不要塞进 schema。
 """
 
 from __future__ import annotations

--- a/tools/get_doc.py
+++ b/tools/get_doc.py
@@ -4,21 +4,17 @@
 签名首参、``if get_doc: return self._load_doc()`` 分支）收敛到一处：
 
 - 类装饰器往工具的 ``args_schema`` 注入非必填 ``get_doc: bool = False`` 字段；
-- 按 langchain 真正的执行方法（``_run``/``_arun``，见 tools/policies.py）包一层
-  同构 wrapper：``get_doc=True`` 时短路返回 ``self._load_doc()``（TOOL.md 按目录
-  加载，返回普通字符串），否则原样转发给原方法；
+- 包一层 **async** wrapper（全工具 arun 化后执行方法恒为 ``_arun``）：
+  ``get_doc=True`` 时短路返回 ``await off_thread(self._load_doc())``（TOOL.md 按
+  目录加载、读盘离环，返回普通字符串），否则原样转发给原方法；
 - wrapper 通过 ``functools.wraps`` 保留原签名，不影响 langchain 的
   ``run_manager`` 注入与模型侧 schema（模型侧只认 args_schema）。
 
 用法：
 
     @get_doc
-    class SomeSyncTool(ToolBase):
-        ...
-
-    @get_doc
-    class SomeAsyncTool(ToolBase):
-        async def _arun(self, ...): ...
+    class SomeTool(ToolBase):
+        async def _arun(self, ...): ...   # 须覆写 async _arun（装饰器只支持异步工具）
 
 无参装饰器：字段描述统一用模块级 ``DEFAULT_DESCRIPTION``。若某工具需要更长
 引导文案，请写到同目录 TOOL.md（``get_doc=True`` 返回的内容），schema 里只放
@@ -45,6 +41,7 @@ from pydantic import Field
 
 from langchain_core.tools import BaseTool
 
+from tools.base import off_thread
 from tools.policies import enrich_tool_class
 
 DEFAULT_DESCRIPTION = "设为 true 以获取使用说明"
@@ -63,25 +60,21 @@ def get_doc(cls: ToolClass) -> ToolClass:
     """
 
     def make_wrapper(orig: Callable[..., Any]) -> Callable[..., Any]:
-        if inspect.iscoroutinefunction(orig):
-
-            @functools.wraps(orig)
-            async def async_wrapper(
-                self: Any, *args: Any, **kwargs: Any
-            ) -> Any:
-                if kwargs.pop("get_doc", False):
-                    return self._load_doc()
-                return await orig(self, *args, **kwargs)
-
-            return async_wrapper
+        # 全工具 arun 化后只存在 async 执行方法；同步方法属配置错误，导入期即报错。
+        if not inspect.iscoroutinefunction(orig):
+            raise TypeError(
+                f"@get_doc 仅支持覆写 async _arun 的工具；"
+                f"{orig.__name__} 不是协程函数"
+            )
 
         @functools.wraps(orig)
-        def sync_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        async def async_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
             if kwargs.pop("get_doc", False):
-                return self._load_doc()
-            return orig(self, *args, **kwargs)
+                # TOOL.md 磁盘读取离环，避免卡事件循环
+                return await off_thread(self._load_doc)
+            return await orig(self, *args, **kwargs)
 
-        return sync_wrapper
+        return async_wrapper
 
     return enrich_tool_class(
         cls,

--- a/tools/interaction/tool_ask_qa.py
+++ b/tools/interaction/tool_ask_qa.py
@@ -21,9 +21,6 @@ class AskUserQATool(ToolBase):
     )
     args_schema: type[BaseModel] = AskUserQAInput
 
-    def _run(self, question: str = "") -> str:
-        raise NotImplementedError("ask_user_qa 仅支持异步模式")
-
     async def _arun(self, question: str = "") -> str:
         if not question:
             return format_error("question 不能为空")

--- a/tools/interaction/tool_multi_choice.py
+++ b/tools/interaction/tool_multi_choice.py
@@ -25,13 +25,6 @@ class AskUserMultiChoiceTool(ToolBase):
     )
     args_schema: type[BaseModel] = AskUserMultiChoiceInput
 
-    def _run(
-        self,
-        question: str = "",
-        options: list[str] | None = None,
-    ) -> str:
-        raise NotImplementedError("ask_user_multi_choice 仅支持异步模式")
-
     async def _arun(
         self,
         question: str = "",

--- a/tools/interaction/tool_single_choice.py
+++ b/tools/interaction/tool_single_choice.py
@@ -25,13 +25,6 @@ class AskUserSingleChoiceTool(ToolBase):
     )
     args_schema: type[BaseModel] = AskUserSingleChoiceInput
 
-    def _run(
-        self,
-        question: str = "",
-        options: list[str] | None = None,
-    ) -> str:
-        raise NotImplementedError("ask_user_single_choice 仅支持异步模式")
-
     async def _arun(
         self,
         question: str = "",

--- a/tools/map/tool_cycling.py
+++ b/tools/map/tool_cycling.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, format_error, format_success, off_thread
 from tools.get_doc import get_doc
 from tools.map.map_api import parse_cycling_response
 
@@ -23,7 +23,10 @@ class CyclingRouteTool(ToolBase):
     )
     args_schema: type[BaseModel] = CyclingRouteInput
 
-    def _run(
+    def _run(self, **kwargs: object) -> str:
+        raise NotImplementedError("get_cycling_route 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
         self,
         origin_longitude: str = "",
         origin_latitude: str = "",
@@ -41,7 +44,8 @@ class CyclingRouteTool(ToolBase):
             return format_error("起点和终点经纬度不能为空")
 
         try:
-            data = self.client.amap_request(
+            data = await off_thread(
+                self.client.amap_request,
                 "/v4/direction/bicycling",
                 {
                     "origin": f"{origin_longitude},{origin_latitude}",

--- a/tools/map/tool_cycling.py
+++ b/tools/map/tool_cycling.py
@@ -23,9 +23,6 @@ class CyclingRouteTool(ToolBase):
     )
     args_schema: type[BaseModel] = CyclingRouteInput
 
-    def _run(self, **kwargs: object) -> str:
-        raise NotImplementedError("get_cycling_route 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         origin_longitude: str = "",

--- a/tools/map/tool_fuzzy_addr.py
+++ b/tools/map/tool_fuzzy_addr.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, format_error, format_success, off_thread
 from tools.get_doc import get_doc
 from tools.map.map_api import parse_poi_response
 
@@ -25,7 +25,10 @@ class FuzzyAddressTool(ToolBase):
     )
     args_schema: type[BaseModel] = FuzzyAddressInput
 
-    def _run(
+    def _run(self, **kwargs: object) -> str:
+        raise NotImplementedError("fuzzy_address_search 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
         self,
         keywords: str = "",
         city: str | None = None,
@@ -52,7 +55,7 @@ class FuzzyAddressTool(ToolBase):
             if citylimit:
                 params["citylimit"] = "true"
 
-            data = self.client.amap_request("/v3/place/text", params)
+            data = await off_thread(self.client.amap_request, "/v3/place/text", params)
             result = parse_poi_response(data)
 
             if result["status"] == "1":

--- a/tools/map/tool_fuzzy_addr.py
+++ b/tools/map/tool_fuzzy_addr.py
@@ -25,9 +25,6 @@ class FuzzyAddressTool(ToolBase):
     )
     args_schema: type[BaseModel] = FuzzyAddressInput
 
-    def _run(self, **kwargs: object) -> str:
-        raise NotImplementedError("fuzzy_address_search 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         keywords: str = "",

--- a/tools/map/tool_geocode.py
+++ b/tools/map/tool_geocode.py
@@ -22,9 +22,6 @@ class GeocodeTool(ToolBase):
     )
     args_schema: type[BaseModel] = GeocodeInput
 
-    def _run(self, address: str = "") -> str:
-        raise NotImplementedError("geocode_address 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, address: str = "") -> str:
         if not address:
             return format_error("address 不能为空")

--- a/tools/map/tool_geocode.py
+++ b/tools/map/tool_geocode.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, format_error, format_success, off_thread
 from tools.get_doc import get_doc
 
 
@@ -23,11 +23,15 @@ class GeocodeTool(ToolBase):
     args_schema: type[BaseModel] = GeocodeInput
 
     def _run(self, address: str = "") -> str:
+        raise NotImplementedError("geocode_address 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, address: str = "") -> str:
         if not address:
             return format_error("address 不能为空")
 
         try:
-            data = self.client.amap_request(
+            data = await off_thread(
+                self.client.amap_request,
                 "/v3/geocode/geo",
                 {"address": address, "output": "json"},
             )

--- a/tools/map/tool_nearby.py
+++ b/tools/map/tool_nearby.py
@@ -26,18 +26,6 @@ class NearbySearchTool(ToolBase):
     )
     args_schema: type[BaseModel] = NearbySearchInput
 
-    def _run(
-        self,
-        location: str = "",
-        keywords: str | None = None,
-        types: str | None = None,
-        radius: int = 1000,
-        sortrule: int = 1,
-        offset: int = 20,
-        page: int = 1,
-    ) -> str:
-        raise NotImplementedError("nearby_search 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         location: str = "",

--- a/tools/map/tool_nearby.py
+++ b/tools/map/tool_nearby.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, format_error, format_success, off_thread
 from tools.get_doc import get_doc
 from tools.map.map_api import parse_poi_response
 
@@ -36,6 +36,18 @@ class NearbySearchTool(ToolBase):
         offset: int = 20,
         page: int = 1,
     ) -> str:
+        raise NotImplementedError("nearby_search 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
+        self,
+        location: str = "",
+        keywords: str | None = None,
+        types: str | None = None,
+        radius: int = 1000,
+        sortrule: int = 1,
+        offset: int = 20,
+        page: int = 1,
+    ) -> str:
         if not location:
             return format_error("location 不能为空")
         if not keywords and not types:
@@ -56,7 +68,7 @@ class NearbySearchTool(ToolBase):
             if types:
                 params["types"] = types
 
-            data = self.client.amap_request("/v3/place/around", params)
+            data = await off_thread(self.client.amap_request, "/v3/place/around", params)
             result = parse_poi_response(data)
 
             if result["status"] == "1":

--- a/tools/map/tool_transit.py
+++ b/tools/map/tool_transit.py
@@ -25,9 +25,6 @@ class TransitRouteTool(ToolBase):
     )
     args_schema: type[BaseModel] = TransitRouteInput
 
-    def _run(self, **kwargs: object) -> str:
-        raise NotImplementedError("get_transit_route 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         origin_longitude: str = "",

--- a/tools/map/tool_transit.py
+++ b/tools/map/tool_transit.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, format_error, format_success, off_thread
 from tools.get_doc import get_doc
 from tools.map.map_api import parse_transit_response
 
@@ -25,7 +25,10 @@ class TransitRouteTool(ToolBase):
     )
     args_schema: type[BaseModel] = TransitRouteInput
 
-    def _run(
+    def _run(self, **kwargs: object) -> str:
+        raise NotImplementedError("get_transit_route 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
         self,
         origin_longitude: str = "",
         origin_latitude: str = "",
@@ -45,7 +48,8 @@ class TransitRouteTool(ToolBase):
             return format_error("起点和终点经纬度不能为空")
 
         try:
-            data = self.client.amap_request(
+            data = await off_thread(
+                self.client.amap_request,
                 "/v3/direction/transit/integrated",
                 {
                     "origin": f"{origin_longitude},{origin_latitude}",

--- a/tools/network/tavily/tool_extract.py
+++ b/tools/network/tavily/tool_extract.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from pydantic import BaseModel, Field
-from tavily import TavilyClient
+from tavily import AsyncTavilyClient
 
 from tools.base import ToolBase, format_success, format_error
 from tools.background import background
@@ -45,20 +45,23 @@ class TavilyExtractTool(ToolBase):
     )
     args_schema: type[BaseModel] = TavilyExtractInput
 
-    _tavily: TavilyClient | None = None
+    _tavily: AsyncTavilyClient | None = None
 
     @property
-    def _tavily_client(self) -> TavilyClient:
+    def _tavily_client(self) -> AsyncTavilyClient:
         if self._tavily is None:
             from config.settings import get_settings
 
             key = get_settings().tavily_api_key
             if not key:
                 raise ValueError("TAVILY_API_KEY 未配置，请在 .env 中设置")
-            self._tavily = TavilyClient(api_key=key)
+            self._tavily = AsyncTavilyClient(api_key=key)
         return self._tavily
 
     def _run(self, **kwargs: Any) -> str:
+        raise NotImplementedError("tavily_extract 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, **kwargs: Any) -> str:
         try:
             urls = kwargs.get("urls", [])
             if not urls:
@@ -78,7 +81,7 @@ class TavilyExtractTool(ToolBase):
             if chunks_per_source is not None:
                 params["chunks_per_source"] = chunks_per_source
 
-            result = self._tavily_client.extract(**params)
+            result = await self._tavily_client.extract(**params)
 
             # Tavily extract 返回格式:
             # { results: [{ url, title, raw_content, images }], failed_results, response_time }

--- a/tools/network/tavily/tool_extract.py
+++ b/tools/network/tavily/tool_extract.py
@@ -58,9 +58,6 @@ class TavilyExtractTool(ToolBase):
             self._tavily = AsyncTavilyClient(api_key=key)
         return self._tavily
 
-    def _run(self, **kwargs: Any) -> str:
-        raise NotImplementedError("tavily_extract 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, **kwargs: Any) -> str:
         try:
             urls = kwargs.get("urls", [])

--- a/tools/network/tavily/tool_search.py
+++ b/tools/network/tavily/tool_search.py
@@ -68,9 +68,6 @@ class TavilySearchTool(ToolBase):
             self._tavily = AsyncTavilyClient(api_key=key)
         return self._tavily
 
-    def _run(self, **kwargs: Any) -> str:
-        raise NotImplementedError("tavily_search 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, **kwargs: Any) -> str:
         try:
             query = kwargs.get("query", "")

--- a/tools/network/tavily/tool_search.py
+++ b/tools/network/tavily/tool_search.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from pydantic import BaseModel, Field
-from tavily import TavilyClient
+from tavily import AsyncTavilyClient
 
 from tools.base import ToolBase, format_success, format_error
 from tools.background import background
@@ -55,20 +55,23 @@ class TavilySearchTool(ToolBase):
     args_schema: type[BaseModel] = TavilySearchInput
 
     # 注意: client 字段被 ToolBase 占用（SharedAPIClient），这里用 _tavily 代替
-    _tavily: TavilyClient | None = None
+    _tavily: AsyncTavilyClient | None = None
 
     @property
-    def _tavily_client(self) -> TavilyClient:
+    def _tavily_client(self) -> AsyncTavilyClient:
         if self._tavily is None:
             from config.settings import get_settings
 
             key = get_settings().tavily_api_key
             if not key:
                 raise ValueError("TAVILY_API_KEY 未配置，请在 .env 中设置")
-            self._tavily = TavilyClient(api_key=key)
+            self._tavily = AsyncTavilyClient(api_key=key)
         return self._tavily
 
     def _run(self, **kwargs: Any) -> str:
+        raise NotImplementedError("tavily_search 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, **kwargs: Any) -> str:
         try:
             query = kwargs.get("query", "")
             max_results = kwargs.get("max_results", 5)
@@ -94,7 +97,7 @@ class TavilySearchTool(ToolBase):
             if exclude_domains is not None:
                 params["exclude_domains"] = exclude_domains
 
-            result = self._tavily_client.search(**params)
+            result = await self._tavily_client.search(**params)
 
             # Tavily 返回格式: { query, answer, results: [...], response_time }
             return format_success(

--- a/tools/network/tool_holiday.py
+++ b/tools/network/tool_holiday.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, format_error, format_success, off_thread
 from tools.background import background
 from tools.get_doc import get_doc
 
@@ -38,7 +38,10 @@ class HolidayCalendarTool(ToolBase):
     )
     args_schema: type[BaseModel] = HolidayCalendarInput
 
-    def _run(
+    def _run(self, **kwargs: object) -> str:
+        raise NotImplementedError("holiday_calendar 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
         self,
         date: str = "",
         month: str = "",
@@ -52,7 +55,8 @@ class HolidayCalendarTool(ToolBase):
             return format_error("必须提供 date、month 或 year 参数之一")
 
         try:
-            result = self.client.uapi.misc.get_misc_holiday_calendar(
+            result = await off_thread(
+                self.client.uapi.misc.get_misc_holiday_calendar,
                 date=date,
                 month=month,
                 year=year,

--- a/tools/network/tool_holiday.py
+++ b/tools/network/tool_holiday.py
@@ -38,9 +38,6 @@ class HolidayCalendarTool(ToolBase):
     )
     args_schema: type[BaseModel] = HolidayCalendarInput
 
-    def _run(self, **kwargs: object) -> str:
-        raise NotImplementedError("holiday_calendar 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         date: str = "",

--- a/tools/network/tool_image_understand.py
+++ b/tools/network/tool_image_understand.py
@@ -10,7 +10,13 @@ from pydantic import BaseModel, Field
 from zai import ZhipuAiClient
 
 from config.settings import get_settings
-from tools.base import ToolBase, check_path_access, format_error, format_success
+from tools.base import (
+    ToolBase,
+    check_path_access,
+    format_error,
+    format_success,
+    off_thread,
+)
 from tools.background import background
 from tools.get_doc import get_doc
 
@@ -75,7 +81,10 @@ class ImageUnderstandTool(ToolBase):
     )
     args_schema: type[BaseModel] = ImageUnderstandInput
 
-    def _run(
+    def _run(self, **kwargs: object) -> str:
+        raise NotImplementedError("analyze_image 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
         self,
         image_source: str = "",
         prompt: str = "请描述这张图片",
@@ -87,11 +96,12 @@ class ImageUnderstandTool(ToolBase):
         client = ZhipuAiClient(api_key=settings.zhipuai_api_key)
 
         try:
-            image_bytes, mime = _load_image_bytes(image_source)
+            image_bytes, mime = await off_thread(_load_image_bytes, image_source)
             image_b64 = base64.b64encode(image_bytes).decode("utf-8")
             data_url = f"data:{mime};base64,{image_b64}"
 
-            response = client.chat.completions.create(
+            response = await off_thread(
+                client.chat.completions.create,
                 model=MODEL,
                 messages=[
                     {

--- a/tools/network/tool_image_understand.py
+++ b/tools/network/tool_image_understand.py
@@ -81,9 +81,6 @@ class ImageUnderstandTool(ToolBase):
     )
     args_schema: type[BaseModel] = ImageUnderstandInput
 
-    def _run(self, **kwargs: object) -> str:
-        raise NotImplementedError("analyze_image 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         image_source: str = "",

--- a/tools/network/tool_read_image.py
+++ b/tools/network/tool_read_image.py
@@ -45,13 +45,6 @@ class ReadImageTool(ToolBase):
     )
     args_schema: type[BaseModel] = ReadImageInput
 
-    def _run(
-        self,
-        image_path: str = "",
-        tool_call_id: str = "",
-    ) -> Command:
-        raise NotImplementedError("read_image 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         image_path: str = "",

--- a/tools/network/tool_read_image.py
+++ b/tools/network/tool_read_image.py
@@ -14,7 +14,13 @@ from langgraph.types import Command
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
-from tools.base import ToolBase, check_path_access, format_error, format_success
+from tools.base import (
+    ToolBase,
+    check_path_access,
+    format_error,
+    format_success,
+    off_thread,
+)
 from tools.get_doc import get_doc
 
 
@@ -40,6 +46,20 @@ class ReadImageTool(ToolBase):
     args_schema: type[BaseModel] = ReadImageInput
 
     def _run(
+        self,
+        image_path: str = "",
+        tool_call_id: str = "",
+    ) -> Command:
+        raise NotImplementedError("read_image 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
+        self,
+        image_path: str = "",
+        tool_call_id: str = "",
+    ) -> Command:
+        return await off_thread(self._run_impl, image_path, tool_call_id)
+
+    def _run_impl(
         self,
         image_path: str = "",
         tool_call_id: str = "",

--- a/tools/network/tool_weather.py
+++ b/tools/network/tool_weather.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from tools.base import ToolBase, format_error, format_success
+from tools.base import ToolBase, format_error, format_success, off_thread
 from tools.background import background
 from tools.get_doc import get_doc
 
@@ -163,8 +163,22 @@ class WeatherTool(ToolBase):
         indices: bool = False,
         lang: str = "zh",
     ) -> str:
+        raise NotImplementedError("weather 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
+        self,
+        city: str = "",
+        adcode: str = "",
+        extended: bool = False,
+        forecast: bool = False,
+        hourly: bool = False,
+        minutely: bool = False,
+        indices: bool = False,
+        lang: str = "zh",
+    ) -> str:
         try:
-            result = self.client.uapi.misc.get_misc_weather(
+            result = await off_thread(
+                self.client.uapi.misc.get_misc_weather,
                 city=city,
                 adcode=adcode,
                 extended=extended,

--- a/tools/network/tool_weather.py
+++ b/tools/network/tool_weather.py
@@ -152,19 +152,6 @@ class WeatherTool(ToolBase):
     )
     args_schema: type[BaseModel] = WeatherInput
 
-    def _run(
-        self,
-        city: str = "",
-        adcode: str = "",
-        extended: bool = False,
-        forecast: bool = False,
-        hourly: bool = False,
-        minutely: bool = False,
-        indices: bool = False,
-        lang: str = "zh",
-    ) -> str:
-        raise NotImplementedError("weather 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         city: str = "",

--- a/tools/policies.py
+++ b/tools/policies.py
@@ -1,115 +1,151 @@
-"""工具策略类装饰器的共享底层原语。
+"""类装饰器（confirm_execution / get_doc / background）共享的底层原语。
 
-confirm_execution 与 get_doc 都改在类层面「操控整个工具类」：解析 langchain
-真正会调用的执行方法（``_run`` 还是 ``_arun``）、必要时替换其实现，并向工具
-的 ``args_schema``（Input pydantic 模型）注入附加字段。本模块收敛这些
-pydantic / langchain 细节，供各策略类装饰器复用，避免各自复制一份。
+这些装饰器都在「类层面」操控整个工具类：解析 langchain 真正会调用的执行方法
+（``_run`` / ``_arun``）、必要时替换其实现，并向工具的 ``args_schema``（Input
+pydantic 模型）注入附加字段。本模块收敛这些 pydantic / langchain 细节，供各
+策略类装饰器复用，避免各自复制一份。
 
-关键机制（pydantic 2.13 / langchain-core 1.3 实证，见 langchain_core/tools/base.py）：
+两个必须先理解的框架事实（pydantic 2.13 / langchain-core 1.3 实证，见
+langchain_core/tools/base.py）：
 
-- 子类覆写了 ``_arun`` 时，langchain 的异步/同步调用最终都走 ``_arun``
-  （``BaseTool.arun`` 按 ``cls._arun is not BaseTool._arun`` 判定选执行函数）；
-  否则走 ``_run``（``BaseTool._arun`` 默认在线程池里执行 ``_run``）。
-  因此解析执行方法的规则恰好与 langchain 自身的判定一致。
-- 事后改写 pydantic 字段（``cls.args_schema = X`` 或改
-  ``model_fields["args_schema"].default``）都不生效——pydantic v2 在类创建时
-  捕获字段默认值。要覆写字段，必须返回一个 pydantic **新子类**，在其命名空间里
-  用 ``__annotations__`` 重声明 ``args_schema`` 字段。
-- 给 Input 模型追加字段用 ``create_model(orig.__name__, __base__=orig, ...)``，
-  兼容已含 ``Annotated[..., InjectedToolCallId]`` 的模型。
+1. 执行方法的判定镜像 langchain 自身：子类覆写 ``_arun`` 时，同步/异步调用最终
+   都走 ``_arun``（``BaseTool.arun`` 按 ``cls._arun is not BaseTool._arun`` 选执行
+   函数）；否则走 ``_run``（``BaseTool._arun`` 默认在线程池里执行 ``_run``）。
+   见 ``exec_method_name``。
+2. 字段只能在 pydantic **新子类**上覆写：pydantic v2 在类创建时捕获字段默认值，
+   事后 ``cls.args_schema = X`` 或改 ``model_fields["args_schema"].default`` 都不
+   生效。因此 enrich 在确有改动时返回 ``type(cls.__name__, (cls,), namespace)``
+   新子类，并在其命名空间里用 ``__annotations__`` 重声明 ``args_schema``；
+   给 Input 模型追加字段则用 ``create_model(orig.__name__, __base__=orig, ...)``，
+   兼容已含 ``Annotated[..., InjectedToolCallId]`` 的模型。
 """
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, create_model
+from collections.abc import Callable
+from typing import Any
+
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel, create_model
+from pydantic.fields import FieldInfo
 
-from typing import Callable
+# args_schema 字段规格：(字段注解类型, Field(...) 产生的 FieldInfo)。
+# 装饰器按此约定注入「策略开关」字段（如 get_doc / background）。
+FieldSpec = tuple[type[Any], FieldInfo]
 
-# langchain 可能注入、以及策略自身消耗的技术性 kwargs——永远不该进
-# ask_user 确认载荷（用户可见字段之外的实现细节）。
+# langchain 可能注入、以及策略自身消耗的技术性 kwargs——永远不该进 ask_user
+# 确认载荷或后台任务摘要（用户可见字段之外的实现细节）。
 INJECTED_KWARGS: frozenset[str] = frozenset({
     "run_manager", "config", "callbacks", "get_doc", "background",
 })
 
 
 def exec_method_name(cls: type[BaseTool]) -> str:
-    """返回 langchain 实际会调用的执行方法名（镜像 BaseTool.arun 的判定）。"""
+    """返回 langchain 实际会调用的执行方法名（镜像 ``BaseTool.arun`` 的判定）。
+
+    判据必须与 langchain 保持一致（覆写 ``_arun`` 走 ``_arun``，否则 ``_run``）；
+    langchain-core 若改动此判定，本函数应在契约测试中报红。注册工具已全 arun 化，
+    对它们本函数恒返回 ``_arun``；保留 _run 分支仅用于容忍未经转换的第三方子类。
+    """
     if cls._arun is not BaseTool._arun:
         return "_arun"
     return "_run"
 
 
-def current_input(cls: type[BaseTool]) -> type[BaseModel] | None:
-    """返回工具当前的 args_schema（Input pydantic 模型），未设置时为 None。"""
+def get_args_schema(cls: type[BaseTool]) -> type[BaseModel] | None:
+    """返回工具当前的 args_schema（Input pydantic 模型），未设置时返回 None。"""
     default = cls.model_fields["args_schema"].default
     if isinstance(default, type) and issubclass(default, BaseModel):
         return default
     return None
 
 
-def add_input_field(
-    orig: type[BaseModel],
-    name: str,
-    typ: type,
-    field: Field,
-) -> type[BaseModel]:
-    """在 Input 模型上追加一个字段，返回（可能新建的）模型。
+def _schema_with_extra_fields(
+    cls: type[BaseTool],
+    schema_fields: dict[str, FieldSpec] | None,
+) -> type[BaseModel] | None:
+    """把 *schema_fields* 注入 Input 模型，返回增强后的模型；无需改动时返回 None。
 
-    幂等：字段已存在时原样返回。新模型以 ``create_model`` 子类化 *orig* 生成，
-    保留其既有全部字段与校验，并把 *name* 追加到末尾（非必填、带默认值）。
+    - 字段已在模型上则跳过（幂等：多套策略叠层时不会重复注入）。
+    - 工具未显式设置 args_schema 时字段将静默不生效（对应包装恒直通）——装饰器
+      声明了能力却被悄然丢弃。此处直接抛 TypeError，让失效在导入期显性暴露
+      （与 confirm_execution 对非异步工具 fail-fast 的做法一致）。
     """
-    if name in orig.model_fields:
-        return orig
-    return create_model(
-        orig.__name__,
-        __base__=orig,
-        **{name: (typ, field)},
-    )
+    if not schema_fields:
+        return None
+    base = get_args_schema(cls)
+    if base is None:
+        raise TypeError(
+            f"{cls.__name__} 未显式设置 args_schema，无法注入字段 "
+            f"{sorted(schema_fields)}"
+        )
+    additions = {
+        name: (annotation, field)
+        for name, (annotation, field) in schema_fields.items()
+        if name not in base.model_fields
+    }
+    if not additions:
+        return None
+    # 一次 create_model 建出携带全部新字段的单层子类：__base__=base 保留既有
+    # 字段与校验，新字段追加在末尾。
+    return create_model(base.__name__, __base__=base, **additions)
+
+
+def _wrapped_exec_method(
+    cls: type[BaseTool],
+    wrap_method: Callable[[Callable[..., Any]], Callable[..., Any]] | None,
+    method_name: str,
+) -> tuple[str, Callable[..., Any]] | None:
+    """解析 *method_name* 指向的方法并交给 *wrap_method* 包装。
+
+    返回 (方法名, 包装后的方法)；*wrap_method* 为空时不包装（返回 None）。
+    此处只读不写原类，替换发生在 enrich 生成的新子类上。
+    """
+    if wrap_method is None:
+        return None
+    return method_name, wrap_method(getattr(cls, method_name))
 
 
 def enrich_tool_class(
     cls: type[BaseTool],
     *,
-    schema_fields: dict[str, tuple[type, Field]] | None = None,
-    wrap_method: Callable[[Callable], Callable] | None = None,
+    schema_fields: dict[str, FieldSpec] | None = None,
+    wrap_method: Callable[[Callable[..., Any]], Callable[..., Any]] | None = None,
     method_name: str | None = None,
 ) -> type[BaseTool]:
-    """返回一个（必要时新建的）pydantic 子类，应用两类增强：
+    """应用两类类级增强，返回一个（必要时新建的）子类：
 
-    - ``schema_fields``：往工具的 args_schema 注入字段；
+    - ``schema_fields``：向 args_schema 注入字段；
     - ``wrap_method``：把真正执行的方法（``_run``/``_arun``）替换为包装结果。
 
-    无任何增强时原样返回 *cls*。字段覆写必须通过新建子类完成（见模块注释），
-    故始终返回 ``type(name, (cls,), namespace)``。继承链上再套一层策略
-    （如 get_doc 叠在 confirm 之上）得到的是子类套子类，天然构成
-    外层→内层→核心 的调用链。
+    两种增强都无实际改动时原样返回 *cls*；否则返回
+    ``type(name, (cls,), namespace)`` 新子类（字段覆写必须落在新子类上，见模块
+    注释）。继承链上再套一层策略（如 get_doc 叠在 confirm 之上）得到的是子类套
+    子类，天然构成 外层→内层→核心 的调用链。
 
-    ``method_name`` 可显式指定要包装的方法名，覆盖默认的 ``exec_method_name``
-    解析（如 background 装饰器强制包装 ``_arun``，使纯同步工具也能以
-    ``asyncio.create_task`` 方式后台化——同步工具未覆写 ``_arun`` 时，该名字
-    解析到 langchain 的默认实现，其内部经线程池执行 ``_run``）。
+    ``method_name`` 可显式指定要包装的方法名，覆盖 ``exec_method_name`` 的默认
+    解析（如 background 装饰器强制包装 ``_arun``，使纯同步工具也能后台化——同步
+    工具未覆写 ``_arun`` 时，该名字解析到 langchain 的默认实现，其内部经线程池
+    执行 ``_run``）。
     """
-    if not schema_fields and wrap_method is None:
+    name = method_name or exec_method_name(cls)
+    new_schema = _schema_with_extra_fields(cls, schema_fields)
+    new_method = _wrapped_exec_method(cls, wrap_method, name)
+    if new_schema is None and new_method is None:
         return cls
-
-    new_input = current_input(cls)
-    if schema_fields and new_input is not None:
-        for name, (typ, field) in schema_fields.items():
-            new_input = add_input_field(new_input, name, typ, field)
-
-    method_name = method_name or exec_method_name(cls)
-    orig = getattr(cls, method_name)
 
     namespace: dict[str, object] = {
         "__module__": cls.__module__,
         "__qualname__": cls.__qualname__,
         "__doc__": cls.__doc__,
     }
-    if schema_fields and new_input is not None and new_input is not current_input(cls):
-        namespace["args_schema"] = new_input
+    if new_schema is not None:
+        # 仅赋值 args_schema 属性不生效：pydantic 在类创建时捕获字段，须在子类
+        # 命名空间里同时用 __annotations__ 重声明 args_schema 才算「覆写字段」。
+        namespace["args_schema"] = new_schema
         namespace["__annotations__"] = {"args_schema": type[BaseModel]}
-    if wrap_method is not None:
-        namespace[method_name] = wrap_method(orig)
+    if new_method is not None:
+        wrapped_name, wrapped = new_method
+        namespace[wrapped_name] = wrapped
 
     return type(cls.__name__, (cls,), namespace)

--- a/tools/policies.py
+++ b/tools/policies.py
@@ -1,14 +1,15 @@
 """类装饰器（confirm_execution / get_doc / background）共享的底层原语。
 
-仓库里的工具已全部统一为「真身 ``async def _arun``」形态，因此这些装饰器
-无需再判断执行方法是 ``_run`` 还是 ``_arun`` —— 一律包装 ``_arun``、只产出
-async wrapper。本模块收敛这类「类级增强」所需的 pydantic / langchain 细节。
+统一约定：工具类只实现 ``async def _arun``，装饰器也一律只包装 ``_arun``。
 
-框架事实（pydantic 2.x）：字段默认值在类创建时被捕获，事后改 ``cls.args_schema``
-或 ``model_fields["args_schema"].default`` 都不生效；要追加/覆写字段只能返回一个
-**pydantic 新子类**，在其命名空间里用 ``__annotations__`` 重声明 ``args_schema``。
+本模块提供两个原语：
+- ``get_args_schema``：读取工具当前的 Input 模型；
+- ``enrich_tool_class``：给工具类注入 schema 字段、包装 ``_arun``，返回其新子类。
+
+机制（pydantic 2.x 在类创建时捕获字段默认值，事后改写不生效）：要追加/覆写
+``args_schema`` 只能返回新子类，在其命名空间里用 ``__annotations__`` 重声明；
 追加字段用 ``create_model(orig.__name__, __base__=orig, ...)`` 生成携带新字段的
-Input 模型，保留原字段与校验（兼容已含 ``Annotated[..., InjectedToolCallId]``
+Input 模型（保留原字段与校验，兼容含 ``Annotated[..., InjectedToolCallId]``
 的模型）。
 """
 
@@ -74,17 +75,13 @@ def enrich_tool_class(
     schema_fields: dict[str, FieldSpec] | None = None,
     wrap_method: Callable[[Callable[..., Any]], Callable[..., Any]] | None = None,
 ) -> type[BaseTool]:
-    """对工具类应用两类「类级增强」，返回它的一个新子类（纯函数，不改原类）：
+    """对工具类应用两类「类级增强」，返回其新子类（纯函数，不改原类）：
 
-    - ``schema_fields``：向 args_schema 注入策略开关字段；
+    - ``schema_fields``：向 args_schema 注入开关字段；
     - ``wrap_method``：把 ``_arun`` 替换为包装结果。
 
-    ``_arun`` 一定可取（覆写即真实异步体；未覆写时取 ``BaseTool._arun`` 默认实现，
-    其内部经线程池执行 ``_run``），故无需解析 sync/async。
-
-    每次调用都新建子类：叠加策略（get_doc 叠在 confirm / background 之上）天然构成
-    外层→内层→核心 的调用链。重复应用同一策略会再包一层（方法被二次包装），
-    属调用方责任，本函数不做隐式去重。
+    始终新建子类，叠加多个增强即子类套子类、外层包装内层。``_arun`` 必可取：
+    未覆写时是 ``BaseTool._arun`` 默认实现（其内部经线程池执行 ``_run``）。
     """
     namespace: dict[str, object] = {
         "__module__": cls.__module__,

--- a/tools/policies.py
+++ b/tools/policies.py
@@ -1,23 +1,15 @@
 """类装饰器（confirm_execution / get_doc / background）共享的底层原语。
 
-这些装饰器都在「类层面」操控整个工具类：解析 langchain 真正会调用的执行方法
-（``_run`` / ``_arun``）、必要时替换其实现，并向工具的 ``args_schema``（Input
-pydantic 模型）注入附加字段。本模块收敛这些 pydantic / langchain 细节，供各
-策略类装饰器复用，避免各自复制一份。
+仓库里的工具已全部统一为「真身 ``async def _arun``」形态，因此这些装饰器
+无需再判断执行方法是 ``_run`` 还是 ``_arun`` —— 一律包装 ``_arun``、只产出
+async wrapper。本模块收敛这类「类级增强」所需的 pydantic / langchain 细节。
 
-两个必须先理解的框架事实（pydantic 2.13 / langchain-core 1.3 实证，见
-langchain_core/tools/base.py）：
-
-1. 执行方法的判定镜像 langchain 自身：子类覆写 ``_arun`` 时，同步/异步调用最终
-   都走 ``_arun``（``BaseTool.arun`` 按 ``cls._arun is not BaseTool._arun`` 选执行
-   函数）；否则走 ``_run``（``BaseTool._arun`` 默认在线程池里执行 ``_run``）。
-   见 ``exec_method_name``。
-2. 字段只能在 pydantic **新子类**上覆写：pydantic v2 在类创建时捕获字段默认值，
-   事后 ``cls.args_schema = X`` 或改 ``model_fields["args_schema"].default`` 都不
-   生效。因此 enrich 在确有改动时返回 ``type(cls.__name__, (cls,), namespace)``
-   新子类，并在其命名空间里用 ``__annotations__`` 重声明 ``args_schema``；
-   给 Input 模型追加字段则用 ``create_model(orig.__name__, __base__=orig, ...)``，
-   兼容已含 ``Annotated[..., InjectedToolCallId]`` 的模型。
+框架事实（pydantic 2.x）：字段默认值在类创建时被捕获，事后改 ``cls.args_schema``
+或 ``model_fields["args_schema"].default`` 都不生效；要追加/覆写字段只能返回一个
+**pydantic 新子类**，在其命名空间里用 ``__annotations__`` 重声明 ``args_schema``。
+追加字段用 ``create_model(orig.__name__, __base__=orig, ...)`` 生成携带新字段的
+Input 模型，保留原字段与校验（兼容已含 ``Annotated[..., InjectedToolCallId]``
+的模型）。
 """
 
 from __future__ import annotations
@@ -30,30 +22,17 @@ from pydantic import BaseModel, create_model
 from pydantic.fields import FieldInfo
 
 # args_schema 字段规格：(字段注解类型, Field(...) 产生的 FieldInfo)。
-# 装饰器按此约定注入「策略开关」字段（如 get_doc / background）。
 FieldSpec = tuple[type[Any], FieldInfo]
 
-# langchain 可能注入、以及策略自身消耗的技术性 kwargs——永远不该进 ask_user
-# 确认载荷或后台任务摘要（用户可见字段之外的实现细节）。
+# langchain 可能注入、以及策略自身消耗的技术性 kwargs —— 不该进 ask_user 确认
+# 载荷或后台任务摘要（用户可见字段之外的实现细节）。
 INJECTED_KWARGS: frozenset[str] = frozenset({
     "run_manager", "config", "callbacks", "get_doc", "background",
 })
 
 
-def exec_method_name(cls: type[BaseTool]) -> str:
-    """返回 langchain 实际会调用的执行方法名（镜像 ``BaseTool.arun`` 的判定）。
-
-    判据必须与 langchain 保持一致（覆写 ``_arun`` 走 ``_arun``，否则 ``_run``）；
-    langchain-core 若改动此判定，本函数应在契约测试中报红。注册工具已全 arun 化，
-    对它们本函数恒返回 ``_arun``；保留 _run 分支仅用于容忍未经转换的第三方子类。
-    """
-    if cls._arun is not BaseTool._arun:
-        return "_arun"
-    return "_run"
-
-
 def get_args_schema(cls: type[BaseTool]) -> type[BaseModel] | None:
-    """返回工具当前的 args_schema（Input pydantic 模型），未设置时返回 None。"""
+    """返回工具当前的 args_schema（Input pydantic 模型），未显式设置时返回 None。"""
     default = cls.model_fields["args_schema"].default
     if isinstance(default, type) and issubclass(default, BaseModel):
         return default
@@ -64,12 +43,11 @@ def _schema_with_extra_fields(
     cls: type[BaseTool],
     schema_fields: dict[str, FieldSpec] | None,
 ) -> type[BaseModel] | None:
-    """把 *schema_fields* 注入 Input 模型，返回增强后的模型；无需改动时返回 None。
+    """把 *schema_fields* 注入 Input 模型，返回增强后的模型；无新增字段时返回 None。
 
-    - 字段已在模型上则跳过（幂等：多套策略叠层时不会重复注入）。
-    - 工具未显式设置 args_schema 时字段将静默不生效（对应包装恒直通）——装饰器
-      声明了能力却被悄然丢弃。此处直接抛 TypeError，让失效在导入期显性暴露
-      （与 confirm_execution 对非异步工具 fail-fast 的做法一致）。
+    - 字段已在模型上则跳过（同名策略开关在叠层时不会被重复注入）。
+    - 工具未显式设置 args_schema 时字段将静默不生效，属「装饰器声明了能力却被丢弃」，
+      故直接抛 TypeError，让失效在导入期显性暴露。
     """
     if not schema_fields:
         return None
@@ -86,24 +64,8 @@ def _schema_with_extra_fields(
     }
     if not additions:
         return None
-    # 一次 create_model 建出携带全部新字段的单层子类：__base__=base 保留既有
-    # 字段与校验，新字段追加在末尾。
+    # 一次 create_model 建出携带全部新字段的单层子类（__base__=base 保留原字段与校验）。
     return create_model(base.__name__, __base__=base, **additions)
-
-
-def _wrapped_exec_method(
-    cls: type[BaseTool],
-    wrap_method: Callable[[Callable[..., Any]], Callable[..., Any]] | None,
-    method_name: str,
-) -> tuple[str, Callable[..., Any]] | None:
-    """解析 *method_name* 指向的方法并交给 *wrap_method* 包装。
-
-    返回 (方法名, 包装后的方法)；*wrap_method* 为空时不包装（返回 None）。
-    此处只读不写原类，替换发生在 enrich 生成的新子类上。
-    """
-    if wrap_method is None:
-        return None
-    return method_name, wrap_method(getattr(cls, method_name))
 
 
 def enrich_tool_class(
@@ -111,41 +73,30 @@ def enrich_tool_class(
     *,
     schema_fields: dict[str, FieldSpec] | None = None,
     wrap_method: Callable[[Callable[..., Any]], Callable[..., Any]] | None = None,
-    method_name: str | None = None,
 ) -> type[BaseTool]:
-    """应用两类类级增强，返回一个（必要时新建的）子类：
+    """对工具类应用两类「类级增强」，返回它的一个新子类（纯函数，不改原类）：
 
-    - ``schema_fields``：向 args_schema 注入字段；
-    - ``wrap_method``：把真正执行的方法（``_run``/``_arun``）替换为包装结果。
+    - ``schema_fields``：向 args_schema 注入策略开关字段；
+    - ``wrap_method``：把 ``_arun`` 替换为包装结果。
 
-    两种增强都无实际改动时原样返回 *cls*；否则返回
-    ``type(name, (cls,), namespace)`` 新子类（字段覆写必须落在新子类上，见模块
-    注释）。继承链上再套一层策略（如 get_doc 叠在 confirm 之上）得到的是子类套
-    子类，天然构成 外层→内层→核心 的调用链。
+    ``_arun`` 一定可取（覆写即真实异步体；未覆写时取 ``BaseTool._arun`` 默认实现，
+    其内部经线程池执行 ``_run``），故无需解析 sync/async。
 
-    ``method_name`` 可显式指定要包装的方法名，覆盖 ``exec_method_name`` 的默认
-    解析（如 background 装饰器强制包装 ``_arun``，使纯同步工具也能后台化——同步
-    工具未覆写 ``_arun`` 时，该名字解析到 langchain 的默认实现，其内部经线程池
-    执行 ``_run``）。
+    每次调用都新建子类：叠加策略（get_doc 叠在 confirm / background 之上）天然构成
+    外层→内层→核心 的调用链。重复应用同一策略会再包一层（方法被二次包装），
+    属调用方责任，本函数不做隐式去重。
     """
-    name = method_name or exec_method_name(cls)
-    new_schema = _schema_with_extra_fields(cls, schema_fields)
-    new_method = _wrapped_exec_method(cls, wrap_method, name)
-    if new_schema is None and new_method is None:
-        return cls
-
     namespace: dict[str, object] = {
         "__module__": cls.__module__,
         "__qualname__": cls.__qualname__,
         "__doc__": cls.__doc__,
     }
+    new_schema = _schema_with_extra_fields(cls, schema_fields)
     if new_schema is not None:
-        # 仅赋值 args_schema 属性不生效：pydantic 在类创建时捕获字段，须在子类
-        # 命名空间里同时用 __annotations__ 重声明 args_schema 才算「覆写字段」。
+        # 仅赋值 args_schema 不生效：pydantic 在类创建时捕获字段，须在子类命名空间
+        # 里同时用 __annotations__ 重声明 args_schema 才算「覆写字段」。
         namespace["args_schema"] = new_schema
         namespace["__annotations__"] = {"args_schema": type[BaseModel]}
-    if new_method is not None:
-        wrapped_name, wrapped = new_method
-        namespace[wrapped_name] = wrapped
-
+    if wrap_method is not None:
+        namespace["_arun"] = wrap_method(cls._arun)
     return type(cls.__name__, (cls,), namespace)

--- a/tools/sub_agent/tool_call_sub_agent.py
+++ b/tools/sub_agent/tool_call_sub_agent.py
@@ -49,9 +49,6 @@ class CallSubAgentTool(ToolBase):
     )
     args_schema: type[BaseModel] = CallSubAgentInput
 
-    def _run(self, get_doc: bool = False, task: str = "", name: str = "") -> str:
-        raise NotImplementedError("call_sub_agent 仅支持异步模式")
-
     async def _arun(self, task: str = "", name: str = "") -> str:
         if not task.strip():
             return format_error("task 不能为空")

--- a/tools/system/tool_python.py
+++ b/tools/system/tool_python.py
@@ -298,9 +298,6 @@ class RunPythonTool(ToolBase):
     )
     args_schema: type[BaseModel] = RunPythonInput
 
-    def _run(self, code: str = "") -> str:
-        raise NotImplementedError("run_python 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         code: str = "",

--- a/tools/task/tool_await.py
+++ b/tools/task/tool_await.py
@@ -37,9 +37,6 @@ class AwaitBackgroundTool(ToolBase):
     )
     args_schema: type[BaseModel] = AwaitBackgroundInput
 
-    def _run(self, index: int = 1, timeout_seconds: int = 180) -> str:
-        raise NotImplementedError("await_background 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, index: int, timeout_seconds: int = 180) -> str:
         """等待后台任务并返回其真实输出。
 

--- a/tools/task/tool_list.py
+++ b/tools/task/tool_list.py
@@ -22,9 +22,6 @@ class ListBackgroundTool(ToolBase):
     )
     args_schema: type[BaseModel] = ListBackgroundInput
 
-    def _run(self) -> str:
-        raise NotImplementedError("list_background 仅支持异步模式，请使用 _arun")
-
     async def _arun(self) -> str:
         """返回全部后台任务概要（供 agent 发现索引与查看进度）。"""
         session_id = interaction.current_session_id.get()

--- a/tools/task/tool_tracker.py
+++ b/tools/task/tool_tracker.py
@@ -34,6 +34,12 @@ class TaskTrackerTool(ToolBase):
         self,
         todos: list[TodoItem] | None = None,
     ) -> str:
+        raise NotImplementedError("task_tracker 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
+        self,
+        todos: list[TodoItem] | None = None,
+    ) -> str:
         if not todos:
             return format_error("请传入 todos 参数（全量任务清单）")
 

--- a/tools/task/tool_tracker.py
+++ b/tools/task/tool_tracker.py
@@ -30,12 +30,6 @@ class TaskTrackerTool(ToolBase):
     )
     args_schema: type[BaseModel] = TaskTrackerInput
 
-    def _run(
-        self,
-        todos: list[TodoItem] | None = None,
-    ) -> str:
-        raise NotImplementedError("task_tracker 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         todos: list[TodoItem] | None = None,

--- a/tools/todo/todo_base.py
+++ b/tools/todo/todo_base.py
@@ -1,39 +1,44 @@
-"""Todoist API 共享封装（内部依赖，不是 Tool）。"""
+"""Todoist API 共享封装（内部依赖，不是 Tool）。
+
+全 Todo 工具共用 ``SharedAPIClient.todoist`` 这一个 ``TodoistAPIAsync`` 实例，
+helper 方法均为 async（其分页方法返回 ``AsyncResultsPaginator``，用
+``async for page in await api.get_*()`` 展平）。
+"""
 
 from datetime import date, datetime
 
-from todoist_api_python.api import TodoistAPI
+from todoist_api_python.api_async import TodoistAPIAsync
 from todoist_api_python.models import Label, Project, Section, Task
+
+from tools.base import SharedAPIClient
 
 
 class TodoAPIHelper:
-    """封装 Todoist API 的通用方法，供各 Todo Tool 调用。"""
+    """封装 Todoist async API 的通用方法，供各 Todo Tool 调用。"""
 
-    def __init__(self, token: str):
-        self._api: TodoistAPI | None = None
-        self._token = token
+    def __init__(self, client: SharedAPIClient):
+        self._client = client
 
     @property
-    def api(self) -> TodoistAPI:
-        if self._api is None:
-            if not self._token:
-                raise ValueError("未找到 Todoist API Token")
-            self._api = TodoistAPI(self._token)
-        return self._api
+    def api(self) -> TodoistAPIAsync:
+        """共享 Todoist async 客户端（无 client/token 缺失时抛 ValueError）。"""
+        if self._client is None:
+            raise ValueError("未找到 Todoist API Token")
+        return self._client.todoist
 
     # ── 项目 ──
 
-    def get_project_id(self, project_name: str) -> str | None:
+    async def get_project_id(self, project_name: str) -> str | None:
         """按名称查找 project ID（大小写不敏感）。"""
-        for projects in self.api.get_projects():
+        async for projects in await self.api.get_projects():
             for project in projects:
                 if project.name.lower() == project_name.lower():
                     return project.id
         return None
 
-    def get_project_name(self, project_id: str) -> str:
+    async def get_project_name(self, project_id: str) -> str:
         """按 ID 查找项目名称，未找到返回 'Inbox'。"""
-        for projects in self.api.get_projects():
+        async for projects in await self.api.get_projects():
             for project in projects:
                 if project.id == project_id:
                     return project.name
@@ -41,53 +46,55 @@ class TodoAPIHelper:
 
     # ── 分区 ──
 
-    def get_section_id(self, section_name: str, project_id: str) -> str | None:
+    async def get_section_id(self, section_name: str, project_id: str) -> str | None:
         """按名称和所属项目查找 section ID。"""
-        for sections in self.api.get_sections(project_id=project_id):
+        async for sections in await self.api.get_sections(project_id=project_id):
             for section in sections:
                 if section.name.lower() == section_name.lower():
                     return section.id
         return None
 
-    def get_section_name(self, section_id: str, project_id: str | None = None) -> str | None:
+    async def get_section_name(
+        self, section_id: str, project_id: str | None = None
+    ) -> str | None:
         """按 ID 查找 section 名称。传入 project_id 可缩小搜索范围。"""
-        for sections in self.api.get_sections(project_id=project_id):
+        async for sections in await self.api.get_sections(project_id=project_id):
             for section in sections:
                 if section.id == section_id:
                     return section.name
         return None
 
-    def find_section_global(self, section_name: str) -> tuple[str, str] | None:
+    async def find_section_global(self, section_name: str) -> tuple[str, str] | None:
         """在所有项目中查找指定名称的 section，返回 (project_id, section_id)。"""
-        for sections in self.api.get_sections():
+        async for sections in await self.api.get_sections():
             for section in sections:
                 if section.name.lower() == section_name.lower():
                     return section.project_id, section.id
         return None
 
-    def get_sections_by_project(self, project_name: str) -> list[Section]:
+    async def get_sections_by_project(self, project_name: str) -> list[Section]:
         """按项目名获取所有分区列表。"""
-        pid = self.get_project_id(project_name)
+        pid = await self.get_project_id(project_name)
         if pid is None:
             return []
         result: list[Section] = []
-        for sections in self.api.get_sections(project_id=pid):
+        async for sections in await self.api.get_sections(project_id=pid):
             result.extend(sections)
         return result
 
-    def get_all_sections(self) -> list[Section]:
+    async def get_all_sections(self) -> list[Section]:
         """获取所有项目的所有分区。"""
         result: list[Section] = []
-        for sections in self.api.get_sections():
+        async for sections in await self.api.get_sections():
             result.extend(sections)
         return result
 
     # ── 标签 ──
 
-    def get_all_labels(self) -> list[Label]:
+    async def get_all_labels(self) -> list[Label]:
         """获取所有标签。"""
         result: list[Label] = []
-        for labels in self.api.get_labels():
+        async for labels in await self.api.get_labels():
             result.extend(labels)
         return result
 
@@ -138,7 +145,7 @@ class TodoAPIHelper:
 
     # ── 统一序列化 ──
 
-    def task_to_dict(self, task: Task) -> dict:
+    async def task_to_dict(self, task: Task) -> dict:
         """Task → 完整响应字典。供 add / update / query / list / add_quick 统一使用。"""
         due_dict: dict | None = None
         if task.due:
@@ -169,10 +176,10 @@ class TodoAPIHelper:
             "content": task.content,
             "description": task.description,
             "project_id": task.project_id,
-            "project_name": self.get_project_name(task.project_id),
+            "project_name": await self.get_project_name(task.project_id),
             "section_id": task.section_id,
             "section_name": (
-                self.get_section_name(task.section_id, task.project_id)
+                await self.get_section_name(task.section_id, task.project_id)
                 if task.section_id
                 else None
             ),
@@ -211,13 +218,13 @@ class TodoAPIHelper:
             "folder_id": project.folder_id,
         }
 
-    def section_to_dict(self, section: Section) -> dict:
+    async def section_to_dict(self, section: Section) -> dict:
         """Section → 响应字典。"""
         return {
             "section_id": section.id,
             "name": section.name,
             "project_id": section.project_id,
-            "project_name": self.get_project_name(section.project_id),
+            "project_name": await self.get_project_name(section.project_id),
             "order": section.order,
             "is_collapsed": section.is_collapsed,
         }

--- a/tools/todo/tool_add.py
+++ b/tools/todo/tool_add.py
@@ -104,10 +104,13 @@ class TodoAddTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(
+    def _run(self, **kwargs: object) -> str:
+        raise NotImplementedError("todo_add 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
         self,
         content: str = "",
         description: str = "",
@@ -140,7 +143,7 @@ class TodoAddTool(ToolBase):
         except ValueError as e:
             return format_error(str(e))
 
-        project_id = self.helper.get_project_id(project_name)
+        project_id = await self.helper.get_project_id(project_name)
         if project_id is None:
             return format_error(
                 f"项目 '{project_name}' 不存在。请先调用 todo_list_projects 查看可用项目"
@@ -148,7 +151,7 @@ class TodoAddTool(ToolBase):
 
         section_id = None
         if section_name:
-            section_id = self.helper.get_section_id(section_name, project_id)
+            section_id = await self.helper.get_section_id(section_name, project_id)
             if section_id is None:
                 return format_error(
                     f"项目 '{project_name}' 下不存在分区 '{section_name}'。"
@@ -169,7 +172,7 @@ class TodoAddTool(ToolBase):
                 self.helper.parse_deadline(deadline_date) if deadline_date else None
             )
 
-            task = api.add_task(
+            task = await api.add_task(
                 content=content,
                 description=description_val,
                 project_id=project_id,
@@ -190,6 +193,6 @@ class TodoAddTool(ToolBase):
                 deadline_date=deadline_date_obj,
                 deadline_lang=deadline_lang,
             )
-            return format_success(self.helper.task_to_dict(task))
+            return format_success(await self.helper.task_to_dict(task))
         except Exception as e:
             return format_error(f"添加任务失败: {e}")

--- a/tools/todo/tool_add.py
+++ b/tools/todo/tool_add.py
@@ -107,9 +107,6 @@ class TodoAddTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self, **kwargs: object) -> str:
-        raise NotImplementedError("todo_add 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         content: str = "",

--- a/tools/todo/tool_complete.py
+++ b/tools/todo/tool_complete.py
@@ -22,10 +22,13 @@ class TodoCompleteTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
     def _run(self, task_id: str = "") -> str:
+        raise NotImplementedError("todo_complete 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, task_id: str = "") -> str:
         if not task_id:
             return format_error("task_id 不能为空")
 
@@ -35,8 +38,8 @@ class TodoCompleteTool(ToolBase):
             return format_error(str(e))
 
         try:
-            current_task = api.get_task(task_id)
-            ok = api.complete_task(task_id)
+            current_task = await api.get_task(task_id)
+            ok = await api.complete_task(task_id)
             if ok:
                 return format_success(
                     {

--- a/tools/todo/tool_complete.py
+++ b/tools/todo/tool_complete.py
@@ -25,9 +25,6 @@ class TodoCompleteTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self, task_id: str = "") -> str:
-        raise NotImplementedError("todo_complete 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, task_id: str = "") -> str:
         if not task_id:
             return format_error("task_id 不能为空")

--- a/tools/todo/tool_delete.py
+++ b/tools/todo/tool_delete.py
@@ -25,9 +25,6 @@ class TodoDeleteTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self, task_id: str = "") -> str:
-        raise NotImplementedError("todo_delete 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, task_id: str = "") -> str:
         if not task_id:
             return format_error("task_id 不能为空")

--- a/tools/todo/tool_delete.py
+++ b/tools/todo/tool_delete.py
@@ -22,10 +22,13 @@ class TodoDeleteTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
     def _run(self, task_id: str = "") -> str:
+        raise NotImplementedError("todo_delete 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, task_id: str = "") -> str:
         if not task_id:
             return format_error("task_id 不能为空")
 
@@ -35,7 +38,7 @@ class TodoDeleteTool(ToolBase):
             return format_error(str(e))
 
         try:
-            ok = api.delete_task(task_id)
+            ok = await api.delete_task(task_id)
             if ok:
                 return format_success({"task_id": task_id, "message": "任务删除成功"})
             return format_error("删除任务失败")

--- a/tools/todo/tool_list.py
+++ b/tools/todo/tool_list.py
@@ -56,9 +56,6 @@ class TodoListTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self, **kwargs: object) -> str:
-        raise NotImplementedError("todo_list 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         project_name: str | None = None,

--- a/tools/todo/tool_list.py
+++ b/tools/todo/tool_list.py
@@ -53,10 +53,13 @@ class TodoListTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(
+    def _run(self, **kwargs: object) -> str:
+        raise NotImplementedError("todo_list 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
         self,
         project_name: str | None = None,
         section_name: str | None = None,
@@ -74,7 +77,7 @@ class TodoListTool(ToolBase):
         kwargs: dict = {}
 
         if project_name:
-            pid = self.helper.get_project_id(project_name)
+            pid = await self.helper.get_project_id(project_name)
             if pid is None:
                 return format_success({"total": 0, "tasks": []})
             kwargs["project_id"] = pid
@@ -82,7 +85,7 @@ class TodoListTool(ToolBase):
         if section_name:
             if project_name:
                 # 已知项目上下文
-                sid = self.helper.get_section_id(
+                sid = await self.helper.get_section_id(
                     section_name, kwargs.get("project_id", "")
                 )
                 if sid is None:
@@ -90,7 +93,7 @@ class TodoListTool(ToolBase):
                 kwargs["section_id"] = sid
             else:
                 # 跨项目查找
-                result = self.helper.find_section_global(section_name)
+                result = await self.helper.find_section_global(section_name)
                 if result is None:
                     return format_success({"total": 0, "tasks": []})
                 kwargs["section_id"] = result[1]
@@ -105,10 +108,10 @@ class TodoListTool(ToolBase):
             kwargs["limit"] = limit
 
         all_tasks = []
-        for tasks in api.get_tasks(**kwargs):
+        async for tasks in await api.get_tasks(**kwargs):
             all_tasks.extend(tasks)
 
-        task_list = [self.helper.task_to_dict(t) for t in all_tasks]
+        task_list = [await self.helper.task_to_dict(t) for t in all_tasks]
         task_list.sort(key=lambda x: x["task_id"])
 
         return format_success({"total": len(task_list), "tasks": task_list})

--- a/tools/todo/tool_list_labels.py
+++ b/tools/todo/tool_list_labels.py
@@ -28,9 +28,6 @@ class TodoListLabelsTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self) -> str:
-        raise NotImplementedError("todo_list_labels 仅支持异步模式，请使用 _arun")
-
     async def _arun(self) -> str:
         all_labels = await self.helper.get_all_labels()
         label_list = [self.helper.label_to_dict(l) for l in all_labels]

--- a/tools/todo/tool_list_labels.py
+++ b/tools/todo/tool_list_labels.py
@@ -25,11 +25,14 @@ class TodoListLabelsTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
     def _run(self) -> str:
-        all_labels = self.helper.get_all_labels()
+        raise NotImplementedError("todo_list_labels 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self) -> str:
+        all_labels = await self.helper.get_all_labels()
         label_list = [self.helper.label_to_dict(l) for l in all_labels]
         label_list.sort(key=lambda x: x["name"])
 

--- a/tools/todo/tool_list_projects.py
+++ b/tools/todo/tool_list_projects.py
@@ -22,17 +22,20 @@ class TodoListProjectsTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
     def _run(self) -> str:
+        raise NotImplementedError("todo_list_projects 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self) -> str:
         try:
             api = self.helper.api
         except ValueError as e:
             return format_error(str(e))
 
         all_projects = []
-        for projects in api.get_projects():
+        async for projects in await api.get_projects():
             all_projects.extend(projects)
 
         project_list = [self.helper.project_to_dict(p) for p in all_projects]

--- a/tools/todo/tool_list_projects.py
+++ b/tools/todo/tool_list_projects.py
@@ -25,9 +25,6 @@ class TodoListProjectsTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self) -> str:
-        raise NotImplementedError("todo_list_projects 仅支持异步模式，请使用 _arun")
-
     async def _arun(self) -> str:
         try:
             api = self.helper.api

--- a/tools/todo/tool_list_sections.py
+++ b/tools/todo/tool_list_sections.py
@@ -32,9 +32,6 @@ class TodoListSectionsTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self, project_name: str | None = None) -> str:
-        raise NotImplementedError("todo_list_sections 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, project_name: str | None = None) -> str:
         if project_name:
             pid = await self.helper.get_project_id(project_name)

--- a/tools/todo/tool_list_sections.py
+++ b/tools/todo/tool_list_sections.py
@@ -29,21 +29,24 @@ class TodoListSectionsTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
     def _run(self, project_name: str | None = None) -> str:
+        raise NotImplementedError("todo_list_sections 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, project_name: str | None = None) -> str:
         if project_name:
-            pid = self.helper.get_project_id(project_name)
+            pid = await self.helper.get_project_id(project_name)
             if pid is None:
                 return format_error(
                     f"项目 '{project_name}' 不存在。请先调用 todo_list_projects 查看可用项目"
                 )
-            all_sections = self.helper.get_sections_by_project(project_name)
+            all_sections = await self.helper.get_sections_by_project(project_name)
         else:
-            all_sections = self.helper.get_all_sections()
+            all_sections = await self.helper.get_all_sections()
 
-        section_list = [self.helper.section_to_dict(s) for s in all_sections]
+        section_list = [await self.helper.section_to_dict(s) for s in all_sections]
         section_list.sort(key=lambda x: x["section_id"])
 
         return format_success({"total": len(section_list), "sections": section_list})

--- a/tools/todo/tool_query.py
+++ b/tools/todo/tool_query.py
@@ -25,9 +25,6 @@ class TodoQueryTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self, task_id: str = "") -> str:
-        raise NotImplementedError("todo_query 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, task_id: str = "") -> str:
         if not task_id:
             return format_error("task_id 不能为空")

--- a/tools/todo/tool_query.py
+++ b/tools/todo/tool_query.py
@@ -22,10 +22,13 @@ class TodoQueryTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
     def _run(self, task_id: str = "") -> str:
+        raise NotImplementedError("todo_query 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, task_id: str = "") -> str:
         if not task_id:
             return format_error("task_id 不能为空")
 
@@ -35,7 +38,7 @@ class TodoQueryTool(ToolBase):
             return format_error(str(e))
 
         try:
-            task = api.get_task(task_id)
-            return format_success(self.helper.task_to_dict(task))
+            task = await api.get_task(task_id)
+            return format_success(await self.helper.task_to_dict(task))
         except Exception as e:
             return format_error(f"任务不存在: {e}")

--- a/tools/todo/tool_uncomplete.py
+++ b/tools/todo/tool_uncomplete.py
@@ -25,9 +25,6 @@ class TodoUncompleteTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self, task_id: str = "") -> str:
-        raise NotImplementedError("todo_uncomplete 仅支持异步模式，请使用 _arun")
-
     async def _arun(self, task_id: str = "") -> str:
         if not task_id:
             return format_error("task_id 不能为空")

--- a/tools/todo/tool_uncomplete.py
+++ b/tools/todo/tool_uncomplete.py
@@ -22,10 +22,13 @@ class TodoUncompleteTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
     def _run(self, task_id: str = "") -> str:
+        raise NotImplementedError("todo_uncomplete 仅支持异步模式，请使用 _arun")
+
+    async def _arun(self, task_id: str = "") -> str:
         if not task_id:
             return format_error("task_id 不能为空")
 
@@ -35,8 +38,8 @@ class TodoUncompleteTool(ToolBase):
             return format_error(str(e))
 
         try:
-            current_task = api.get_task(task_id)
-            ok = api.uncomplete_task(task_id)
+            current_task = await api.get_task(task_id)
+            ok = await api.uncomplete_task(task_id)
             if ok:
                 return format_success(
                     {

--- a/tools/todo/tool_update.py
+++ b/tools/todo/tool_update.py
@@ -73,9 +73,6 @@ class TodoUpdateTool(ToolBase):
             self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(self, **kwargs: object) -> str:
-        raise NotImplementedError("todo_update 仅支持异步模式，请使用 _arun")
-
     async def _arun(
         self,
         task_id: str = "",

--- a/tools/todo/tool_update.py
+++ b/tools/todo/tool_update.py
@@ -70,10 +70,13 @@ class TodoUpdateTool(ToolBase):
     @property
     def helper(self) -> TodoAPIHelper:
         if self._helper is None:
-            self._helper = TodoAPIHelper(self.client._todoist_token)
+            self._helper = TodoAPIHelper(self.client)
         return self._helper
 
-    def _run(
+    def _run(self, **kwargs: object) -> str:
+        raise NotImplementedError("todo_update 仅支持异步模式，请使用 _arun")
+
+    async def _arun(
         self,
         task_id: str = "",
         content: str | None = None,
@@ -106,14 +109,14 @@ class TodoUpdateTool(ToolBase):
             return format_error(str(e))
 
         try:
-            current_task = api.get_task(task_id)
+            current_task = await api.get_task(task_id)
 
             # ── 移动逻辑：project 和/或 section ──
             move_kwargs: dict[str, str] = {}
             section_target_project: str | None = None
 
             if project_name:
-                pid = self.helper.get_project_id(project_name)
+                pid = await self.helper.get_project_id(project_name)
                 if pid is None:
                     return format_error(
                         f"项目 '{project_name}' 不存在。请先调用 todo_list_projects 查看可用项目"
@@ -124,17 +127,17 @@ class TodoUpdateTool(ToolBase):
 
             if section_name:
                 ctx_project = section_target_project or current_task.project_id
-                sid = self.helper.get_section_id(section_name, ctx_project)
+                sid = await self.helper.get_section_id(section_name, ctx_project)
                 if sid is None:
+                    ctx_name = await self.helper.get_project_name(ctx_project)
                     return format_error(
-                        f"项目 '{self.helper.get_project_name(ctx_project)}'"
-                        f" 下不存在分区 '{section_name}'"
+                        f"项目 '{ctx_name}' 下不存在分区 '{section_name}'"
                     )
                 # section 隐式关联了 project，传 section_id 即可
                 move_kwargs["section_id"] = sid
 
             if move_kwargs:
-                api.move_task(task_id=task_id, **move_kwargs)
+                await api.move_task(task_id=task_id, **move_kwargs)
 
             # ── 字段更新 ──
             parsed_due_date = None
@@ -149,7 +152,7 @@ class TodoUpdateTool(ToolBase):
                 self.helper.parse_deadline(deadline_date) if deadline_date else None
             )
 
-            task = api.update_task(
+            task = await api.update_task(
                 task_id=task_id,
                 content=content,
                 description=description,
@@ -168,6 +171,6 @@ class TodoUpdateTool(ToolBase):
                 deadline_date=deadline_date_obj,
                 deadline_lang=deadline_lang,
             )
-            return format_success(self.helper.task_to_dict(task))
+            return format_success(await self.helper.task_to_dict(task))
         except Exception as e:
             return format_error(f"任务不存在或更新失败: {e}")


### PR DESCRIPTION
## 背景

三个类装饰器（confirm/get_doc/background）原先需要按工具是 sync（_run）还是
async（_arun）分叉决定包装哪个执行方法、写同步还是异步 wrapper。全量异步化后
该分叉消失。

## 改动

- 39 个工具全部统一为「真身 async _arun + ToolBase @final _run 占位」：
  每个工具不再各自覆写 _run（删除 39 处 raise stub），ToolBase 统一提供 final
  _run 满足 BaseTool 抽象并禁用子类覆写。
- 阻塞体经 asyncio.to_thread（tools.base.off_thread）离环，@background spawn 的
  协程不再冻结事件循环；todoist/tavily 改用原生 async 客户端。
- 装饰器底层简化（tools/policies.py）：删除 exec_method_name 与 method_name
  参数，恒包装 _arun；enrich_tool_class 恒新建子类（纯函数契约）。
- get_doc 收尾为单一 async wrapper 并读盘离环。
- 相关测试同步 async 化（tests/test_todo 等）。

## 验证

- pytest tests 全量 342 passed
- 39 工具实例化冒烟通过（exec 恒 _arun、无自有 _run）