### PR TITLE
feat: Computer Use 屏幕操作开关与边缘灯提示

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -362,7 +362,7 @@ class CheckPendingNode:
 
         # ── 队列非空：合并注入 + 跳回 START ──
         pending = session.drain_pending()
-        text, _, _ = merge_pending_batch(pending)
+        text, _, _, _ = merge_pending_batch(pending)
         # 时间戳随注入进入 LLM 上下文；pending_consumed 推送干净合并文本供前端展示
         injected = [HumanMessage(content=text + now_timestamp())]
 

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -122,12 +122,15 @@ def now_timestamp() -> str:
     return f"（{now.year:04d}-{now.month:02d}-{now.day:02d} {wd} {now.hour:02d}:{now.minute:02d}）"
 
 
-def merge_pending_batch(batch: list[PendingMessage]) -> tuple[str, bool, list[str] | None]:
+def merge_pending_batch(
+    batch: list[PendingMessage],
+) -> tuple[str, bool, list[str] | None, bool]:
     """将一批排队消息合并为单个 Agent 输入（合并处理语义）。
 
-    返回 ``(text, image_recognition, image_refs)``：
+    返回 ``(text, image_recognition, image_refs, computer_use)``：
     - 文本以空行（\\n\\n）连接（消息文本已不含时间戳，时间戳由注入侧统一追加）；
-    - 图片标记 OR 累积——任一消息启用图像认知则整体启用，路径全部合并。
+    - 图片标记 OR 累积——任一消息启用图像认知则整体启用，路径全部合并；
+    - computer_use 同样 OR 累积——任一消息开启 Computer Use 则本轮下发屏幕操作工具。
     """
     text = "\n\n".join(_strip_time_suffix(p.text) for p in batch)
     images = [
@@ -136,7 +139,8 @@ def merge_pending_batch(batch: list[PendingMessage]) -> tuple[str, bool, list[st
         if p.image_recognition
         for img in (p.image_refs or [])
     ]
-    return text, bool(images), images or None
+    computer_use = any(p.computer_use for p in batch)
+    return text, bool(images), images or None, computer_use
 
 
 async def _inject_cancel_tool_messages(session: SessionState, config: dict[str, Any], sender: TurnSender) -> None:
@@ -495,6 +499,7 @@ async def run_agent_turn(
     model_name: str | None = None,
     image_recognition: bool = False,
     image_refs: list[str] | None = None,
+    computer_use: bool = False,
     studio_name: str | None = None,
     queued_pending: list[PendingMessage] | None = None,
 ):
@@ -551,7 +556,10 @@ async def run_agent_turn(
 
         # 2. 构建执行上下文
         ctx: _TurnContext = await _build_turn_context(
-            tools=app_state.tool_manager.get_all(multimodal=llm_conf.multimodal),
+            tools=app_state.tool_manager.get_all(
+                multimodal=llm_conf.multimodal,
+                computer_use=computer_use,
+            ),
             session=session,
             llm_conf=llm_conf,
             user_message=user_message,

--- a/api/agent/turn.py
+++ b/api/agent/turn.py
@@ -15,6 +15,7 @@ from agent.studio import render_studio_by_name
 from api.agent import interaction
 from api.agent.context_usage import estimate_context_usage_from_session
 from api.events import CallbackSender, TurnSender
+from api.edge_light import edge_light_activity, edge_light_session_on
 from api.callbacks.websocket_callback import WebSocketCallback
 from api.providers import FALLBACK_CTX
 from api.providers.manager import get_manager, ProviderManager
@@ -330,7 +331,7 @@ async def _build_turn_context(
     if studio_section:
         system_prompt = system_prompt + "\n\n" + studio_section
     cb_sender = CallbackSender.from_context()
-    ws_callback = WebSocketCallback(cb_sender)
+    ws_callback = WebSocketCallback(cb_sender, session_id=session.session_id)
 
     agent = build_agent(
         model=llm_conf.llm,
@@ -530,6 +531,12 @@ async def run_agent_turn(
 
     current_task = asyncio.current_task()
     mgr = get_manager()
+    # Computer Use 消息 → 点亮/常亮基准（前端 toggle 事件可能先到，此处幂等确认）
+    if computer_use:
+        try:
+            edge_light_session_on(session.session_id, True)
+        except Exception:
+            pass
     try:
         # 1. 解析 LLM 配置
         llm_conf: _LlmConfig = _resolve_llm(
@@ -581,3 +588,8 @@ async def run_agent_turn(
         )
     finally:
         session.clear_active_task(current_task)
+        # 兜底：整轮结束/取消后清除流式标记，避免边缘灯持续闪烁
+        try:
+            edge_light_activity(session.session_id, False)
+        except Exception:
+            pass

--- a/api/callbacks/websocket_callback.py
+++ b/api/callbacks/websocket_callback.py
@@ -9,6 +9,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import ToolMessage
 from langchain_core.outputs import LLMResult
 
+from api.edge_light import edge_light_activity
 from api.events import CallbackSender
 from api.utils.logger import get_logger
 from .tool_extractors import _dispatch
@@ -87,9 +88,10 @@ def _parse_tool_input(tool_input: str | None) -> dict[str, Any] | None:
 
 
 class WebSocketCallback(BaseCallbackHandler):
-    def __init__(self, sender: CallbackSender):
+    def __init__(self, sender: CallbackSender, session_id: str | None = None):
         super().__init__()
         self._sender = sender
+        self._session_id = session_id  # 供边缘灯定位"哪个会话在思考/流式"
         self._thinking_started = False
         self._thinking_count = 0
         self._tool_start_time: dict[str, float] = {}
@@ -153,6 +155,8 @@ class WebSocketCallback(BaseCallbackHandler):
         self._thinking_started = True
         self._thinking_count = 0
         await self._sender.thinking_start(time.time())
+        if self._session_id is not None:
+            edge_light_activity(self._session_id, True)  # 思考/流式开始 → 白灯闪烁
 
     async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         # 归一化块式 token：部分 Anthropic 适配模型（如 Kimi K3）把 content blocks
@@ -180,6 +184,8 @@ class WebSocketCallback(BaseCallbackHandler):
         if self._thinking_started:
             self._thinking_started = False
             await self._sender.thinking_end(time.time())
+        if self._session_id is not None:
+            edge_light_activity(self._session_id, False)  # 思考/流式结束 → 回到常亮
 
     async def on_tool_start(
         self, serialized: dict[str, Any], input_str: str, **kwargs: Any

--- a/api/edge_light.py
+++ b/api/edge_light.py
@@ -1,0 +1,150 @@
+"""Computer Use 屏幕边缘灯控制器 — 管理原生 PySide6 覆盖层子进程。
+
+职责：
+- 把「各会话的 Computer Use 开关 + 模型思考/流式活动」汇聚成单一状态
+  ``off | steady | blink`` 写入覆盖层子进程 stdin；
+- 惰性启动子进程；PySide6 缺失或启动失败时自动禁用，不影响主服务（退化为无提示）；
+- 主服务关闭时随进程退出（stdin EOF 后覆盖层自动结束），并显式 terminate 兜底。
+
+覆盖层不拦截任何输入（点击穿透），状态语义见 ``edge_light/overlay.py``。
+"""
+
+import json
+import subprocess
+import sys
+from importlib.util import find_spec
+from pathlib import Path
+
+from api.utils.logger import get_logger
+
+_log = get_logger("edge_light")
+
+# 覆盖层子进程脚本：edge_light/overlay.py（相对本文件两层的仓库根）
+_OVERLAY_SCRIPT = Path(__file__).resolve().parent.parent / "edge_light" / "overlay.py"
+
+
+class EdgeLightController:
+    """汇聚并驱动边缘灯覆盖层。每个方法幂等；调用方无需关心子进程生命周期。"""
+
+    def __init__(self) -> None:
+        self._proc: subprocess.Popen | None = None
+        self._current: str | None = None   # 已写出的状态
+        self._enabled: bool | None = None  # None=尚未尝试 / True / False
+        self._sessions: set[str] = set()   # 已开启 Computer Use 的会话
+        self._streaming: set[str] = set()  # 正在思考/流式输出的会话
+
+    # ── 对外状态入口 ──────────────────────────────────────
+    def session_on(self, session_id: str, enabled: bool) -> None:
+        """会话 Computer Use 开关：True → 常亮基准；False → 关闭该会话贡献。"""
+        (self._sessions.add(session_id) if enabled else self._sessions.discard(session_id))
+        self._streaming.discard(session_id)
+        self._recompute()
+
+    def session_activity(self, session_id: str, active: bool) -> None:
+        """模型思考/流式活动：仅当该会话已开启 Computer Use 时生效（闪烁）。"""
+        if session_id not in self._sessions:
+            self._streaming.discard(session_id)
+            return
+        (self._streaming.add(session_id) if active else self._streaming.discard(session_id))
+        self._recompute()
+
+    def _recompute(self) -> None:
+        """聚合：任一开启的会话在流式 → blink；有会话开启 → steady；否则 off。"""
+        if not self._sessions:
+            state = "off"
+        elif self._sessions & self._streaming:
+            state = "blink"
+        else:
+            state = "steady"
+        self._write(state)
+
+    # ── 子进程管理 ────────────────────────────────────────
+    def _write(self, state: str) -> None:
+        if self._enabled is False:
+            return
+        if not self._spawn():
+            return
+        if state == self._current:
+            return
+        try:
+            assert self._proc is not None and self._proc.stdin is not None
+            self._proc.stdin.write(json.dumps({"state": state}) + "\n")
+            self._proc.stdin.flush()
+            self._current = state
+        except (BrokenPipeError, OSError):
+            _log.warning("边缘灯子进程写入失败，已禁用")
+            self._proc = None
+            self._enabled = False
+
+    def _spawn(self) -> bool:
+        if self._enabled is True:
+            return self._proc is not None and self._proc.poll() is None
+        if self._enabled is False:
+            return False
+        # 首次使用才尝试启动：PySide6 缺失或脚本不可运行 → 禁用
+        if find_spec("PySide6") is None or not _OVERLAY_SCRIPT.exists():
+            _log.warning("PySide6 不可用，边缘灯覆盖层已禁用（Computer Use 将无光效提示）")
+            self._enabled = False
+            return False
+        try:
+            self._proc = subprocess.Popen(
+                [sys.executable, str(_OVERLAY_SCRIPT)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+            self._enabled = True
+            self._current = None  # 强制重发当前状态
+            _log.info("边缘灯覆盖层子进程已启动 (pid=%s)", self._proc.pid)
+            return True
+        except (OSError, ValueError) as e:
+            _log.warning("边缘灯覆盖层启动失败，已禁用: %s", e)
+            self._proc = None
+            self._enabled = False
+            return False
+
+    def shutdown(self) -> None:
+        """关闭：通知退出并回收子进程（幂等，服务停止时调用）。"""
+        proc = self._proc
+        self._proc = None
+        self._enabled = False
+        self._sessions.clear()
+        self._streaming.clear()
+        if proc is None or proc.poll() is not None:
+            return
+        try:
+            if proc.stdin is not None:
+                proc.stdin.write(json.dumps({"quit": True}) + "\n")
+                proc.stdin.flush()
+                proc.stdin.close()
+            proc.wait(timeout=3)
+        except (BrokenPipeError, OSError, subprocess.TimeoutExpired):
+            proc.terminate()
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+# ── 进程内单例访问（供 create_app 装配与回调无 app 引用的场景）─────────
+
+_active: EdgeLightController | None = None
+
+
+def set_active_controller(controller: EdgeLightController | None) -> None:
+    """由 FastAPI 生命周期装配时注册；为 None 则停用。"""
+    global _active
+    _active = controller
+
+
+def edge_light_session_on(session_id: str, enabled: bool) -> None:
+    """便捷入口：通知控制器某会话 Computer Use 开关变化（无控制器时 no-op）。"""
+    if _active is not None:
+        _active.session_on(session_id, enabled)
+
+
+def edge_light_activity(session_id: str, active: bool) -> None:
+    """便捷入口：通知控制器某会话模型思考/流式活动（无控制器时 no-op）。"""
+    if _active is not None:
+        _active.session_activity(session_id, active)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -13,6 +13,7 @@ from api.agent import interaction
 from api.agent.context_usage import estimate_context_usage_from_session
 from agent import build_system_prompt
 from api.agent.turn import merge_pending_batch, run_agent_turn
+from api.edge_light import edge_light_session_on
 from api.events import ChatSender, MemorySender, TurnSender
 from api.providers import FALLBACK_CTX
 from api.providers.manager import get_manager
@@ -139,6 +140,10 @@ async def _handle_chat(
     if session.is_subagent:
         return agent_task
 
+    # Computer Use 消息到达 → 点亮边缘灯（常亮基准；toggle 事件可能已先行，此处幂等）
+    if incoming.computer_use:
+        edge_light_session_on(session_id, True)
+
     interaction.current_ws.set(ws)  # 供工具函数/Sender.from_context() 通过 WebSocket 推送交互
     interaction.current_session_id.set(session_id)
 
@@ -242,6 +247,21 @@ async def _handle_update_auto_approve(
     interaction.set_session_auto_approve(
         session_id, msg["payload"]["auto_approve"]
     )
+    return agent_task
+
+
+@ws_event_handler("computer_use")
+async def _handle_computer_use(
+    ws: WebSocket,
+    session_id: str,
+    session: SessionState,
+    agent_task: asyncio.Task | None,
+    msg: dict,
+
+) -> asyncio.Task | None:
+    """更新 Computer Use 屏幕操作开关 → 点亮/熄灭边缘灯（enabled=True 常亮）。"""
+    enabled = bool(msg.get("payload", {}).get("enabled", False))
+    edge_light_session_on(session_id, enabled)
     return agent_task
 
 
@@ -354,6 +374,8 @@ async def websocket_chat(ws: WebSocket, session_id: str) -> None:
         _log.debug("WebSocket 断开: session_id=%s", session_id)
     finally:
         session.ws = None
+        # 前端断开 → 该会话 Computer Use 熄灭边缘灯（避免常亮残留）
+        edge_light_session_on(session_id, False)
         _log.debug("清理会话: session_id=%s, agent_task_done=%s",
                    session_id, agent_task is not None and agent_task.done())
         if agent_task is not None and not agent_task.done():

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -58,7 +58,7 @@ def _start_turn_from_ws(
     batch = queued + ([incoming] if incoming else [])
     if not batch:
         return None
-    text, img_recog, img_refs = merge_pending_batch(batch)
+    text, img_recog, img_refs, computer_use = merge_pending_batch(batch)
     last = batch[-1]
     interaction.set_session_auto_approve(session_id, last.auto_approve)
     agent_task = asyncio.create_task(
@@ -71,6 +71,7 @@ def _start_turn_from_ws(
             model_name=last.model_name,
             image_recognition=img_recog,
             image_refs=img_refs,
+            computer_use=computer_use,
             studio_name=last.studio_name,
             queued_pending=queued,
         )
@@ -130,6 +131,7 @@ async def _handle_chat(
         model_name=payload.get("model_name"),
         image_recognition=payload.get("image_recognition", False),
         image_refs=payload.get("image_refs") or [],
+        computer_use=payload.get("computer_use", False),
         studio_name=payload.get("studio_name"),
     )
 

--- a/api/server.py
+++ b/api/server.py
@@ -32,6 +32,7 @@ from api.session.manager import SessionState, session_manager
 from api.memory.long_term import MEMORY_PATH, LongTermMemory
 from api.memory.manager import MemoryManagerBuilder, YamlMemoryManager
 from api.tools.manager import ToolManager
+from api.edge_light import EdgeLightController, set_active_controller
 from version import __version__
 
 from api.middleware.auth import AuthMiddleware
@@ -130,12 +131,18 @@ async def lifespan(app: FastAPI):
     app.state.ltm = LongTermMemory(MemoryManagerBuilder().with_backend(YamlMemoryManager).with_args(yaml_file=str(MEMORY_PATH)).build())
     app.state.ltm.start()
 
+    # 屏幕边缘灯控制器（Computer Use 状态提示）：惰性启动原生覆盖层子进程
+    app.state.edge_light = EdgeLightController()
+    set_active_controller(app.state.edge_light)
+
     # 加载 const 固定会话（需要 tools 已就绪）
     await _load_const_sessions(app)
 
     yield
 
     # 关闭：清理资源
+    set_active_controller(None)
+    app.state.edge_light.shutdown()
     await app.state.tool_manager.close()
     await app.state.ltm.stop()
 

--- a/api/session/manager.py
+++ b/api/session/manager.py
@@ -166,6 +166,7 @@ class PendingMessage:
         model_name:   指定模型（可选）。
         image_recognition: 是否图像认知模式。
         image_refs:   图像文件绝对路径列表。
+        computer_use: 是否 Computer Use 屏幕操作模式（开启后下发 computer_* 工具）。
         studio_name:  所选工作坊名称（可选，注入对应 studio 文件）。
         created_at:   入队时间。
     """
@@ -178,6 +179,7 @@ class PendingMessage:
     model_name: str | None = None
     image_recognition: bool = False
     image_refs: list[str] | None = None
+    computer_use: bool = False
     studio_name: str | None = None
     created_at: float = field(default_factory=time.time)
 

--- a/api/tools/manager.py
+++ b/api/tools/manager.py
@@ -43,28 +43,38 @@ class ToolManager:
         "update_memory", "delete_memory", "merge_memories",
     })
 
-    # 依赖模型视觉能力（识图模式）才交付的工具，与 read_image 同步启用/剔除。
+    # 依赖模型视觉能力（识图能力）才交付的工具，随模型多模态能力同步启用/剔除。
     # 模型不具备多模态视觉时一律过滤（改用外部分析工具 analyze_image 兜底）。
-    _VISION_TOOL_NAMES = frozenset({
-        "read_image", "computer_screenshot", "computer_click",
+    _IMAGE_TOOL_NAMES = frozenset({
+        "read_image",
+    })
+
+    # 屏幕操作（computer use）系列：不跟随模型视觉能力自动暴露，仅当用户显式开启
+    # Computer Use 模式（computer_use=True，且模型具备视觉以读取截图）才交付给 LLM。
+    _COMPUTER_TOOL_NAMES = frozenset({
+        "computer_screenshot", "computer_click",
         "computer_virtual_click", "computer_type", "computer_key",
         "computer_scroll", "computer_wait",
     })
 
-    def get_all(self, multimodal: bool = False) -> list[BaseTool]:
+    def get_all(self, multimodal: bool = False, computer_use: bool = False) -> list[BaseTool]:
         """返回合并后的完整工具列表（消费方主要用这个）。
 
         Args:
-            multimodal: 当前 LLM 是否支持多模态。
-                        True → 保留全部识图工具（read_image 与 computer_* 系列），
-                               过滤 analyze_image；
-                        False → 保留 analyze_image，过滤全部识图工具。
+            multimodal:  当前 LLM 是否支持多模态（视觉能力）。
+                         True → 保留 read_image，过滤 analyze_image；
+                         False → 保留 analyze_image，过滤 read_image。
+            computer_use: 当前是否开启 Computer Use 屏幕操作模式。
+                         computer_* 系列仅在 (multimodal and computer_use) 时交付，
+                         即用户显式开启该模式（且模型能读取截图）才暴露。
         """
         tools = self.native_tools + self.mcp_tools
         if multimodal:
             tools = [t for t in tools if t.name != "analyze_image"]
         else:
-            tools = [t for t in tools if t.name not in self._VISION_TOOL_NAMES]
+            tools = [t for t in tools if t.name not in self._IMAGE_TOOL_NAMES]
+        if not (multimodal and computer_use):
+            tools = [t for t in tools if t.name not in self._COMPUTER_TOOL_NAMES]
         return [t for t in tools if t.name not in self._MEMORY_TOOL_NAMES]
 
     async def reload_mcp(self) -> list[BaseTool]:

--- a/edge_light/__init__.py
+++ b/edge_light/__init__.py
@@ -1,0 +1,9 @@
+"""屏幕边缘灯原生覆盖层（Computer Use 状态提示）。
+
+- ``overlay``: 独立 PySide6 子进程入口，通过 stdin 接收状态指令
+  （off / steady / blink），在全屏边缘渲染白色辉光环。
+- 该包不得导入 ``api`` / ``agent`` 等后端模块，保证可被后端以子进程方式
+  独立运行；后端侧控制器见 :mod:`api.edge_light`。
+"""
+
+__all__: list[str] = []

--- a/edge_light/overlay.py
+++ b/edge_light/overlay.py
@@ -1,0 +1,159 @@
+"""屏幕边缘灯覆盖层 — PySide6 子进程入口。
+
+由后端 :mod:`api.edge_light` 以子进程方式启动，通过 **stdin 读取 JSON 行指令**：
+
+    {"state": "off"}      关闭（不显示）
+    {"state": "steady"}   白灯静止常亮
+    {"state": "blink"}    白灯呼吸闪烁
+    {"quit": true}        退出进程
+
+视觉实现要点：
+- 全屏、无边框、置顶、**点击穿透**（WindowTransparentForInput），不拦截用户任何操作；
+- 辉光环只预渲染一次到离屏 QPixmap（沿屏幕边界多层层叠描边，向内柔化、四角无缝），
+  常亮/闪烁通过 ``setWindowOpacity`` 以很低代价调节整体亮度——闪烁无需逐帧重绘；
+- stdin 在后台线程读取，EOF 视为退出信号，父进程消亡时本进程自动结束。
+
+本文件为独立入口，只依赖标准库与 PySide6，禁止 import 后端模块。
+"""
+
+import json
+import math
+import sys
+import threading
+from collections import deque
+
+from PySide6.QtCore import QRectF, Qt, QTimer
+from PySide6.QtGui import QColor, QPainter, QPainterPath, QPen, QPixmap
+from PySide6.QtWidgets import QApplication, QWidget
+
+# 状态亮度
+STEADY_BRIGHTNESS = 0.5        # 静止常亮
+BLINK_MIN = 0.10               # 闪烁谷底
+BLINK_MAX = 0.90               # 闪烁峰值
+TIMER_MS = 50                  # 亮度刷新周期
+
+# 白灯辉光（沿屏幕边缘柔化）
+_BASE_ALPHA = 220              # 贴边最亮层的像素 alpha
+_GLOW_WIDTH = 34               # 向内柔化的总宽度（px）
+_LAYERS = 40                   # 描边层数，越多过渡越平滑
+
+
+def _brightness_for(state: str, phase: int) -> float:
+    """把状态映射为窗口整体亮度（0.0 ~ 1.0）。"""
+    if state == "steady":
+        return STEADY_BRIGHTNESS
+    if state == "blink":
+        pulse = (math.sin(math.radians(phase)) + 1) / 2  # 0.0 ~ 1.0
+        return BLINK_MIN + (BLINK_MAX - BLINK_MIN) * pulse
+    return 0.0
+
+
+class BorderGlow(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowFlags(
+            Qt.FramelessWindowHint
+            | Qt.WindowStaysOnTopHint
+            | Qt.WindowTransparentForInput
+            | Qt.Tool
+        )
+        self.setAttribute(Qt.WA_TranslucentBackground)
+        self.setAttribute(Qt.WA_ShowWithoutActivating)
+
+        self._state = "off"
+        self._phase = 0
+        self._glow: QPixmap | None = None
+        self._cmds: deque[dict] = deque()
+        self.setVisible(False)
+
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._tick)
+        self._timer.start(TIMER_MS)
+
+        threading.Thread(target=self._read_stdin, daemon=True).start()
+        self.showFullScreen()
+
+    # ── 指令入口：后台线程读取 stdin ────────────────────────
+    def _read_stdin(self) -> None:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                self._cmds.append(json.loads(line))
+            except (json.JSONDecodeError, TypeError):
+                continue
+        self._cmds.append({"quit": True})  # stdin EOF → 父进程退出，跟随结束
+
+    def _drain_cmds(self) -> None:
+        while self._cmds:
+            cmd = self._cmds.popleft()
+            if cmd.get("quit"):
+                QApplication.instance().quit()
+                return
+            state = cmd.get("state")
+            if state in ("off", "steady", "blink"):
+                self._state = state
+                self._phase = 0
+                if state == "off":
+                    self.setVisible(False)
+                elif not self.isVisible():
+                    self.showFullScreen()
+        # blink 推进相位
+        if self._state == "blink":
+            self._phase = (self._phase + 4) % 360
+
+    def _tick(self) -> None:
+        self._drain_cmds()
+        if self._state == "off":
+            return
+        # 常亮/闪烁都只改整体不透明度，GPU 合成，不触发像素级重绘
+        self.setWindowOpacity(_brightness_for(self._state, self._phase))
+
+    # ── 辉光环：仅首次/尺寸变化时渲染一次 ──────────────────
+    def _render_glow(self) -> None:
+        pm = QPixmap(self.size())
+        pm.fill(Qt.transparent)
+        painter = QPainter(pm)
+        painter.setRenderHint(QPainter.Antialiasing)
+        color = QColor(0xFF, 0xFF, 0xFF, _BASE_ALPHA)
+
+        # 屏幕边界矩形路径（绘制中心线正好压在边缘上，外半侧被裁剪、只向内柔化）
+        path = QPainterPath()
+        path.addRect(QRectF(self.rect()))
+
+        for i in range(1, _LAYERS + 1):
+            t = i / _LAYERS                                  # 0 贴边 -> 1 最内侧
+            stroke_width = 2.0 * _GLOW_WIDTH * t
+            alpha = int(_BASE_ALPHA * (1.0 - t) ** 2)        # 越靠内圈越亮
+            pen = QPen(QColor(color.red(), color.green(), color.blue(), alpha), stroke_width)
+            pen.setJoinStyle(Qt.MiterJoin)
+            painter.setPen(pen)
+            painter.setBrush(Qt.NoBrush)
+            painter.drawPath(path)
+        painter.end()
+        self._glow = pm
+        self.update()
+
+    def resizeEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().resizeEvent(event)
+        self._render_glow()
+
+    def paintEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        painter = QPainter(self)
+        if self._glow is not None and self._state != "off":
+            painter.drawPixmap(0, 0, self._glow)
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    # 捕获顶层异常，避免异常弹窗卡死子进程；异常即退出（父进程会捕获进程结束）
+    sys.excepthook = lambda *_a: QApplication.instance().quit()  # type: ignore[assignment]
+    # 必须持有 Python 引用（挂在 QApplication 上贯穿事件循环），
+    # 否则无父的 QWidget 包装对象被 GC 后 QTimer/窗口随之销毁
+    app._overlay_window = BorderGlow()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/edge_light/overlay.py
+++ b/edge_light/overlay.py
@@ -32,10 +32,17 @@ BLINK_MIN = 0.10               # 闪烁谷底
 BLINK_MAX = 0.90               # 闪烁峰值
 TIMER_MS = 50                  # 亮度刷新周期
 
-# 白灯辉光（沿屏幕边缘柔化）
-_BASE_ALPHA = 220              # 贴边最亮层的像素 alpha
-_GLOW_WIDTH = 34               # 向内柔化的总宽度（px）
-_LAYERS = 40                   # 描边层数，越多过渡越平滑
+# 双环辉光：白灯环 + 深色描边环（同心），保证白灯在亮/暗背景下都可见。
+# 深色描边比白灯略宽、白灯向内收一个缝隙，形成"外深内白"的双环。
+_DARK_RGB = (0x16, 0x18, 0x20)   # 描边色（近黑，避免纯黑在暗底上发闷）
+_WHITE_RGB = (0xFF, 0xFF, 0xFF)  # 主光（白灯）
+_DARK_ALPHA = 255                # 描边贴边最亮层的像素 alpha
+_WHITE_ALPHA = 250               # 白灯贴边最亮层的像素 alpha
+_DARK_GLOW_WIDTH = 30            # 描边环柔化总宽度（px）
+_WHITE_GLOW_WIDTH = 16           # 白灯环柔化总宽度（px）
+_DARK_LAYERS = 26                # 描边环描边层数
+_WHITE_LAYERS = 20               # 白灯环描边层数
+_WHITE_INSET = 4                 # 白灯环相对屏幕边界内收量（px），留出深色描边
 
 
 def _brightness_for(state: str, phase: int) -> float:
@@ -111,26 +118,45 @@ class BorderGlow(QWidget):
         self.setWindowOpacity(_brightness_for(self._state, self._phase))
 
     # ── 辉光环：仅首次/尺寸变化时渲染一次 ──────────────────
+    @staticmethod
+    def _draw_glow_around(
+        painter: QPainter,
+        rect: QRectF,
+        rgb: tuple[int, int, int],
+        base_alpha: int,
+        width: float,
+        layers: int,
+    ) -> None:
+        """沿矩形边界画一层柔光：由外(宽/淡)向内收窄变亮，四角 miter 无缝衔接。
+
+        绘制中心线压在矩形边界上，外半侧越出屏幕被裁剪，只向屏幕内侧柔化。
+        """
+        path = QPainterPath()
+        path.addRect(rect)
+        for i in range(1, layers + 1):
+            t = i / layers                                   # 0 贴边 -> 1 最内侧
+            stroke_width = 2.0 * width * t
+            alpha = int(base_alpha * (1.0 - t) ** 2)         # 越靠内圈越亮
+            pen = QPen(QColor(rgb[0], rgb[1], rgb[2], alpha), stroke_width)
+            pen.setJoinStyle(Qt.MiterJoin)
+            painter.setPen(pen)
+            painter.setBrush(Qt.NoBrush)
+            painter.drawPath(path)
+
     def _render_glow(self) -> None:
         pm = QPixmap(self.size())
         pm.fill(Qt.transparent)
         painter = QPainter(pm)
         painter.setRenderHint(QPainter.Antialiasing)
-        color = QColor(0xFF, 0xFF, 0xFF, _BASE_ALPHA)
 
-        # 屏幕边界矩形路径（绘制中心线正好压在边缘上，外半侧被裁剪、只向内柔化）
-        path = QPainterPath()
-        path.addRect(QRectF(self.rect()))
-
-        for i in range(1, _LAYERS + 1):
-            t = i / _LAYERS                                  # 0 贴边 -> 1 最内侧
-            stroke_width = 2.0 * _GLOW_WIDTH * t
-            alpha = int(_BASE_ALPHA * (1.0 - t) ** 2)        # 越靠内圈越亮
-            pen = QPen(QColor(color.red(), color.green(), color.blue(), alpha), stroke_width)
-            pen.setJoinStyle(Qt.MiterJoin)
-            painter.setPen(pen)
-            painter.setBrush(Qt.NoBrush)
-            painter.drawPath(path)
+        screen = QRectF(self.rect())
+        # 1) 深色描边环（略宽）
+        self._draw_glow_around(painter, screen, _DARK_RGB, _DARK_ALPHA, _DARK_GLOW_WIDTH, _DARK_LAYERS)
+        # 2) 白灯环（内收一个缝隙，覆盖在描边内侧）→ 双环效果
+        inner = screen.adjusted(
+            _WHITE_INSET, _WHITE_INSET, -_WHITE_INSET, -_WHITE_INSET
+        )
+        self._draw_glow_around(painter, inner, _WHITE_RGB, _WHITE_ALPHA, _WHITE_GLOW_WIDTH, _WHITE_LAYERS)
         painter.end()
         self._glow = pm
         self.update()

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ moviepy>=1.0.3
 Pillow>=10.0.0
 pyautogui>=0.9.54
 pyperclip>=1.8.0
+PySide6>=6.8.0
 zai-sdk
 fastapi>=0.110.0
 uvicorn[standard]>=0.27.0

--- a/tests/test_edge_light.py
+++ b/tests/test_edge_light.py
@@ -1,0 +1,91 @@
+"""测试边缘灯控制器状态汇聚（不启动 GUI 子进程）。
+
+仅验证 EdgeLightController 把「会话开关 + 思考/流式活动」汇聚为
+off / steady / blink 的幂等逻辑；覆盖层子进程真实启动留待手工冒烟。
+"""
+
+import json
+from types import SimpleNamespace
+
+from api.edge_light import EdgeLightController
+
+
+class _FakeStdin:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def write(self, s: str) -> None:
+        self.lines.append(s)
+
+    def flush(self) -> None:
+        pass
+
+
+class _NoSpawnController(EdgeLightController):
+    """已"启用"的替身控制器：不启动子进程，_spawn 恒真，写入进假 stdin。"""
+
+    def __init__(self, fake_in: _FakeStdin) -> None:
+        super().__init__()
+        self._enabled = True
+        self._current = None
+        self._proc = SimpleNamespace(stdin=fake_in)
+
+    def _spawn(self) -> bool:
+        return True
+
+
+def _controller() -> tuple[_NoSpawnController, _FakeStdin]:
+    fake_in = _FakeStdin()
+    return _NoSpawnController(fake_in), fake_in
+
+
+def _states(lines: list[str]) -> list[str]:
+    return [json.loads(line)["state"] for line in lines]
+
+
+def test_off_until_session_enabled() -> None:
+    c, fake = _controller()
+    c.session_activity("s1", True)  # 未开启会话，活动被忽略 → 无任何写入
+    assert fake.lines == []
+
+    c.session_on("s1", True)  # 开启 → steady（常亮）
+    assert _states(fake.lines) == ["steady"]
+
+
+def test_steady_blink_transitions() -> None:
+    c, fake = _controller()
+    c.session_on("s1", True)
+    c.session_activity("s1", True)  # 思考/流式 → blink
+    c.session_activity("s1", False)  # 结束 → 回到 steady
+    c.session_on("s1", False)  # 关闭 → off
+    assert _states(fake.lines) == ["steady", "blink", "steady", "off"]
+
+
+def test_activity_only_counts_for_enabled_session() -> None:
+    c, fake = _controller()
+    c.session_on("s1", True)
+    assert _states(fake.lines) == ["steady"]
+    c.session_activity("other", True)  # 非开启会话 → 不闪烁
+    assert len(fake.lines) == 1
+    c.session_activity("s1", True)
+    assert _states(fake.lines) == ["steady", "blink"]
+
+
+def test_multiple_sessions_or_any_blink() -> None:
+    c, fake = _controller()
+    c.session_on("s1", True)
+    c.session_on("s2", True)  # 任一开启 → steady
+    assert _states(fake.lines) == ["steady"]
+    c.session_activity("s2", True)  # 任一在流式 → blink
+    assert _states(fake.lines) == ["steady", "blink"]
+    c.session_on("s1", False)  # 仍剩 s2 开启 → 保持 blink
+    assert _states(fake.lines) == ["steady", "blink"]
+
+
+def test_idempotent_no_duplicate_write() -> None:
+    c, fake = _controller()
+    c.session_on("s1", True)
+    c.session_on("s1", True)  # 状态未变 → 不重复写入
+    c.session_activity("s1", True)
+    c.session_activity("s1", True)
+    assert _states(fake.lines) == ["steady", "blink"]

--- a/tests/test_pending_queue.py
+++ b/tests/test_pending_queue.py
@@ -54,7 +54,7 @@ from api.session.manager import PendingMessage, SessionState, session_manager
 class FakeToolManager:
     """最小工具管理器，get_all 返回空列表。"""
 
-    def get_all(self, multimodal: bool = False) -> list:
+    def get_all(self, multimodal: bool = False, computer_use: bool = False) -> list:
         return []
 
 
@@ -177,10 +177,11 @@ def test_merge_pending_batch():
             image_refs=["/a.jpg", "/b.jpg"],
         ),
     ]
-    text, img_recog, img_refs = merge_pending_batch(batch)
+    text, img_recog, img_refs, computer_use = merge_pending_batch(batch)
     assert text == "你好\n\n第二条\n\n带图"  # 空行分隔 + 时间后缀剥离
     assert img_recog is True
     assert img_refs == ["/a.jpg", "/b.jpg"]
+    assert computer_use is False  # 默认未开启 Computer Use
 
 
 def test_merge_pending_batch_images_or():
@@ -188,10 +189,23 @@ def test_merge_pending_batch_images_or():
         PendingMessage(pending_id="1", text="纯文本"),
         PendingMessage(pending_id="2", text="有图", image_recognition=True, image_refs=["/x.png"]),
     ]
-    text, img_recog, img_refs = merge_pending_batch(batch)
+    text, img_recog, img_refs, computer_use = merge_pending_batch(batch)
     assert text == "纯文本\n\n有图"
     assert img_recog is True  # OR 累积
     assert img_refs == ["/x.png"]
+    assert computer_use is False
+
+
+def test_merge_pending_batch_computer_use_or():
+    batch = [
+        PendingMessage(pending_id="1", text="普通问题"),
+        PendingMessage(pending_id="2", text="帮我操作屏幕", computer_use=True),
+    ]
+    text, img_recog, img_refs, computer_use = merge_pending_batch(batch)
+    assert text == "普通问题\n\n帮我操作屏幕"
+    assert img_recog is False
+    assert img_refs is None
+    assert computer_use is True  # OR 累积：任一消息开启则整体开启
 
 
 # ── _handle_chat 忙碌路径 ─────────────────────────────────────

--- a/tests/test_tool_manager_gating.py
+++ b/tests/test_tool_manager_gating.py
@@ -1,0 +1,74 @@
+"""测试 ToolManager.get_all 的多模态 / Computer Use 工具门控。
+
+不触发 load_all（不加载真实 native/MCP），仅手工塞入带 name 的 stub 工具，
+验证 read_image / analyze_image 的多模态互斥，以及 computer_* 系列
+是否仅随 ``computer_use=True``（且模型具备视觉）交付。
+"""
+
+from types import SimpleNamespace
+
+from api.tools.manager import ToolManager
+
+# 全部相关工具名（含一个无关普通工具作对照）
+_NAMES = [
+    "read_image",
+    "analyze_image",
+    "computer_screenshot",
+    "computer_click",
+    "computer_virtual_click",
+    "computer_type",
+    "computer_key",
+    "computer_scroll",
+    "computer_wait",
+    "get_weather",
+]
+_COMPUTER = {
+    "computer_screenshot", "computer_click", "computer_virtual_click",
+    "computer_type", "computer_key", "computer_scroll", "computer_wait",
+}
+
+
+def _make_manager() -> ToolManager:
+    """构造不含真实工具的 ToolManager，仅验证名称过滤。"""
+    manager = ToolManager()
+    manager._native_tools = [SimpleNamespace(name=n) for n in _NAMES]
+    manager._mcp_tools = []
+    return manager
+
+
+def _names(manager: ToolManager, multimodal: bool, computer_use: bool) -> set[str]:
+    return {t.name for t in manager.get_all(multimodal=multimodal, computer_use=computer_use)}
+
+
+def test_vision_model_without_computer_use_excludes_screen_tools() -> None:
+    """多模态模型但未开启 Computer Use：保留 read_image，剔除 computer_*。"""
+    names = _names(_make_manager(), multimodal=True, computer_use=False)
+    assert "read_image" in names
+    assert "analyze_image" not in names
+    assert names.isdisjoint(_COMPUTER)
+    assert "get_weather" in names
+
+
+def test_non_vision_model_computer_use_is_defensive_filtered() -> None:
+    """非多模态模型即便标记 computer_use=True 也不暴露屏幕工具（无法读取截图）。"""
+    names = _names(_make_manager(), multimodal=False, computer_use=True)
+    assert "read_image" not in names
+    assert "analyze_image" in names
+    assert names.isdisjoint(_COMPUTER)
+
+
+def test_vision_model_with_computer_use_enables_screen_tools() -> None:
+    """多模态模型 + Computer Use 开启：computer_* 系列完整交付。"""
+    names = _names(_make_manager(), multimodal=True, computer_use=True)
+    assert names >= _COMPUTER
+    assert "read_image" in names
+    assert "analyze_image" not in names
+
+
+def test_non_vision_model_defaults() -> None:
+    """默认（非多模态、未开启 Computer Use）：read_image 与 computer_* 均剔除。"""
+    names = _names(_make_manager(), multimodal=False, computer_use=False)
+    assert "read_image" not in names
+    assert "analyze_image" in names
+    assert names.isdisjoint(_COMPUTER)
+    assert "get_weather" in names

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -51,7 +51,7 @@ def get_all_tools() -> list[BaseTool]:
     from tools.network.tool_read_image import ReadImageTool
     from tools.network.tavily import TavilySearchTool, TavilyExtractTool
 
-    # Computer（屏幕操作，仅多模态识图模式交付给 LLM）
+    # Computer（屏幕操作，仅 Computer Use 模式开启时交付给 LLM）
     from tools.computer.tool_screenshot import ScreenshotTool
     from tools.computer.tool_click import ClickTool
     from tools.computer.tool_virtual_click import VirtualClickTool

--- a/web/src/components/ChatInput.vue
+++ b/web/src/components/ChatInput.vue
@@ -129,6 +129,15 @@
             <Icon name="image-cog" :size="18" />
           </button>
           <button
+            class="btn-computer"
+            :class="{ active: computerUse, 'flash-denied': flashComputerDenied }"
+            :disabled="disabled"
+            :title="computerBtnTitle"
+            @click="handleToggleComputerUse"
+          >
+            <Icon name="computer" :size="18" />
+          </button>
+          <button
             class="btn-memory"
             :class="{ active: privateMode }"
             :disabled="disabled"
@@ -237,13 +246,14 @@ const props = defineProps<{
   skipRecall: boolean
   autoApprove: boolean
   imageRecognition: boolean
+  computerUse: boolean
   hasVision?: boolean
   /** Agent 输出期间排队等待注入的消息 */
   pendingMessages: PendingMessage[]
 }>()
 
 const emit = defineEmits<{
-  send: [text: string, refs: ParsedRef[], providerId?: string, modelName?: string, imageRecognition?: boolean, imagePaths?: string[]]
+  send: [text: string, refs: ParsedRef[], providerId?: string, modelName?: string, imageRecognition?: boolean, imagePaths?: string[], computerUse?: boolean]
   stop: []
   removePending: [pendingId: string]
   clearPending: []
@@ -252,6 +262,7 @@ const emit = defineEmits<{
   toggleRecall: []
   toggleAutoApprove: []
   toggleImageRecognition: []
+  toggleComputerUse: []
 }>()
 
 const text = ref('')
@@ -329,6 +340,31 @@ function handleToggleImageRecognition() {
     return
   }
   emit('toggleImageRecognition')
+}
+
+// ── Computer Use 屏幕操作按钮：无视觉模型时闪烁拒绝（与图像认知一致）──
+const flashComputerDenied = ref(false)
+let computerFlashTimer: ReturnType<typeof setTimeout> | null = null
+
+const computerBtnTitle = computed(() => {
+  if (props.hasVision === false) {
+    return '当前模型不支持视觉能力，无法使用 Computer Use 屏幕操作'
+  }
+  return 'Computer Use：开启后 AI 可截屏查看并操控屏幕（点击、输入、按键、滚动）'
+})
+
+function handleToggleComputerUse() {
+  if (props.hasVision === false) {
+    // 模型不支持视觉 → 闪烁低饱和度红色提示，不切换
+    flashComputerDenied.value = true
+    if (computerFlashTimer) clearTimeout(computerFlashTimer)
+    computerFlashTimer = setTimeout(() => {
+      flashComputerDenied.value = false
+      computerFlashTimer = null
+    }, 600)
+    return
+  }
+  emit('toggleComputerUse')
 }
 
 // ── 链接引用 ──
@@ -712,7 +748,7 @@ function handleSend() {
     }
   }
 
-  emit('send', msg, sendRefs, selectedProviderId.value || undefined, selectedModelName.value || undefined, sendImageRecog, imagePaths)
+  emit('send', msg, sendRefs, selectedProviderId.value || undefined, selectedModelName.value || undefined, sendImageRecog, imagePaths, props.computerUse)
   text.value = ''
   refs.value = []
   nextTick(() => autoResize())
@@ -1365,6 +1401,45 @@ function onResizeEnd(e: PointerEvent) {
 @keyframes vision-flash-fade {
   0%   { background: color-mix(in srgb, #ef4444 35%, transparent); }
   100% { background: color-mix(in srgb, #ef4444 0%, transparent); }
+}
+
+/* ── Computer Use 屏幕操作按钮 ── */
+.btn-computer {
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  padding: 0;
+  font-family: inherit;
+  flex-shrink: 0;
+}
+.btn-computer:hover:not(:disabled) {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+.btn-computer:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.btn-computer.active {
+  background: color-mix(in srgb, #81ae92 12%, transparent);
+  color: #81ae92;
+  box-shadow: 0 0 0 1px color-mix(in srgb, #81ae92 30%, transparent);
+}
+
+/* 无视觉模型时闪烁拒绝（与图像认知按钮共用动画） */
+.btn-computer.flash-denied {
+  background: color-mix(in srgb, #ef4444 18%, transparent);
+  color: #ef4444;
+  box-shadow: 0 0 0 1px color-mix(in srgb, #ef4444 30%, transparent);
+  animation: vision-flash-fade 0.6s ease-out;
 }
 
 /* ── 记忆/私密模式按钮 ── */

--- a/web/src/components/Icon.vue
+++ b/web/src/components/Icon.vue
@@ -63,6 +63,12 @@ const svgContents: Record<string, string> = {
   <circle cx="8.5" cy="8.5" r="1.5"/>
   <polyline points="21 15 16 10 5 21"/>
 </svg>`,
+  'computer': `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+  <line x1="8" y1="21" x2="16" y2="21"/>
+  <line x1="12" y1="17" x2="12" y2="21"/>
+  <path d="M6.5 11.5 10 14.2 11.2 10.6z"/>
+</svg>`,
   'code': `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
   <polyline points="16 18 22 12 16 6"/>
   <polyline points="8 6 2 12 8 18"/>

--- a/web/src/composables/useChat.ts
+++ b/web/src/composables/useChat.ts
@@ -104,8 +104,8 @@ export function useChat(sessionId: Ref<string>) {
     { immediate: true },
   )
 
-  function send(text: string, refs: ParsedRef[] = [], providerId?: string, modelName?: string, imageRecognition?: boolean, imagePaths?: string[]) {
-    store.send(sessionId.value, text, refs, providerId, modelName, imageRecognition, imagePaths)
+  function send(text: string, refs: ParsedRef[] = [], providerId?: string, modelName?: string, imageRecognition?: boolean, imagePaths?: string[], computerUse?: boolean) {
+    store.send(sessionId.value, text, refs, providerId, modelName, imageRecognition, imagePaths, computerUse)
   }
 
   function cancel() {

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -547,6 +547,7 @@ export const useChatStore = defineStore('chat', () => {
     modelName?: string,
     imageRecognition?: boolean,
     imagePaths?: string[],
+    computerUse?: boolean,
   ) {
     const ch = channels.get(sid)
     if (!ch?.ws || ch.ws.readyState !== WebSocket.OPEN) return
@@ -567,6 +568,7 @@ export const useChatStore = defineStore('chat', () => {
         model_name: modelName,
         client_msg_id: clientMsgId,
         ...(imageRecognition && imagePaths?.length ? { image_recognition: true, image_refs: imagePaths } : {}),
+        ...(computerUse ? { computer_use: true } : {}),
         ...(ch.studioName ? { studio_name: ch.studioName } : {}),
       },
     }

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -77,6 +77,8 @@ export interface SessionChannel {
   privateMode: boolean
   skipRecall: boolean
   autoApprove: boolean
+  /** Computer Use 屏幕操作开关（通知后端驱动边缘灯；随频道保持，重连时重放） */
+  computerUse: boolean
   /** 会话级工作坊状态（同 privateMode/skipRecall，切会话时随频道更新） */
   studioName: string
 }
@@ -142,6 +144,7 @@ export const useChatStore = defineStore('chat', () => {
         privateMode: false,
         skipRecall: false,
         autoApprove: false,
+        computerUse: false,
         studioName: '',
       })
     } else {
@@ -328,6 +331,13 @@ export const useChatStore = defineStore('chat', () => {
       if (ch.reconnectTimer) {
         clearTimeout(ch.reconnectTimer)
         ch.reconnectTimer = null
+      }
+      // 重连后重放 Computer Use 开关（后端在 WS 断开时已熄灭边缘灯）
+      if (ch.computerUse && ch.ws?.readyState === WebSocket.OPEN) {
+        ch.ws.send(JSON.stringify({
+          type: 'computer_use',
+          payload: { enabled: true },
+        } as ClientMessage))
       }
     }
 
@@ -551,6 +561,9 @@ export const useChatStore = defineStore('chat', () => {
   ) {
     const ch = channels.get(sid)
     if (!ch?.ws || ch.ws.readyState !== WebSocket.OPEN) return
+    if (typeof computerUse !== 'undefined') {
+      ch.computerUse = computerUse
+    }
 
     const flatMsg = buildFlatMessage(text, refs)
     // 客户端消息 ID：作为 client_msg_id 发送，后端复用作 pending_id，
@@ -568,7 +581,7 @@ export const useChatStore = defineStore('chat', () => {
         model_name: modelName,
         client_msg_id: clientMsgId,
         ...(imageRecognition && imagePaths?.length ? { image_recognition: true, image_refs: imagePaths } : {}),
-        ...(computerUse ? { computer_use: true } : {}),
+        ...(ch.computerUse ? { computer_use: true } : {}),
         ...(ch.studioName ? { studio_name: ch.studioName } : {}),
       },
     }
@@ -688,6 +701,19 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
+  /** 更新 Computer Use 开关：同步频道状态并通知后端驱动屏幕边缘灯。 */
+  function updateComputerUse(sid: string, enabled: boolean) {
+    const ch = channels.get(sid)
+    if (!ch) return
+    ch.computerUse = enabled
+    if (ch.ws?.readyState === WebSocket.OPEN) {
+      ch.ws.send(JSON.stringify({
+        type: 'computer_use',
+        payload: { enabled },
+      } as ClientMessage))
+    }
+  }
+
   return {
     channels,
     allSessionStatuses,
@@ -705,6 +731,7 @@ export const useChatStore = defineStore('chat', () => {
     sendUserResponse,
     removeTurns,
     updateAutoApprove,
+    updateComputerUse,
     removePendingMessage,
     clearPendingMessages,
     restoreTurnsFromBackend,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -263,6 +263,8 @@ export interface ChatMessage {
     image_recognition?: boolean
     /** 图像认知模式下的图片文件绝对路径列表 */
     image_refs?: string[]
+    /** Computer Use 屏幕操作模式：开启后后端将 computer_* 工具下发给 LLM */
+    computer_use?: boolean
     /** 客户端生成的消息 ID，后端用作 pending_id 以关联入队确认 */
     client_msg_id?: string
     /** 所选工作坊名称（对应 studios/*.yaml 的 name 字段），未选中时不携带 */

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -308,6 +308,14 @@ export interface UpdateAutoApproveMessage {
   }
 }
 
+/** computer_use — 会话中途更新 Computer Use 屏幕操作开关（驱动边缘灯） */
+export interface ComputerUseMessage {
+  type: 'computer_use'
+  payload: {
+    enabled: boolean
+  }
+}
+
 /** skip_memory_search — 用户跳过当前轮的语义记忆搜索 */
 export interface SkipMemorySearchMessage {
   type: 'skip_memory_search'
@@ -341,7 +349,7 @@ export interface RunPythonInterruptMessage {
   }
 }
 
-export type ClientMessage = ChatMessage | CancelMessage | PingMessage | UserResponseMessage | UpdateAutoApproveMessage | SkipMemorySearchMessage | RemovePendingMessage | ClearPendingMessage | RunPythonInterruptMessage
+export type ClientMessage = ChatMessage | CancelMessage | PingMessage | UserResponseMessage | UpdateAutoApproveMessage | ComputerUseMessage | SkipMemorySearchMessage | RemovePendingMessage | ClearPendingMessage | RunPythonInterruptMessage
 
 // === 前端 UI 状态类型 ===
 

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -13,10 +13,14 @@
     <template v-else>
     <header class="chat-header">
         <StatusBadge :connected="connected" :health="health" />
-        <div v-if="imageRecognition || privateMode || skipRecall || autoApprove" class="header-mode-tags">
+        <div v-if="imageRecognition || computerUse || privateMode || skipRecall || autoApprove" class="header-mode-tags">
           <span v-if="imageRecognition" class="mode-tag">
             <svg class="mode-tag-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
             图像认知
+          </span>
+          <span v-if="computerUse" class="mode-tag">
+            <svg class="mode-tag-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/><path d="M6.5 11.5 10 14.2 11.2 10.6z"/></svg>
+            屏幕操作
           </span>
           <span v-if="privateMode" class="mode-tag">
             <svg class="mode-tag-icon" viewBox="0 0 82.118 82.118" fill="currentColor"><path d="M75.346,15.559h-47.9c-3.499,0-4.873,1.509-6.328,2.905c-0.294,0.283-0.613,0.685-0.982,1.01c-0.045,0.04-0.088,0.128-0.129,0.172L0.548,40.216c-0.721,0.761-0.731,1.962-0.024,2.737l19.459,21.298c0.07,0.076,0.146-0.04,0.227,0.024c2.194,1.756,3.463,2.284,7.237,2.284h47.899c4.35,0,6.772-2.659,6.772-7.184V24.2C82.118,19.491,79.491,15.559,75.346,15.559z M78.118,59.375c0,1.331,0.075,3.184-2.772,3.184h-47.9c-2.675,0-3.106-0.101-4.616-1.307L4.731,41.544L22.85,22.461c0.387-0.344,0.725-0.833,1.037-1.134c1.281-1.229,1.668-1.767,3.559-1.767h47.899c2.248,0,2.772,2.589,2.772,4.641v35.174H78.118z M26.143,34.135c-4.297,0-7.793,3.496-7.793,7.794c0,4.297,3.496,7.793,7.793,7.793s7.793-3.496,7.793-7.793C33.936,37.631,30.44,34.135,26.143,34.135z M26.143,45.722c-2.092,0-3.793-1.701-3.793-3.793s1.701-3.794,3.793-3.794s3.793,1.702,3.793,3.794S28.235,45.722,26.143,45.722z"/></svg>
@@ -58,6 +62,7 @@
       :skip-recall="skipRecall"
       :auto-approve="autoApprove"
       :image-recognition="imageRecognition"
+      :computer-use="computerUse"
       :has-vision="selectedModelHasVision"
       :pending-messages="pendingMessages"
       @remove-pending="onRemovePending"
@@ -69,6 +74,7 @@
       @toggle-recall="setSkipRecall(!skipRecall)"
       @toggle-auto-approve="setAutoApprove(!autoApprove)"
       @toggle-image-recognition="imageRecognition = !imageRecognition"
+      @toggle-computer-use="computerUse = !computerUse"
     />
     <div v-else class="sub-agent-bar-wrapper">
       <div class="sub-agent-bar">
@@ -127,6 +133,7 @@ const selectedProviderId = ref('')
 const providers = ref<ProviderConfig[]>([])
 const hasProviders = ref(true)
 const imageRecognition = ref(false)
+const computerUse = ref(false)
 
 onMounted(async () => {
   try {
@@ -167,8 +174,8 @@ function addCitation(ref: ParsedRef) {
   chatInputRef.value?.addRef(ref)
 }
 
-function onSend(text: string, refs: ParsedRef[], providerId?: string, modelName?: string, imageRecognition?: boolean, imagePaths?: string[]) {
-  send(text, refs, providerId, modelName, imageRecognition, imagePaths)
+function onSend(text: string, refs: ParsedRef[], providerId?: string, modelName?: string, imageRecognition?: boolean, imagePaths?: string[], computerUse?: boolean) {
+  send(text, refs, providerId, modelName, imageRecognition, imagePaths, computerUse)
 }
 
 function onRemovePending(pendingId: string) {

--- a/web/src/views/ChatView.vue
+++ b/web/src/views/ChatView.vue
@@ -74,7 +74,7 @@
       @toggle-recall="setSkipRecall(!skipRecall)"
       @toggle-auto-approve="setAutoApprove(!autoApprove)"
       @toggle-image-recognition="imageRecognition = !imageRecognition"
-      @toggle-computer-use="computerUse = !computerUse"
+      @toggle-computer-use="onToggleComputerUse"
     />
     <div v-else class="sub-agent-bar-wrapper">
       <div class="sub-agent-bar">
@@ -176,6 +176,12 @@ function addCitation(ref: ParsedRef) {
 
 function onSend(text: string, refs: ParsedRef[], providerId?: string, modelName?: string, imageRecognition?: boolean, imagePaths?: string[], computerUse?: boolean) {
   send(text, refs, providerId, modelName, imageRecognition, imagePaths, computerUse)
+}
+
+function onToggleComputerUse() {
+  computerUse.value = !computerUse.value
+  // 通知后端驱动屏幕边缘灯（常亮基准 = Computer Use 开启）
+  chatStore.updateComputerUse(sessionId.value, computerUse.value)
 }
 
 function onRemovePending(pendingId: string) {


### PR DESCRIPTION
## 变更内容

- **Computer Use 开关**：前端新增屏幕操作按钮，用户显式开启后 computer_* 系列工具（截屏/点击/输入/按键/滚动/等待）才会下发给 LLM；仅多模态模型且开启时交付，非视觉模型防御性过滤。
- **屏幕边缘灯**：新增 PySide6 原生覆盖层子进程，开启 Computer Use 时屏幕边缘白灯常亮（steady），模型思考/流式输出时呼吸闪烁（blink），点击穿透不拦截操作；PySide6 缺失或启动失败时优雅降级为无提示。
- **排队合并**：merge_pending_batch 扩展为 4 元组，computer_use 与图像认知一致按 OR 累积。
- **前端**：ChatInput 新增按钮（无视觉模型闪烁拒绝）、header 模式标签、WS 重连后重放开关状态。
- **测试**：覆盖边缘灯状态汇聚、工具门控四种组合、pending 合并 OR 累积。

Closes 无关联 issue