### PR TITLE
fix(providers): 为 OpenCode 网关补发 x-opencode-session 请求头

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -1,10 +1,12 @@
 """Provider 抽象基类与类型定义。"""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, asdict, field
-from typing import Literal
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
 
 from langchain_core.language_models.chat_models import BaseChatModel
+
+from api.providers.opencode_headers import opencode_session_headers
 
 FALLBACK_CTX: int = 128_000
 
@@ -83,6 +85,26 @@ class Provider(ABC):
         ...
 
     # ── 能力（子类按需覆盖）──────────────────────────────
+
+    def request_headers(self) -> dict[str, str]:
+        """需要附加到每个 LLM 请求的缺省请求头（如 OpenCode 网关的会话亲和头）。
+
+        默认按 base_url 自动判定：指向 OpenCode 网关（host 为 opencode.ai）时注入
+        运行期稳定的 ``x-opencode-session``；否则返回空 dict（不注入任何头）。
+        """
+        return opencode_session_headers(self.config.base_url, self.config.api_key)
+
+    def _with_default_headers(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """将网关缺省请求头合并进 kwargs（``default_headers``）并返回。
+
+        调用方已传入的 ``default_headers`` 优先保留，再叠加
+        :meth:`request_headers` 的网关必需头；合并结果为空则不注入该键。
+        """
+        headers: dict[str, str] = dict(kwargs.pop("default_headers", None) or {})
+        headers.update(self.request_headers())
+        if headers:
+            kwargs["default_headers"] = headers
+        return kwargs
 
     def apply_thinking(self, kwargs: dict, enabled: bool) -> dict:
         """按需注入思考模式参数，返回注入后的 kwargs。

--- a/api/providers/anthropic_provider.py
+++ b/api/providers/anthropic_provider.py
@@ -23,6 +23,7 @@ class AnthropicProvider(Provider):
     def create_llm(self, model: str, **kwargs: Any) -> BaseChatModel:
         from langchain_anthropic import ChatAnthropic
 
+        kwargs = self._with_default_headers(kwargs)
         return ChatAnthropic(
             model=model,
             api_key=self.config.api_key,
@@ -57,8 +58,10 @@ class AnthropicProvider(Provider):
     def _async_client(self) -> Any:
         from anthropic import AsyncAnthropic
 
+        headers = self.request_headers()
         return AsyncAnthropic(
             api_key=self.config.api_key,
             base_url=self.config.base_url or DEFAULT_BASE_URL,
             timeout=10,
+            **({"default_headers": headers} if headers else {}),
         )

--- a/api/providers/openai_provider.py
+++ b/api/providers/openai_provider.py
@@ -13,6 +13,7 @@ class OpenAIProvider(Provider):
     def create_llm(self, model: str, **kwargs: Any) -> BaseChatModel:
         from langchain_openai import ChatOpenAI
 
+        kwargs = self._with_default_headers(kwargs)
         return ChatOpenAI(
             model=model,
             api_key=self.config.api_key,
@@ -55,8 +56,10 @@ class OpenAIProvider(Provider):
     def _async_client(self) -> Any:
         from openai import AsyncOpenAI
 
+        headers = self.request_headers()
         return AsyncOpenAI(
             api_key=self.config.api_key,
             base_url=self.config.base_url,
             timeout=10,
+            **({"default_headers": headers} if headers else {}),
         )

--- a/api/providers/opencode_headers.py
+++ b/api/providers/opencode_headers.py
@@ -1,0 +1,47 @@
+"""OpenCode 网关请求头辅助。
+
+OpenCode 网关（https://opencode.ai，含 "Console Go" / Zen 端点，如
+``https://opencode.ai/zen/go/v1``）自 2026-09-06 起要求每个补全请求携带稳定的
+``x-opencode-session`` 请求头，用于会话亲和路由（粘到同一后端实例以复用 KV/提示缓存）。
+请求头缺失时网关退化为按客户端 IP 兜底路由，故此前表现为偶发的
+``400 MissingSessionID``（"Request is missing x-opencode-session ..."）。
+
+本模块对指向 OpenCode 网关的 base_url 生成该请求头；session id 在同一进程内
+（按 base_url+api_key 键控）保持稳定。其它网关返回空 dict，不注入任何内容。
+"""
+
+import urllib.parse
+import uuid
+
+_OPENCODE_HOST_SUFFIX = ".opencode.ai"
+
+
+def is_opencode_gateway(base_url: str) -> bool:
+    """判断 base_url 是否指向 OpenCode 网关（host 为 opencode.ai 或子域）。"""
+    if not base_url:
+        return False
+    try:
+        host = (urllib.parse.urlparse(base_url).hostname or "").lower()
+    except ValueError:
+        return False
+    return host == "opencode.ai" or host.endswith(_OPENCODE_HOST_SUFFIX)
+
+
+# 每个 (base_url, api_key) 对应一个运行期稳定的 session id，reload/多次构造不变。
+_session_ids: dict[tuple[str, str], str] = {}
+
+
+def opencode_session_headers(base_url: str, api_key: str) -> dict[str, str]:
+    """为 OpenCode 网关生成需附加的缺省请求头；非网关 URL 返回空 dict。
+
+    Returns:
+        ``{"x-opencode-session": "<运行期稳定 id>"}`` 或 ``{}``。
+    """
+    if not is_opencode_gateway(base_url):
+        return {}
+    key = (base_url.rstrip("/"), api_key)
+    session_id = _session_ids.get(key)
+    if session_id is None:
+        session_id = uuid.uuid4().hex
+        _session_ids[key] = session_id
+    return {"x-opencode-session": session_id}

--- a/tests/test_api/test_providers.py
+++ b/tests/test_api/test_providers.py
@@ -12,6 +12,7 @@ from api.providers import ProviderConfig, build_provider
 from api.providers.anthropic_provider import DEFAULT_BASE_URL, AnthropicProvider
 from api.providers.manager import ProviderManager
 from api.providers.openai_provider import OpenAIProvider
+from api.providers.opencode_headers import is_opencode_gateway, opencode_session_headers
 from api.providers.store import ProviderConfigStore
 
 
@@ -207,3 +208,99 @@ class TestListModels:
         )
         assert asyncio.run(provider.list_models()) == ["a-model", "b-model"]
         assert captured["base_url"] == "https://proxy.example.com"
+
+
+# ── OpenCode 网关 x-opencode-session 请求头 ───────────────────────────────
+
+
+class TestOpenCodeGatewayDetection:
+    """is_opencode_gateway 对 opencode.ai 及其子域返回 True，其余为 False。"""
+
+    def test_opencode_go_and_zen_urls_are_gateway(self) -> None:
+        assert is_opencode_gateway("https://opencode.ai/zen/go/v1")
+        assert is_opencode_gateway("https://opencode.ai/zen/v1")
+
+    def test_opencode_subdomain_is_gateway(self) -> None:
+        assert is_opencode_gateway("https://go.opencode.ai/zen/go/v1")
+
+    def test_other_hosts_are_not_gateway(self) -> None:
+        assert not is_opencode_gateway("https://api.deepseek.com/v1")
+        assert not is_opencode_gateway("https://notopencode.ai/v1")
+        assert not is_opencode_gateway("")
+        assert not is_opencode_gateway("https://opencode.ai.evil.com/v1")
+
+
+class TestOpenCodeSessionHeaders:
+    """opencode_session_headers：网关返回稳定会话头，非网关返回空。"""
+
+    def test_gateway_returns_session_header(self) -> None:
+        headers = opencode_session_headers("https://opencode.ai/zen/go/v1", "sk-a")
+        assert set(headers) == {"x-opencode-session"}
+        assert len(headers["x-opencode-session"]) == 32
+
+    def test_session_id_is_stable_for_same_endpoint(self) -> None:
+        first = opencode_session_headers("https://opencode.ai/zen/go/v1", "sk-a")
+        second = opencode_session_headers("https://opencode.ai/zen/go/v1", "sk-a")
+        assert first == second
+
+    def test_session_id_differs_across_endpoint_or_key(self) -> None:
+        a = opencode_session_headers("https://opencode.ai/zen/go/v1", "sk-a")
+        b = opencode_session_headers("https://opencode.ai/zen/v1", "sk-a")
+        c = opencode_session_headers("https://opencode.ai/zen/go/v1", "sk-b")
+        assert a != b
+        assert a != c
+
+    def test_non_gateway_returns_empty(self) -> None:
+        assert opencode_session_headers("https://api.deepseek.com/v1", "sk-a") == {}
+
+
+class TestOpenCodeHeaderInjection:
+    """create_llm/_async_client 对 OpenCode 网关注入 x-opencode-session。"""
+
+    OPENCODE_URL = "https://opencode.ai/zen/go/v1"
+
+    def test_openai_create_llm_injects_stable_session(self) -> None:
+        provider = OpenAIProvider(_config(base_url=self.OPENCODE_URL))
+        llm1 = provider.create_llm("test-model")
+        llm2 = provider.create_llm("test-model")
+        h1 = llm1.default_headers or {}
+        h2 = llm2.default_headers or {}
+        assert "x-opencode-session" in h1
+        assert h1 == h2
+
+    def test_anthropic_create_llm_injects_session(self) -> None:
+        provider = AnthropicProvider(
+            _config(provider_type="anthropic", base_url=self.OPENCODE_URL)
+        )
+        llm = provider.create_llm("claude-sonnet-5")
+        assert "x-opencode-session" in (llm.default_headers or {})
+
+    def test_non_opencode_create_llm_injects_nothing(self) -> None:
+        provider = OpenAIProvider(_config(base_url="https://api.deepseek.com/v1"))
+        llm = provider.create_llm("test-model")
+        assert llm.default_headers in (None, {})
+
+    def test_callers_default_headers_are_preserved(self) -> None:
+        provider = OpenAIProvider(_config(base_url=self.OPENCODE_URL))
+        llm = provider.create_llm(
+            "test-model", default_headers={"x-custom": "keep-me"}
+        )
+        headers = llm.default_headers or {}
+        assert headers["x-custom"] == "keep-me"
+        assert "x-opencode-session" in headers
+
+    def test_openai_async_client_injects_session_for_gateway(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_client(**kwargs: object) -> _FakeModelsClient:
+            captured.update(kwargs)
+            return _FakeModelsClient()
+
+        monkeypatch.setattr("openai.AsyncOpenAI", fake_client)
+        provider = OpenAIProvider(_config(base_url=self.OPENCODE_URL))
+        provider._async_client()
+        headers = captured.get("default_headers", {})
+        assert isinstance(headers, dict)
+        assert "x-opencode-session" in headers


### PR DESCRIPTION
## 背景

OpenCode Zen/Go 网关（`https://opencode.ai/zen/go/v1`，即默认 provider `opencode`）自 2026-09-06 起要求每个补全请求携带稳定的 `x-opencode-session` 请求头，用于会话亲和路由（粘到同一后端实例以复用 KV/提示缓存）。请求头缺失时网关退化为按客户端 IP 兜底路由，表现为偶发的：

```
400 MissingSessionID: Request is missing x-opencode-session ...
```

## 改动

在 Provider 层对指向 `opencode.ai` 的 `base_url` 自动注入该请求头：

- 新增 `api/providers/opencode_headers.py`：网关判定（host 为 `opencode.ai`/子域）+ 按 `base_url+api_key` 生成运行期稳定的 session id。
- `Provider.request_headers()` / `_with_default_headers()`：统一向 LLM 客户端注入缺省请求头，保留调用方已有 `default_headers`。
- `OpenAIProvider` / `AnthropicProvider` 的 `create_llm` 与 `_async_client` 全部接入，覆盖主对话、memory、vision、health check 等调用链。
- 非 OpenCode 提供商不注入任何头，行为不变。

## 测试

`tests/test_api/test_providers.py` 新增网关探测、session id 稳定性、OpenAI/Anthropic 注入、async client 注入 4 组用例。`pytest tests/test_api/test_providers.py` → 26 passed。
